### PR TITLE
fix(memory): Cast UUID to str for asyncpg in match_memories

### DIFF
--- a/backend/app/infrastructure/repositories/memory_repo.py
+++ b/backend/app/infrastructure/repositories/memory_repo.py
@@ -76,9 +76,9 @@ class MemoryRepository:
             "query_embedding": str(vector),
             "match_threshold": threshold,
             "match_count": count,
-            "p_user_id": user_id,
-            "p_agent_id": agent_id,
-            "p_room_id": room_id,
+            "p_user_id": str(user_id) if user_id else None,
+            "p_agent_id": str(agent_id) if agent_id else None,
+            "p_room_id": str(room_id) if room_id else None,
         }
         result = await self.session.execute(statement, params)
         return [Memory(**row) for row in result.mappings()]


### PR DESCRIPTION
Fixed an issue where querying memories using `match_memories` caused an `asyncpg` `DataError` due to passing `UUID` objects directly to Postgres `text` type arguments. Converted the UUID parameters to strings before passing them to the parameterized query in `MemoryRepository.match_memories`.

---
*PR created automatically by Jules for task [12071941917348360258](https://jules.google.com/task/12071941917348360258) started by @YKDBontekoe*