### PR TITLE
fix: Use supported instructor mode for OpenRouter

### DIFF
--- a/backend/app/infrastructure/external/openrouter.py
+++ b/backend/app/infrastructure/external/openrouter.py
@@ -30,7 +30,7 @@ class OpenRouterClient:
         )
         self.instructor_client: instructor.AsyncInstructor = instructor.from_openai(
             self.openai_client,
-            mode=instructor.Mode.MD_JSON,
+            mode=instructor.Mode.OPENROUTER_STRUCTURED_OUTPUTS,
         )
 
     async def embed(self, text: str, model: str) -> list[float]:

--- a/backend/tests/test_openrouter.py
+++ b/backend/tests/test_openrouter.py
@@ -19,7 +19,7 @@ def test_get_openrouter_client() -> None:
 
 
 def test_openrouter_client_init() -> None:
-    """Test that the OpenRouterClient initializes instructor with MD_JSON mode."""
+    """Test that the OpenRouterClient initializes instructor with OPENROUTER_STRUCTURED_OUTPUTS mode."""
     with (
         patch("openai.AsyncOpenAI") as mock_openai,
         patch("instructor.from_openai") as mock_from_openai,
@@ -39,9 +39,9 @@ def test_openrouter_client_init() -> None:
         mock_openai.assert_called_once()
         assert mock_openai.call_args[1]["api_key"] == "test-key"
 
-        # Verify instructor is initialized with MD_JSON mode
+        # Verify instructor is initialized with OPENROUTER_STRUCTURED_OUTPUTS mode
         mock_from_openai.assert_called_once_with(
             mock_openai_instance,
-            mode=instructor.Mode.MD_JSON,
+            mode=instructor.Mode.OPENROUTER_STRUCTURED_OUTPUTS,
         )
         assert client.instructor_client == mock_instructor_instance


### PR DESCRIPTION
Replaced `instructor.Mode.MD_JSON` with `instructor.Mode.OPENROUTER_STRUCTURED_OUTPUTS` when initializing the `instructor.from_openai` client in `backend/app/infrastructure/external/openrouter.py`.

The backend `generate_agent` route was previously crashing with an `AssertionError` when calling `structured_completion` because the `instructor` library explicitly checks the supported modes for `Provider.OPENROUTER` (which are `TOOLS`, `OPENROUTER_STRUCTURED_OUTPUTS`, and `JSON`) and raises an assertion error if the configured mode is not supported.

Also updated the `test_openrouter_client_init` test to reflect this new mode configuration.

---
*PR created automatically by Jules for task [14848790575323967282](https://jules.google.com/task/14848790575323967282) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AI service structured output mode configuration to use native provider capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->