### PR TITLE
ci: bump aquasecurity/trivy-action to v0.35.0

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -125,7 +125,7 @@ jobs:
       # unfixed CRITICAL CVEs. Running two separate scans on the same image wastes
       # time and double-counts billable minutes.
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ needs.build.outputs.image-tag }}
           format: 'sarif'


### PR DESCRIPTION
Upgrades aquasecurity/trivy-action from 0.29.0 to 0.35.0 to resolve a downloading/execution error with the newer v0.57.1 Trivy binaries.

---
*PR created automatically by Jules for task [13866502373752742802](https://jules.google.com/task/13866502373752742802) started by @YKDBontekoe*