### PR TITLE
fix: explicit cast for UUID parameters in match_memories raw SQL to fix asyncpg DataError

### DIFF
--- a/backend/app/infrastructure/repositories/memory_repo.py
+++ b/backend/app/infrastructure/repositories/memory_repo.py
@@ -49,18 +49,15 @@ class MemoryRepository:
                 query_embedding := $1::vector,
                 match_threshold := $2,
                 match_count := $3,
-                p_user_id := $4,
-                p_agent_id := $5,
-                p_room_id := $6
+                p_user_id := $4::uuid,
+                p_agent_id := $5::uuid,
+                p_room_id := $6::uuid
             )
         """
-        p_user = str(user_id) if user_id else None
-        p_agent = str(agent_id) if agent_id else None
-        p_room = str(room_id) if room_id else None
         # asyncpg expects the vector as a bracket-formatted string, e.g. "[0.1,0.2,...]"
         vector_str = "[" + ",".join(str(v) for v in vector) + "]"
         records = await conn.execute_query_dict(
-            query, [vector_str, threshold, count, p_user, p_agent, p_room]
+            query, [vector_str, threshold, count, user_id, agent_id, room_id]
         )
         return [Memory(**row) for row in records]
 

--- a/backend/tests/test_repositories.py
+++ b/backend/tests/test_repositories.py
@@ -227,11 +227,27 @@ class TestMemoryRepository:
         repo = MemoryRepository()
         mock_conn = AsyncMock()
         mock_conn.execute_query_dict = AsyncMock(return_value=[])
+        uid = uuid4()
+        aid = uuid4()
+        rid = uuid4()
         with patch("app.infrastructure.repositories.memory_repo.Tortoise") as mock_tortoise:
             mock_tortoise.get_connection.return_value = mock_conn
-            result = await repo.match_memories([0.1, 0.2], 0.5, 5, uuid4())
+            result = await repo.match_memories([0.1, 0.2], 0.5, 5, uid, aid, rid)
         assert result == []
         mock_conn.execute_query_dict.assert_awaited_once()
+        call_args = mock_conn.execute_query_dict.call_args
+        sql_query = call_args[0][0]
+        params = call_args[0][1]
+
+        # Verify the explicit casts are in the SQL string
+        assert "$4::uuid" in sql_query
+        assert "$5::uuid" in sql_query
+        assert "$6::uuid" in sql_query
+
+        # Verify parameters are passed as UUID objects, not strings
+        assert params[3] == uid
+        assert params[4] == aid
+        assert params[5] == rid
 
     async def test_search_fulltext_delegates_to_raw_sql(self) -> None:
         repo = MemoryRepository()


### PR DESCRIPTION
Fixes a `DataError` issue reported by Sentry where `asyncpg` was crashing when receiving a Python `UUID` object instead of a string within the `match_memories` RPC call. 

By explicitly casting the positional parameters to `::uuid` within the raw SQL string (e.g., `$4::uuid`), `asyncpg` can successfully bind the arguments. 

Test cases are also updated to verify the generated SQL and its bindings.

Closes #53

---
*PR created automatically by Jules for task [3286030166372519939](https://jules.google.com/task/3286030166372519939) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability of memory matching functionality through improved UUID parameter handling in database queries.

* **Tests**
  * Expanded test coverage to validate proper UUID parameter handling and query composition in memory repository operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->