### PR TITLE
Fix `.coderabbit.yaml` schema validation error

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -34,6 +34,6 @@ reviews:
       - label: "refactor"
         instructions: "Apply if the PR restructures code without changing behavior."
 
-auto_review:
-  enabled: true
-  drafts: false
+  auto_review:
+    enabled: true
+    drafts: false


### PR DESCRIPTION
The CodeRabbit configuration schema updated its requirements, defining `auto_review` as a property of `reviews` instead of a top-level property. This PR correctly nests `auto_review` and its sub-properties under the `reviews` section to resolve the schema validation error.

---
*PR created automatically by Jules for task [3118789342262523964](https://jules.google.com/task/3118789342262523964) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured configuration file formatting for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->