### PR TITLE
fix(agents): handle InstructorRetryException and network errors gracefully

### DIFF
--- a/backend/app/api/v1/agents.py
+++ b/backend/app/api/v1/agents.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
+from openai import APIConnectionError
+
+try:
+    from instructor.core.exceptions import InstructorRetryException
+except ImportError:
+    from instructor.exceptions import InstructorRetryException
 
 from app.api.dependencies import get_agent_service
 from app.core.security.auth import CurrentUser  # noqa: TCH001
@@ -67,4 +73,13 @@ async def generate_agent(
     service: Annotated[AgentService, Depends(get_agent_service)],
 ) -> AgentGenerationResponse:
     """Use AI to generate an agent persona."""
-    return await service.generate_agent_profile(data.keywords)
+    try:
+        return await service.generate_agent_profile(data.keywords)
+    except (APIConnectionError, OSError) as e:
+        raise HTTPException(
+            status_code=503, detail="Upstream AI service is currently unreachable"
+        ) from e
+    except InstructorRetryException as e:
+        raise HTTPException(
+            status_code=503, detail="Upstream AI service failed to generate a valid response"
+        ) from e

--- a/backend/tests/test_agents_routes.py
+++ b/backend/tests/test_agents_routes.py
@@ -5,6 +5,12 @@ from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
+from openai import APIConnectionError
+
+try:
+    from instructor.core.exceptions import InstructorRetryException
+except ImportError:
+    from instructor.exceptions import InstructorRetryException
 
 from app.api.dependencies import get_agent_service
 from app.core.security.auth import get_current_user
@@ -113,3 +119,58 @@ def test_build_agent_response_without_avatar() -> None:
     assert response.integrations == ["steam"]
     assert response.integration_configs == {"steam": {"steam_id": "123"}}
     assert not hasattr(response, "avatar_url")
+
+
+def test_generate_agent_network_error(client: TestClient) -> None:
+    mock_service = MagicMock()
+    mock_service.generate_agent_profile = AsyncMock(
+        side_effect=APIConnectionError(request=MagicMock())
+    )
+
+    app.dependency_overrides[get_current_user] = lambda: uuid4()
+    app.dependency_overrides[get_agent_service] = lambda: mock_service
+
+    response = client.post(
+        "/api/v1/agents/generate",
+        headers={"Authorization": "Bearer fake_token"},
+        json={"keywords": "friendly assistant"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Upstream AI service is currently unreachable"
+
+
+def test_generate_agent_oserror(client: TestClient) -> None:
+    mock_service = MagicMock()
+    mock_service.generate_agent_profile = AsyncMock(side_effect=OSError("Network is unreachable"))
+
+    app.dependency_overrides[get_current_user] = lambda: uuid4()
+    app.dependency_overrides[get_agent_service] = lambda: mock_service
+
+    response = client.post(
+        "/api/v1/agents/generate",
+        headers={"Authorization": "Bearer fake_token"},
+        json={"keywords": "friendly assistant"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Upstream AI service is currently unreachable"
+
+
+def test_generate_agent_instructor_retry_exception(client: TestClient) -> None:
+    mock_service = MagicMock()
+    mock_service.generate_agent_profile = AsyncMock(
+        side_effect=InstructorRetryException(n_attempts=3, last_completion=None, total_usage=0)
+    )
+
+    app.dependency_overrides[get_current_user] = lambda: uuid4()
+    app.dependency_overrides[get_agent_service] = lambda: mock_service
+
+    response = client.post(
+        "/api/v1/agents/generate",
+        headers={"Authorization": "Bearer fake_token"},
+        json={"keywords": "friendly assistant"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Upstream AI service failed to generate a valid response"


### PR DESCRIPTION
Closes #70

This PR fixes an unhandled `InstructorRetryException` (as reported in Sentry) occurring in the `generate_agent` endpoint. 

- Added error handling for `InstructorRetryException`, `APIConnectionError`, and `OSError` to gracefully return a `503 Service Unavailable` status instead of a `500 Internal Server Error`.
- Implemented backwards-compatible imports for `InstructorRetryException`.
- Added unit tests to ensure that `503` is correctly returned for these exceptions when generating agent profiles.

---
*PR created automatically by Jules for task [8830883302551770278](https://jules.google.com/task/8830883302551770278) started by @YKDBontekoe*