### PR TITLE
ci: fix working-directory inheritance in flutter-generate-code composite action

### DIFF
--- a/.github/actions/flutter-generate-code/action.yml
+++ b/.github/actions/flutter-generate-code/action.yml
@@ -1,11 +1,18 @@
 name: 'Flutter Generate Code'
 description: 'Installs dependencies and runs build_runner to generate code'
+inputs:
+  working-directory:
+    description: 'Working directory'
+    required: false
+    default: '.'
 runs:
   using: "composite"
   steps:
     - name: Install dependencies
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: flutter pub get
     - name: Run build_runner
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: dart run build_runner build --delete-conflicting-outputs

--- a/.github/workflows/flutter-pipeline.yml
+++ b/.github/workflows/flutter-pipeline.yml
@@ -63,6 +63,8 @@ jobs:
           cache: true
       - name: Install dependencies and generate code
         uses: ./.github/actions/flutter-generate-code
+        with:
+          working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: Build APK
         run: flutter build apk --release
       - name: Build App Bundle
@@ -105,6 +107,8 @@ jobs:
           cache: true
       - name: Install dependencies and generate code
         uses: ./.github/actions/flutter-generate-code
+        with:
+          working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: Build IPA
         run: flutter build ios --release --no-codesign
       - name: Upload IPA
@@ -140,6 +144,8 @@ jobs:
           cache: true
       - name: Install dependencies and generate code
         uses: ./.github/actions/flutter-generate-code
+        with:
+          working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: Build Web
         run: flutter build web --release
       - name: Upload Web Build


### PR DESCRIPTION
GitHub Actions composite actions do not automatically inherit the caller's `defaults.run.working-directory`. This caused the `flutter pub get` and `dart run build_runner` steps in the `flutter-generate-code` action to execute in the repository root instead of the intended frontend directory during android, ios, and web build jobs.

This commit updates the composite action to accept an explicit `working-directory` input (defaulting to '.') and updates the workflow call-sites to pass the correct `${{ env.WORKING_DIRECTORY }}`.

---
*PR created automatically by Jules for task [9795912641714040863](https://jules.google.com/task/9795912641714040863) started by @YKDBontekoe*