### PR TITLE
fix: add staticDistDir to lighthouse config to resolve 'No URLs provided to collect'

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3055,11 +3055,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.2"
+version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586, upload-time = "2026-01-16T18:04:18.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371, upload-time = "2026-01-16T18:04:17.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
 ]
 
 [[package]]

--- a/frontend/.lighthouserc.json
+++ b/frontend/.lighthouserc.json
@@ -1,7 +1,7 @@
 {
   "ci": {
     "collect": {
-      "staticDistDir": "./web-dist"
+      "staticDistDir": "../web-dist"
     },
     "assert": {
       "assertions": {


### PR DESCRIPTION
This specifies the path for the Lighthouse CI action to find the build artifact (`web-dist`) so it can be served and tested.

---
*PR created automatically by Jules for task [7048244496937115989](https://jules.google.com/task/7048244496937115989) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Lighthouse CI configuration to enable collection from the built static distribution, allowing performance and accessibility audits to target the production-ready output. This only adjusts where Lighthouse collects files; it does not change assertions, public behavior, or any exposed functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->