### PR TITLE
fix(db): add explicit cast for UUID parameters in match_memories to prevent asyncpg DataError

### DIFF
--- a/backend/app/infrastructure/repositories/memory_repo.py
+++ b/backend/app/infrastructure/repositories/memory_repo.py
@@ -49,9 +49,9 @@ class MemoryRepository:
                 query_embedding := $1::vector,
                 match_threshold := $2,
                 match_count := $3,
-                p_user_id := $4,
-                p_agent_id := $5,
-                p_room_id := $6
+                p_user_id := $4::uuid,
+                p_agent_id := $5::uuid,
+                p_room_id := $6::uuid
             )
         """
         p_user = str(user_id) if user_id else None

--- a/backend/tests/test_repositories.py
+++ b/backend/tests/test_repositories.py
@@ -227,11 +227,23 @@ class TestMemoryRepository:
         repo = MemoryRepository()
         mock_conn = AsyncMock()
         mock_conn.execute_query_dict = AsyncMock(return_value=[])
+        test_uuid = uuid4()
         with patch("app.infrastructure.repositories.memory_repo.Tortoise") as mock_tortoise:
             mock_tortoise.get_connection.return_value = mock_conn
-            result = await repo.match_memories([0.1, 0.2], 0.5, 5, uuid4())
+            result = await repo.match_memories([0.1, 0.2], 0.5, 5, test_uuid)
         assert result == []
         mock_conn.execute_query_dict.assert_awaited_once()
+
+        args, kwargs = mock_conn.execute_query_dict.call_args
+        query = args[0]
+        params = args[1]
+
+        assert "p_user_id := $4::uuid" in query
+        assert "p_agent_id := $5::uuid" in query
+        assert "p_room_id := $6::uuid" in query
+        assert params[3] == str(test_uuid)
+        assert params[4] is None
+        assert params[5] is None
 
     async def test_search_fulltext_delegates_to_raw_sql(self) -> None:
         repo = MemoryRepository()


### PR DESCRIPTION
Fixes a bug causing an `asyncpg.exceptions.DataError` when performing vector similarity searches. The underlying issue occurred because Tortoise ORM (`asyncpg`) requires explicit type casting for positional arguments when executing raw SQL queries with parameter bindings that map to specific PostgreSQL types like `uuid`.

- Explicitly cast `$4`, `$5`, and `$6` as `::uuid` in the raw SQL statement inside `MemoryRepository.match_memories`.
- Add test coverage in `test_repositories.py` to assert the updated SQL formulation and the parameters being passed.

Closes #42

---
*PR created automatically by Jules for task [17444921007275596953](https://jules.google.com/task/17444921007275596953) started by @YKDBontekoe*