### PR TITLE
Fix `asyncpg` `DataError` for UUID bindings in `match_memories`

### DIFF
--- a/backend/app/infrastructure/repositories/memory_repo.py
+++ b/backend/app/infrastructure/repositories/memory_repo.py
@@ -56,8 +56,12 @@ class MemoryRepository:
         """
         # asyncpg expects the vector as a bracket-formatted string, e.g. "[0.1,0.2,...]"
         vector_str = "[" + ",".join(str(v) for v in vector) + "]"
+        p_user_id = str(user_id) if user_id else None
+        p_agent_id = str(agent_id) if agent_id else None
+        p_room_id = str(room_id) if room_id else None
+
         records = await conn.execute_query_dict(
-            query, [vector_str, threshold, count, user_id, agent_id, room_id]
+            query, [vector_str, threshold, count, p_user_id, p_agent_id, p_room_id]
         )
         return [Memory(**row) for row in records]
 

--- a/backend/tests/test_repositories.py
+++ b/backend/tests/test_repositories.py
@@ -244,10 +244,10 @@ class TestMemoryRepository:
         assert "$5::uuid" in sql_query
         assert "$6::uuid" in sql_query
 
-        # Verify parameters are passed as UUID objects, not strings
-        assert params[3] == uid
-        assert params[4] == aid
-        assert params[5] == rid
+        # Verify parameters are passed as strings, not UUID objects
+        assert params[3] == str(uid)
+        assert params[4] == str(aid)
+        assert params[5] == str(rid)
 
     async def test_search_fulltext_delegates_to_raw_sql(self) -> None:
         repo = MemoryRepository()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2002,12 +2002,6 @@ dev = [
     { name = "types-requests" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "aerich", specifier = ">=0.7.2" },
@@ -2044,12 +2038,6 @@ requires-dist = [
     { name = "webauthn", specifier = ">=2.7.0" },
 ]
 provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.2.0" },
-    { name = "pytest-asyncio", specifier = ">=0.23.0" },
-]
 
 [[package]]
 name = "mmh3"


### PR DESCRIPTION
The `MemoryRepository.match_memories` method was encountering a Sentry `DataError` (`asyncpg.exceptions.DataError`) because it was passing Python `UUID` objects to the raw parameterised SQL `execute_query_dict` execution. Although the SQL included cast hints like `$4::uuid`, asyncpg's parameter binder for unstructured parameters expects the incoming types to be text (strings) rather than objects.

This PR fixes this by explicitly calling `str()` on `user_id`, `agent_id`, and `room_id` before passing them to the query runner. Unit tests have also been updated to verify these parameters are bound as expected.

Closes #74

---
*PR created automatically by Jules for task [124103564738418034](https://jules.google.com/task/124103564738418034) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal parameter handling for database queries to ensure consistent data type serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->