### PR TITLE
fix(db): Strip pgbouncer argument from Supabase URL for asyncpg

### DIFF
--- a/backend/app/infrastructure/database/tortoise.py
+++ b/backend/app/infrastructure/database/tortoise.py
@@ -1,12 +1,29 @@
 """Tortoise ORM configuration and initialization."""
 
+import urllib.parse
+
 from tortoise import Tortoise
 
 from app.core.config import get_settings
 
 raw_url = get_settings().database_url or ""
+
 if raw_url.startswith("postgresql://"):
     raw_url = raw_url.replace("postgresql://", "postgres://", 1)
+
+if raw_url.startswith("postgres://"):
+    parsed = urllib.parse.urlparse(raw_url)
+    query = dict(urllib.parse.parse_qsl(parsed.query))
+
+    # Remove pgbouncer argument as it's not supported by asyncpg
+    query.pop("pgbouncer", None)
+
+    # Disable prepared statement caching to avoid InvalidSQLStatementNameError
+    # when using PgBouncer in transaction mode
+    query["statement_cache_size"] = "0"
+
+    parsed = parsed._replace(query=urllib.parse.urlencode(query))
+    raw_url = urllib.parse.urlunparse(parsed)
 
 # Database configuration for Tortoise and Aerich
 TORTOISE_ORM = {

--- a/backend/tests/test_tortoise.py
+++ b/backend/tests/test_tortoise.py
@@ -1,0 +1,32 @@
+import importlib
+
+from app.core.config import get_settings
+
+
+def test_tortoise_config_parsing(monkeypatch):
+    """Test that the Tortoise configuration correctly strips pgbouncer and adds statement_cache_size."""
+
+    # We want to re-import the module to force it to re-evaluate the module-level code.
+    # But before that, we need to mock the setting.
+    test_url = "postgresql://user:pass@host:5432/db?pgbouncer=true&connection_limit=1"
+
+    monkeypatch.setenv("DATABASE_URL", test_url)
+
+    # Invalidate settings cache
+    get_settings.cache_clear()
+
+    import app.infrastructure.database.tortoise as tortoise_mod
+
+    importlib.reload(tortoise_mod)
+
+    raw_url = tortoise_mod.TORTOISE_ORM["connections"]["default"]
+
+    assert "pgbouncer" not in raw_url
+    assert "statement_cache_size=0" in raw_url
+    assert "connection_limit=1" in raw_url
+    assert raw_url.startswith("postgres://")
+
+    # Clean up and restore
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    get_settings.cache_clear()
+    importlib.reload(tortoise_mod)


### PR DESCRIPTION
Closes #43

### What does this PR do?
Fixes the backend issue where Sentry reported `TypeError: connect() got an unexpected keyword argument 'pgbouncer'` on the `/api/v1/memory` route (and effectively everywhere Tortoise is initialized). 

### Why is this needed?
The Supabase connection string for transaction pooling includes `pgbouncer=true` by default. Tortoise ORM uses `asyncpg` which doesn't support this keyword parameter and will fail during the initial `.connect()`. Additionally, when using transaction-level PgBouncer, prepared statements cannot be cached effectively across connections, leading to `InvalidSQLStatementNameError`. 

### Changes made
1. Modified `backend/app/infrastructure/database/tortoise.py` to parse `raw_url` via `urllib.parse`.
2. Removed the unsupported `pgbouncer` argument from the query parameters.
3. Added `statement_cache_size=0` to the query parameters to disable prepared statement caching dynamically at initialization.
4. Added an integration test `backend/tests/test_tortoise.py` to assert that the configuration is stripped of `pgbouncer` and injected with `statement_cache_size=0` before `TORTOISE_ORM` is resolved.

---
*PR created automatically by Jules for task [15547476908530890372](https://jules.google.com/task/15547476908530890372) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed PostgreSQL database connection compatibility with connection poolers by optimizing connection URL processing and adjusting statement caching settings to improve database stability and reliability in pooled connection environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->