### PR TITLE
fix(backend): gracefully handle network unreachable errors in memory api

### DIFF
--- a/backend/app/api/v1/memory.py
+++ b/backend/app/api/v1/memory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException
+from openai import APIConnectionError
 
 from app.api.dependencies import get_memory_service
 from app.core.security.auth import CurrentUser  # noqa: TCH001
@@ -23,8 +24,13 @@ async def list_memories(
     service: Annotated[MemoryService, Depends(get_memory_service)],
 ) -> dict[str, list[Memory]]:
     """Retrieve top memories for the current user."""
-    memories = await service.retrieve_memories(query="", user_id=user_id)
-    return {"memories": memories}
+    try:
+        memories = await service.retrieve_memories(query="", user_id=user_id)
+        return {"memories": memories}
+    except APIConnectionError as e:
+        raise HTTPException(
+            status_code=503, detail="Upstream AI service is currently unreachable"
+        ) from e
 
 
 @router.get("/graph", response_model=dict[str, Any])
@@ -43,8 +49,13 @@ async def store_memory(
     service: Annotated[MemoryService, Depends(get_memory_service)],
 ) -> dict[str, Any]:
     """Manually store a new memory."""
-    memory_id = await service.store_memory(content=data.message, user_id=user_id)
-    return {"status": "ok", "id": str(memory_id)}
+    try:
+        memory_id = await service.store_memory(content=data.message, user_id=user_id)
+        return {"status": "ok", "id": str(memory_id)}
+    except APIConnectionError as e:
+        raise HTTPException(
+            status_code=503, detail="Upstream AI service is currently unreachable"
+        ) from e
 
 
 @router.delete("/{memory_id}")

--- a/backend/tests/test_memory_routes.py
+++ b/backend/tests/test_memory_routes.py
@@ -63,3 +63,45 @@ def test_store_memory_route(client: TestClient) -> None:
 
     assert response.status_code == 200
     assert response.json()["id"] == str(memory_id)
+
+
+def test_list_memories_route_network_error(client: TestClient) -> None:
+    user_id = uuid4()
+    mock_service = MagicMock()
+
+    import httpx
+    from openai import APIConnectionError
+
+    request = httpx.Request("GET", "http://test")
+    mock_service.retrieve_memories = AsyncMock(side_effect=APIConnectionError(request=request))
+
+    app.dependency_overrides[get_current_user] = lambda: user_id
+    app.dependency_overrides[get_memory_service] = lambda: mock_service
+
+    response = client.get("/api/v1/memory", headers={"Authorization": "Bearer fake_token"})
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Upstream AI service is currently unreachable"}
+
+
+def test_store_memory_route_network_error(client: TestClient) -> None:
+    user_id = uuid4()
+    mock_service = MagicMock()
+
+    import httpx
+    from openai import APIConnectionError
+
+    request = httpx.Request("POST", "http://test")
+    mock_service.store_memory = AsyncMock(side_effect=APIConnectionError(request=request))
+
+    app.dependency_overrides[get_current_user] = lambda: user_id
+    app.dependency_overrides[get_memory_service] = lambda: mock_service
+
+    response = client.post(
+        "/api/v1/memory",
+        headers={"Authorization": "Bearer fake_token"},
+        json={"message": "Important fact"},
+    )
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Upstream AI service is currently unreachable"}


### PR DESCRIPTION
Resolves an unhandled Sentry issue caused by `OSError: [Errno 101] Network is unreachable` during vector embedding requests to OpenRouter.

**Changes:**
- Added a `try...except APIConnectionError` block to `list_memories` and `store_memory` in `backend/app/api/v1/memory.py`.
- Returning a 503 HTTP status code when the AI service is unreachable, allowing the client to handle it gracefully.
- Added corresponding tests to `backend/tests/test_memory_routes.py` to simulate `openai.APIConnectionError` and verify the expected 503 response.

Closes #44

---
*PR created automatically by Jules for task [14473438240979334355](https://jules.google.com/task/14473438240979334355) started by @YKDBontekoe*