### PR TITLE
fix(agents): add missing fields to AgentGenerationResponse

### DIFF
--- a/backend/app/domain/agents/models.py
+++ b/backend/app/domain/agents/models.py
@@ -282,4 +282,12 @@ class AgentGenerationResponse(BaseModel):
     name: str
     personality: str
     description: str
+    capabilities: list[str] = Field(
+        default_factory=list,
+        description="List of capability IDs (e.g., web_search, memory) the agent should have.",
+    )
+    suggested_integrations: list[str] = Field(
+        default_factory=list,
+        description="List of integration IDs (e.g., discord, slack) the agent could use.",
+    )
     goals: list[str]


### PR DESCRIPTION
The `/api/v1/agents/generate` endpoint returns an `AgentGenerationResponse` that was missing the `capabilities` and `suggested_integrations` fields. The frontend expects these fields as seen in `AgentGenerationResponse.fromJson`. 

This PR adds the missing fields `capabilities` and `suggested_integrations` to the `AgentGenerationResponse` Pydantic model in `backend/app/domain/agents/models.py`. It also includes a test in `backend/tests/test_agents_routes.py` to verify the fix.

---
*PR created automatically by Jules for task [15490099140782559330](https://jules.google.com/task/15490099140782559330) started by @YKDBontekoe*