### PR TITLE
Fix missing image tag in deploy job

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -186,9 +186,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # migrate and scan/build must both succeed before deploying. migrate already
-    # depends on test, and scan already depends on build — so needs: [migrate, scan]
-    # covers the full chain without redundantly listing build.
-    needs: [migrate, scan]
+    # depends on test, and scan already depends on build.
+    # build is explicitly listed because we need to access its output image-tag.
+    needs: [migrate, scan, build]
     if: github.ref == 'refs/heads/main'
     environment:
       name: production


### PR DESCRIPTION
In GitHub Actions, a job can only access the outputs of another job if that job is explicitly declared in its `needs` array. Because `build` was not listed in the `deploy` job's `needs` (relying implicitly on `scan`), `needs.build.outputs.image-tag` evaluated to an empty string, causing the `az containerapp update` command to fail due to a missing `--image` argument.

This patch explicitly adds `build` to the `needs` array so the image tag can be properly accessed.

---
*PR created automatically by Jules for task [12770193789923803077](https://jules.google.com/task/12770193789923803077) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend deployment workflow to enforce proper dependency ordering, ensuring Docker image builds are available before deployment runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->