### PR TITLE
build(frontend): Configure Sentry DSN in flutter build pipeline

### DIFF
--- a/.github/workflows/flutter-pipeline.yml
+++ b/.github/workflows/flutter-pipeline.yml
@@ -66,9 +66,9 @@ jobs:
         with:
           working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: Build APK
-        run: flutter build apk --release --dart-define=SUPABASE_URL="${{ secrets.PRODUCTION_SUPABASE_URL }}" --dart-define=SUPABASE_ANON_KEY="${{ secrets.PRODUCTION_SUPABASE_KEY }}" ${{ vars.PRODUCTION_URL != '' && format('--dart-define=BACKEND_URL="{0}/api/v1"', vars.PRODUCTION_URL) || '' }}
+        run: flutter build apk --release --dart-define=SENTRY_DSN="${{ secrets.SENTRY_DSN }}" --dart-define=SUPABASE_URL="${{ secrets.PRODUCTION_SUPABASE_URL }}" --dart-define=SUPABASE_ANON_KEY="${{ secrets.PRODUCTION_SUPABASE_KEY }}" ${{ vars.PRODUCTION_URL != '' && format('--dart-define=BACKEND_URL="{0}/api/v1"', vars.PRODUCTION_URL) || '' }}
       - name: Build App Bundle
-        run: flutter build appbundle --release --dart-define=SUPABASE_URL="${{ secrets.PRODUCTION_SUPABASE_URL }}" --dart-define=SUPABASE_ANON_KEY="${{ secrets.PRODUCTION_SUPABASE_KEY }}" ${{ vars.PRODUCTION_URL != '' && format('--dart-define=BACKEND_URL="{0}/api/v1"', vars.PRODUCTION_URL) || '' }}
+        run: flutter build appbundle --release --dart-define=SENTRY_DSN="${{ secrets.SENTRY_DSN }}" --dart-define=SUPABASE_URL="${{ secrets.PRODUCTION_SUPABASE_URL }}" --dart-define=SUPABASE_ANON_KEY="${{ secrets.PRODUCTION_SUPABASE_KEY }}" ${{ vars.PRODUCTION_URL != '' && format('--dart-define=BACKEND_URL="{0}/api/v1"', vars.PRODUCTION_URL) || '' }}
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
@@ -110,7 +110,7 @@ jobs:
         with:
           working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: Build IPA
-        run: flutter build ios --release --no-codesign --dart-define=SUPABASE_URL="${{ secrets.PRODUCTION_SUPABASE_URL }}" --dart-define=SUPABASE_ANON_KEY="${{ secrets.PRODUCTION_SUPABASE_KEY }}" ${{ vars.PRODUCTION_URL != '' && format('--dart-define=BACKEND_URL="{0}/api/v1"', vars.PRODUCTION_URL) || '' }}
+        run: flutter build ios --release --no-codesign --dart-define=SENTRY_DSN="${{ secrets.SENTRY_DSN }}" --dart-define=SUPABASE_URL="${{ secrets.PRODUCTION_SUPABASE_URL }}" --dart-define=SUPABASE_ANON_KEY="${{ secrets.PRODUCTION_SUPABASE_KEY }}" ${{ vars.PRODUCTION_URL != '' && format('--dart-define=BACKEND_URL="{0}/api/v1"', vars.PRODUCTION_URL) || '' }}
       - name: Upload IPA
         uses: actions/upload-artifact@v4
         with:
@@ -147,7 +147,7 @@ jobs:
         with:
           working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: Build Web
-        run: flutter build web --release --dart-define=SUPABASE_URL="${{ secrets.PRODUCTION_SUPABASE_URL }}" --dart-define=SUPABASE_ANON_KEY="${{ secrets.PRODUCTION_SUPABASE_KEY }}" ${{ vars.PRODUCTION_URL != '' && format('--dart-define=BACKEND_URL="{0}/api/v1"', vars.PRODUCTION_URL) || '' }}
+        run: flutter build web --release --dart-define=SENTRY_DSN="${{ secrets.SENTRY_DSN }}" --dart-define=SUPABASE_URL="${{ secrets.PRODUCTION_SUPABASE_URL }}" --dart-define=SUPABASE_ANON_KEY="${{ secrets.PRODUCTION_SUPABASE_KEY }}" ${{ vars.PRODUCTION_URL != '' && format('--dart-define=BACKEND_URL="{0}/api/v1"', vars.PRODUCTION_URL) || '' }}
       - name: Upload Web Build
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Added `--dart-define=SENTRY_DSN="${{ secrets.SENTRY_DSN }}"` to all flutter build commands (APK, App Bundle, iOS IPA, and Web) within the `.github/workflows/flutter-pipeline.yml` workflow to ensure error tracking is enabled universally.

---
*PR created automatically by Jules for task [4206844989633614110](https://jules.google.com/task/4206844989633614110) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to include error tracking settings across all Flutter build variants (APK, App Bundle, IPA, Web) for Android, iOS, and Web platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->