### PR TITLE
fix(frontend): update ChatMessage model serialization map

### DIFF
--- a/frontend/lib/core/models/chat_message.dart
+++ b/frontend/lib/core/models/chat_message.dart
@@ -9,13 +9,14 @@ part 'chat_message.g.dart';
 class ChatMessage with _$ChatMessage {
   const ChatMessage._();
 
+  @JsonSerializable(fieldRename: FieldRename.snake)
   const factory ChatMessage({
     required String id,
     @Default('temp') String roomId,
     String? userId,
     String? agentId,
-    required String text,
-    required DateTime timestamp,
+    @JsonKey(name: 'content') required String text,
+    @JsonKey(name: 'created_at') required DateTime timestamp,
     @Default(MessageStatus.sent) MessageStatus status,
     String? crewTaskType,
   }) = _ChatMessage;

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -667,10 +667,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1088,10 +1088,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
- Add `@JsonSerializable(fieldRename: FieldRename.snake)` to `ChatMessage`
- Map `text` field to `content` to match backend `ChatMessageResponse`
- Map `timestamp` field to `created_at` to match backend `ChatMessageResponse`
- Regenerate `chat_message.g.dart` and `chat_message.freezed.dart`

Fixes an issue where parsing `ChatMessageResponse` raised `type 'Null' is not a subtype of type 'String' in type cast`.

---
*PR created automatically by Jules for task [689802407322672971](https://jules.google.com/task/689802407322672971) started by @YKDBontekoe*