### PR TITLE
fix: resolve OpenRouter 404 by switching instructor to MD_JSON mode

### DIFF
--- a/backend/app/infrastructure/external/openrouter.py
+++ b/backend/app/infrastructure/external/openrouter.py
@@ -30,7 +30,7 @@ class OpenRouterClient:
         )
         self.instructor_client: instructor.AsyncInstructor = instructor.from_openai(
             self.openai_client,
-            mode=instructor.Mode.JSON,
+            mode=instructor.Mode.MD_JSON,
         )
 
     async def embed(self, text: str, model: str) -> list[float]:

--- a/backend/tests/test_openrouter.py
+++ b/backend/tests/test_openrouter.py
@@ -19,7 +19,7 @@ def test_get_openrouter_client() -> None:
 
 
 def test_openrouter_client_init() -> None:
-    """Test that the OpenRouterClient initializes instructor with JSON mode."""
+    """Test that the OpenRouterClient initializes instructor with MD_JSON mode."""
     with (
         patch("openai.AsyncOpenAI") as mock_openai,
         patch("instructor.from_openai") as mock_from_openai,
@@ -39,9 +39,9 @@ def test_openrouter_client_init() -> None:
         mock_openai.assert_called_once()
         assert mock_openai.call_args[1]["api_key"] == "test-key"
 
-        # Verify instructor is initialized with JSON mode
+        # Verify instructor is initialized with MD_JSON mode
         mock_from_openai.assert_called_once_with(
             mock_openai_instance,
-            mode=instructor.Mode.JSON,
+            mode=instructor.Mode.MD_JSON,
         )
         assert client.instructor_client == mock_instructor_instance


### PR DESCRIPTION
This PR changes the `instructor.from_openai` initialization from `instructor.Mode.JSON` to `instructor.Mode.MD_JSON`.

The previous commit attempted to fix an OpenRouter 404 issue (where the model endpoint didn't support `tool_choice` parameters injected by `Mode.TOOLS`) by switching to `Mode.JSON`. However, `Mode.JSON` injects `response_format={"type": "json_object"}`, which is also rejected by OpenRouter for models that don't natively support it.

Switching to `Mode.MD_JSON` completely bypasses API-level structuring parameters and relies solely on prompting and parsing standard markdown JSON blocks. This ensures cross-provider compatibility and effectively fixes the Sentry error.

Closes #56

---
*PR created automatically by Jules for task [18230577752153654788](https://jules.google.com/task/18230577752153654788) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the OpenRouter integration's internal data handling mechanism to use an improved data format approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->