### PR TITLE
perf(frontend): Optimize initial load for GroupChatPage with concurrent API fetching

### DIFF
--- a/frontend/lib/features/rooms/pages/group_chat_page.dart
+++ b/frontend/lib/features/rooms/pages/group_chat_page.dart
@@ -62,13 +62,15 @@ class _GroupChatPageState extends State<GroupChatPage> {
   Future<void> _loadData() async {
     setState(() => _isLoading = true);
     try {
-      final agentsData = await ApiService.getRoomAgents(widget.room.id);
-      final messagesData = await ApiService.getRoomMessages(widget.room.id);
+      final results = await Future.wait([
+        ApiService.getRoomAgents(widget.room.id),
+        ApiService.getRoomMessages(widget.room.id),
+      ]);
 
       if (!mounted) return;
       setState(() {
-        _roomAgents = agentsData;
-        _messages = messagesData;
+        _roomAgents = results[0] as List<Agent>;
+        _messages = results[1] as List<ChatMessage>;
       });
       _scrollToBottom();
     } catch (e) {


### PR DESCRIPTION
**Justification:**
Before this change, `GroupChatPage` awaited `ApiService.getRoomAgents` and `ApiService.getRoomMessages` sequentially in `_loadData()`. This was a blocking network bottleneck causing the screen to load in O(time_agents + time_messages).
By using `Future.wait`, both network requests are fetched concurrently, reducing the initial load time to O(max(time_agents, time_messages)). This conforms to the "Consolidate endpoints that the client calls in sequence" and "Database & Query Efficiency" performance guidelines.

---
*PR created automatically by Jules for task [2751557100663615914](https://jules.google.com/task/2751557100663615914) started by @YKDBontekoe*