### PR TITLE
fix(frontend): normalize API base URL for room endpoints

### DIFF
--- a/frontend/__tests__/backendUrl.test.ts
+++ b/frontend/__tests__/backendUrl.test.ts
@@ -1,0 +1,20 @@
+import { normalizeApiBaseUrl, toHealthBaseUrl } from '../src/core/utils/backendUrl';
+
+describe('backend URL normalization', () => {
+  it('appends /api/v1 when base URL has no path', () => {
+    expect(normalizeApiBaseUrl('https://example.com')).toBe('https://example.com/api/v1');
+  });
+
+  it('upgrades /api to /api/v1', () => {
+    expect(normalizeApiBaseUrl('https://example.com/api')).toBe('https://example.com/api/v1');
+  });
+
+  it('preserves an existing /api/v1 path', () => {
+    expect(normalizeApiBaseUrl('https://example.com/api/v1/')).toBe('https://example.com/api/v1');
+  });
+
+  it('derives a health endpoint base URL', () => {
+    expect(toHealthBaseUrl('https://example.com/api/v1')).toBe('https://example.com');
+    expect(toHealthBaseUrl('https://example.com')).toBe('https://example.com');
+  });
+});

--- a/frontend/src/core/api/client.ts
+++ b/frontend/src/core/api/client.ts
@@ -2,6 +2,7 @@ import axios, { AxiosError } from 'axios';
 import { supabase } from '../services/supabase';
 import { Platform } from 'react-native';
 import { useAppStore } from '../../store/useAppStore';
+import { normalizeApiBaseUrl, toHealthBaseUrl } from '../utils/backendUrl';
 import i18next from 'i18next';
 
 const LOCAL_BACKEND_URL = Platform.select({
@@ -22,7 +23,10 @@ export const apiClient = axios.create({
 
 apiClient.interceptors.request.use(async (config) => {
   const storeUrl = useAppStore.getState().baseUrl || LOCAL_BACKEND_URL;
-  config.baseURL = storeUrl.endsWith('/') ? storeUrl : `${storeUrl}/`;
+  const normalizedApiBaseUrl = normalizeApiBaseUrl(storeUrl);
+  config.baseURL = normalizedApiBaseUrl.endsWith('/')
+    ? normalizedApiBaseUrl
+    : `${normalizedApiBaseUrl}/`;
 
   const {
     data: { session },
@@ -49,7 +53,7 @@ apiClient.interceptors.response.use(
 
 export async function waitForBackend(maxAttempts = 30, initialDelay = 1000): Promise<void> {
   const baseUrl = useAppStore.getState().baseUrl || LOCAL_BACKEND_URL;
-  const healthUrl = `${baseUrl.replace(/\/api\/v1\/?$/, '')}/health`;
+  const healthUrl = `${toHealthBaseUrl(baseUrl)}/health`;
 
   let currentDelay = initialDelay;
 
@@ -79,7 +83,11 @@ export async function streamChat(
   signal?: AbortSignal
 ): Promise<void> {
   const storeUrl = useAppStore.getState().baseUrl || LOCAL_BACKEND_URL;
-  const fullUrl = `${storeUrl.endsWith('/') ? storeUrl : `${storeUrl}/`}${endpoint}`;
+  const normalizedApiBaseUrl = normalizeApiBaseUrl(storeUrl);
+  const baseWithSlash = normalizedApiBaseUrl.endsWith('/')
+    ? normalizedApiBaseUrl
+    : `${normalizedApiBaseUrl}/`;
+  const fullUrl = `${baseWithSlash}${endpoint}`;
   const {
     data: { session },
   } = await supabase.auth.getSession();

--- a/frontend/src/core/services/ChatHubService.ts
+++ b/frontend/src/core/services/ChatHubService.ts
@@ -12,6 +12,7 @@
 import { Platform } from 'react-native';
 import { supabase } from './supabase';
 import { useAppStore } from '../../store/useAppStore';
+import { normalizeApiBaseUrl } from '../utils/backendUrl';
 import i18next from 'i18next';
 
 // ---------------------------------------------------------------------------
@@ -64,9 +65,9 @@ const LOCAL_BACKEND_URL = Platform.select({
 });
 
 function toWsUrl(httpBase: string): string {
-  const base = httpBase.replace(/^http/, 'ws').replace(/\/+$/, '');
-  // Avoid doubling the /api/v1 segment when the baseUrl already includes it
-  return base.endsWith('/api/v1') ? `${base}/ws/chat` : `${base}/api/v1/ws/chat`;
+  const apiBase = normalizeApiBaseUrl(httpBase);
+  const wsBase = apiBase.replace(/^http/, 'ws').replace(/\/+$/, '');
+  return `${wsBase}/ws/chat`;
 }
 
 type FrameListener = (frame: HubFrame) => void;

--- a/frontend/src/core/utils/backendUrl.ts
+++ b/frontend/src/core/utils/backendUrl.ts
@@ -1,0 +1,19 @@
+const API_V1_SUFFIX = '/api/v1';
+
+export function normalizeApiBaseUrl(rawBaseUrl: string): string {
+  const trimmed = rawBaseUrl.replace(/\/+$/, '');
+
+  if (trimmed.endsWith(API_V1_SUFFIX)) {
+    return trimmed;
+  }
+
+  if (trimmed.endsWith('/api')) {
+    return `${trimmed}/v1`;
+  }
+
+  return `${trimmed}${API_V1_SUFFIX}`;
+}
+
+export function toHealthBaseUrl(rawBaseUrl: string): string {
+  return normalizeApiBaseUrl(rawBaseUrl).replace(/\/api\/v1$/, '');
+}


### PR DESCRIPTION
Ensure REST, streaming, and websocket clients always target /api/v1 so room creation does not hit /rooms and return 404 when base URLs omit the versioned API path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for backend URL normalization and health endpoint detection scenarios.

* **Refactor**
  * Consolidated URL handling logic across API modules to reduce duplication and improve consistency in backend endpoint management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->