### PR TITLE
fix(memory): handle OSError and APIConnectionError in memory graph endpoint

### DIFF
--- a/backend/app/api/v1/memory.py
+++ b/backend/app/api/v1/memory.py
@@ -39,7 +39,12 @@ async def get_memory_graph(
     service: Annotated[MemoryService, Depends(get_memory_service)],
 ) -> dict[str, Any]:
     """Fetch the memory graph for the current user."""
-    return await service.get_memory_graph(user_id)
+    try:
+        return await service.get_memory_graph(user_id)
+    except (APIConnectionError, OSError) as e:
+        raise HTTPException(
+            status_code=503, detail="Upstream AI service is currently unreachable"
+        ) from e
 
 
 @router.post("", response_model=dict[str, Any])

--- a/backend/tests/test_memory_routes.py
+++ b/backend/tests/test_memory_routes.py
@@ -84,6 +84,40 @@ def test_list_memories_route_network_error(client: TestClient) -> None:
     assert response.json() == {"detail": "Upstream AI service is currently unreachable"}
 
 
+def test_get_memory_graph_network_error(client: TestClient) -> None:
+    user_id = uuid4()
+    mock_service = MagicMock()
+
+    import httpx
+    from openai import APIConnectionError
+
+    request = httpx.Request("GET", "http://test")
+    mock_service.get_memory_graph = AsyncMock(side_effect=APIConnectionError(request=request))
+
+    app.dependency_overrides[get_current_user] = lambda: user_id
+    app.dependency_overrides[get_memory_service] = lambda: mock_service
+
+    response = client.get("/api/v1/memory/graph", headers={"Authorization": "Bearer fake_token"})
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Upstream AI service is currently unreachable"}
+
+
+def test_get_memory_graph_oserror(client: TestClient) -> None:
+    user_id = uuid4()
+    mock_service = MagicMock()
+
+    mock_service.get_memory_graph = AsyncMock(side_effect=OSError(101, "Network is unreachable"))
+
+    app.dependency_overrides[get_current_user] = lambda: user_id
+    app.dependency_overrides[get_memory_service] = lambda: mock_service
+
+    response = client.get("/api/v1/memory/graph", headers={"Authorization": "Bearer fake_token"})
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Upstream AI service is currently unreachable"}
+
+
 def test_list_memories_route_oserror(client: TestClient) -> None:
     user_id = uuid4()
     mock_service = MagicMock()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2002,12 +2002,6 @@ dev = [
     { name = "types-requests" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "aerich", specifier = ">=0.7.2" },
@@ -2044,12 +2038,6 @@ requires-dist = [
     { name = "webauthn", specifier = ">=2.7.0" },
 ]
 provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.2.0" },
-    { name = "pytest-asyncio", specifier = ">=0.23.0" },
-]
 
 [[package]]
 name = "mmh3"


### PR DESCRIPTION
Fixes an unhandled `OSError: [Errno 101] Network is unreachable` Sentry error originating from the `/api/v1/memory/graph` endpoint by catching the error and gracefully handling it as a 503 Service Unavailable.

Closes #76

---
*PR created automatically by Jules for task [11711493470351389829](https://jules.google.com/task/11711493470351389829) started by @YKDBontekoe*