### PR TITLE
refactor: extract EventCard component and harden error handling

### DIFF
--- a/backend/app/domain/chat/service.py
+++ b/backend/app/domain/chat/service.py
@@ -345,8 +345,10 @@ class ChatService:
             )
             if memories:
                 memory_context = "\n".join(f"- {m.content}" for m in memories)
-        except Exception:
-            logger.warning("Memory retrieval failed for room=%s, proceeding without", room_id)
+        except openai.OpenAIError as e:
+            logger.warning("Memory retrieval OpenAI error for room=%s: %s", room_id, e)
+        except Exception as e:
+            logger.warning("Memory retrieval unexpected error for room=%s: %s", room_id, e)
 
         # 5. Broadcast thinking indicator and create step callback.
         agent_names = [a.name for a in room_agents]
@@ -412,8 +414,32 @@ class ChatService:
                     self.bg_service.update_room_summary_background(room_id, conversation_history)
                 )
 
+        except openai.OpenAIError:
+            logger.exception("OpenAI error processing crew task for room=%s", room_id)
+            await chat_hub.broadcast_to_room(
+                room_id,
+                {
+                    "type": "agent_activity",
+                    "data": {
+                        "room_id": str(room_id),
+                        "agent_names": agent_names,
+                        "activity": "error",
+                        "detail": "",
+                    },
+                },
+            )
+            await chat_hub.broadcast_to_room(
+                room_id,
+                {
+                    "type": "error",
+                    "data": {
+                        "message": "Something went wrong, please try again.",
+                        "room_id": str(room_id),
+                    },
+                },
+            )
         except Exception:
-            logger.exception("Failed processing crew task for room=%s", room_id)
+            logger.exception("Unexpected error processing crew task for room=%s", room_id)
             await chat_hub.broadcast_to_room(
                 room_id,
                 {

--- a/backend/app/domain/chat/service.py
+++ b/backend/app/domain/chat/service.py
@@ -348,7 +348,7 @@ class ChatService:
         except openai.OpenAIError as e:
             logger.warning("Memory retrieval OpenAI error for room=%s: %s", room_id, e)
         except Exception as e:
-            logger.warning("Memory retrieval unexpected error for room=%s: %s", room_id, e)
+            logger.exception("Memory retrieval unexpected error for room=%s: %s", room_id, e)
 
         # 5. Broadcast thinking indicator and create step callback.
         agent_names = [a.name for a in room_agents]

--- a/backend/tests/chat/test_chat_ws.py
+++ b/backend/tests/chat/test_chat_ws.py
@@ -4,6 +4,7 @@ import typing
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+import openai
 import pytest
 from tortoise.exceptions import BaseORMException
 
@@ -213,7 +214,6 @@ async def test_run_room_chat_ws_success(chat_service: ChatService) -> None:
         ) as m_agent_resp,
         patch("app.infrastructure.websocket.manager.chat_hub") as mock_hub,
         patch("app.domain.chat.service.asyncio.create_task") as m_create_task,
-        patch("app.domain.chat.service.openai.OpenAIError", Exception),
     ):
         mock_hub.broadcast_to_room = AsyncMock()
         m_persist.return_value = MagicMock(id=uuid4())
@@ -240,15 +240,28 @@ async def test_run_room_chat_ws_unauthorized(chat_service: ChatService) -> None:
         mock_hub.broadcast_to_room.assert_awaited_once()
 
 
-@pytest.mark.asyncio
-async def test_run_room_chat_ws_exception(chat_service: ChatService) -> None:
-    import openai
 
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "side_effect, log_message_part",
+    [
+        (openai.OpenAIError("API error"), "OpenAI error"),
+        (ValueError("Unexpected error"), "Unexpected error"),
+    ],
+)
+async def test_run_room_chat_ws_exceptions(
+    chat_service: ChatService,
+    caplog: pytest.LogCaptureFixture,
+    side_effect: Exception,
+    log_message_part: str,
+) -> None:
     room_id = uuid4()
     user_id = uuid4()
-    typing.cast("AsyncMock", chat_service.chat_repo.list_room_agents).return_value = [
-        MagicMock(id=uuid4(), name="Agent1")
-    ]
+    agent_name = "Agent1"
+    mock_agent = MagicMock(id=uuid4())
+    mock_agent.name = agent_name
+    typing.cast("AsyncMock", chat_service.chat_repo.list_room_agents).return_value = [mock_agent]
     with (
         patch.object(
             chat_service.ws_broadcaster,
@@ -267,36 +280,23 @@ async def test_run_room_chat_ws_exception(chat_service: ChatService) -> None:
     ):
         mock_hub.broadcast_to_room = AsyncMock()
         m_persist.return_value = MagicMock(id=uuid4())
-        m_exec.side_effect = openai.OpenAIError("API error")
+        m_exec.side_effect = side_effect
         await chat_service.run_room_chat_ws(room_id, "Hello", user_id)
-        mock_hub.broadcast_to_room.assert_called()
 
+        assert mock_hub.broadcast_to_room.call_count == 2
 
-@pytest.mark.asyncio
-async def test_run_room_chat_ws_unexpected_exception(chat_service: ChatService) -> None:
-    room_id = uuid4()
-    user_id = uuid4()
-    typing.cast("AsyncMock", chat_service.chat_repo.list_room_agents).return_value = [
-        MagicMock(id=uuid4(), name="Agent1")
-    ]
-    with (
-        patch.object(
-            chat_service.ws_broadcaster,
-            "handle_message_persistence_and_broadcast",
-            new_callable=AsyncMock,
-        ) as m_persist,
-        patch.object(
-            chat_service.ws_broadcaster, "broadcast_thinking_status", new_callable=AsyncMock
-        ),
-        patch.object(chat_service.ws_broadcaster, "create_step_callback", return_value=MagicMock()),
-        patch(
-            "app.domain.chat.crew_orchestrator.CrewOrchestrator.execute_crew_task",
-            new_callable=AsyncMock,
-        ) as m_exec,
-        patch("app.infrastructure.websocket.manager.chat_hub") as mock_hub,
-    ):
-        mock_hub.broadcast_to_room = AsyncMock()
-        m_persist.return_value = MagicMock(id=uuid4())
-        m_exec.side_effect = ValueError("Unexpected error")
-        await chat_service.run_room_chat_ws(room_id, "Hello", user_id)
-        mock_hub.broadcast_to_room.assert_called()
+        # Check first broadcast (agent_activity error)
+        call_args_1 = mock_hub.broadcast_to_room.call_args_list[0][0]
+        assert call_args_1[0] == room_id
+        assert call_args_1[1]["type"] == "agent_activity"
+        assert call_args_1[1]["data"]["activity"] == "error"
+        assert agent_name in call_args_1[1]["data"]["agent_names"]
+
+        # Check second broadcast (generic error payload)
+        call_args_2 = mock_hub.broadcast_to_room.call_args_list[1][0]
+        assert call_args_2[0] == room_id
+        assert call_args_2[1]["type"] == "error"
+        assert "Something went wrong" in call_args_2[1]["data"]["message"]
+
+        # Assert logging contains specific message
+        assert any(log_message_part in record.message for record in caplog.records)

--- a/backend/tests/chat/test_chat_ws.py
+++ b/backend/tests/chat/test_chat_ws.py
@@ -239,9 +239,11 @@ async def test_run_room_chat_ws_unauthorized(chat_service: ChatService) -> None:
         await chat_service.run_room_chat_ws(room_id, user_message, user_id)
         mock_hub.broadcast_to_room.assert_awaited_once()
 
+
 @pytest.mark.asyncio
 async def test_run_room_chat_ws_exception(chat_service: ChatService) -> None:
     import openai
+
     room_id = uuid4()
     user_id = uuid4()
     typing.cast("AsyncMock", chat_service.chat_repo.list_room_agents).return_value = [
@@ -268,6 +270,7 @@ async def test_run_room_chat_ws_exception(chat_service: ChatService) -> None:
         m_exec.side_effect = openai.OpenAIError("API error")
         await chat_service.run_room_chat_ws(room_id, "Hello", user_id)
         mock_hub.broadcast_to_room.assert_called()
+
 
 @pytest.mark.asyncio
 async def test_run_room_chat_ws_unexpected_exception(chat_service: ChatService) -> None:

--- a/backend/tests/chat/test_chat_ws.py
+++ b/backend/tests/chat/test_chat_ws.py
@@ -213,6 +213,7 @@ async def test_run_room_chat_ws_success(chat_service: ChatService) -> None:
         ) as m_agent_resp,
         patch("app.infrastructure.websocket.manager.chat_hub") as mock_hub,
         patch("app.domain.chat.service.asyncio.create_task") as m_create_task,
+        patch("app.domain.chat.service.openai.OpenAIError", Exception),
     ):
         mock_hub.broadcast_to_room = AsyncMock()
         m_persist.return_value = MagicMock(id=uuid4())
@@ -237,3 +238,62 @@ async def test_run_room_chat_ws_unauthorized(chat_service: ChatService) -> None:
         mock_hub.broadcast_to_room = AsyncMock()
         await chat_service.run_room_chat_ws(room_id, user_message, user_id)
         mock_hub.broadcast_to_room.assert_awaited_once()
+
+@pytest.mark.asyncio
+async def test_run_room_chat_ws_exception(chat_service: ChatService) -> None:
+    import openai
+    room_id = uuid4()
+    user_id = uuid4()
+    typing.cast("AsyncMock", chat_service.chat_repo.list_room_agents).return_value = [
+        MagicMock(id=uuid4(), name="Agent1")
+    ]
+    with (
+        patch.object(
+            chat_service.ws_broadcaster,
+            "handle_message_persistence_and_broadcast",
+            new_callable=AsyncMock,
+        ) as m_persist,
+        patch.object(
+            chat_service.ws_broadcaster, "broadcast_thinking_status", new_callable=AsyncMock
+        ),
+        patch.object(chat_service.ws_broadcaster, "create_step_callback", return_value=MagicMock()),
+        patch(
+            "app.domain.chat.crew_orchestrator.CrewOrchestrator.execute_crew_task",
+            new_callable=AsyncMock,
+        ) as m_exec,
+        patch("app.infrastructure.websocket.manager.chat_hub") as mock_hub,
+    ):
+        mock_hub.broadcast_to_room = AsyncMock()
+        m_persist.return_value = MagicMock(id=uuid4())
+        m_exec.side_effect = openai.OpenAIError("API error")
+        await chat_service.run_room_chat_ws(room_id, "Hello", user_id)
+        mock_hub.broadcast_to_room.assert_called()
+
+@pytest.mark.asyncio
+async def test_run_room_chat_ws_unexpected_exception(chat_service: ChatService) -> None:
+    room_id = uuid4()
+    user_id = uuid4()
+    typing.cast("AsyncMock", chat_service.chat_repo.list_room_agents).return_value = [
+        MagicMock(id=uuid4(), name="Agent1")
+    ]
+    with (
+        patch.object(
+            chat_service.ws_broadcaster,
+            "handle_message_persistence_and_broadcast",
+            new_callable=AsyncMock,
+        ) as m_persist,
+        patch.object(
+            chat_service.ws_broadcaster, "broadcast_thinking_status", new_callable=AsyncMock
+        ),
+        patch.object(chat_service.ws_broadcaster, "create_step_callback", return_value=MagicMock()),
+        patch(
+            "app.domain.chat.crew_orchestrator.CrewOrchestrator.execute_crew_task",
+            new_callable=AsyncMock,
+        ) as m_exec,
+        patch("app.infrastructure.websocket.manager.chat_hub") as mock_hub,
+    ):
+        mock_hub.broadcast_to_room = AsyncMock()
+        m_persist.return_value = MagicMock(id=uuid4())
+        m_exec.side_effect = ValueError("Unexpected error")
+        await chat_service.run_room_chat_ws(room_id, "Hello", user_id)
+        mock_hub.broadcast_to_room.assert_called()

--- a/backend/tests/chat/test_chat_ws.py
+++ b/backend/tests/chat/test_chat_ws.py
@@ -240,8 +240,6 @@ async def test_run_room_chat_ws_unauthorized(chat_service: ChatService) -> None:
         mock_hub.broadcast_to_room.assert_awaited_once()
 
 
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "side_effect, log_message_part",

--- a/frontend/app/(main)/productivity.tsx
+++ b/frontend/app/(main)/productivity.tsx
@@ -357,7 +357,7 @@ export default function ProductivityScreen() {
         />
       );
     },
-    [confirmDelete, deleteNote, deleteTask, i18n.language, toggleTask]
+    [confirmDelete, deleteNote, deleteTask, toggleTask]
   );
 
   return (

--- a/frontend/app/(main)/productivity.tsx
+++ b/frontend/app/(main)/productivity.tsx
@@ -18,6 +18,7 @@ import { CreateNoteModal } from '../../src/components/productivity/CreateNoteMod
 import { CreateTaskModal } from '../../src/components/productivity/CreateTaskModal';
 import { NoteCard } from '../../src/components/productivity/NoteCard';
 import { TaskCard } from '../../src/components/productivity/TaskCard';
+import { EventCard } from '../../src/components/productivity/EventCard';
 import { theme } from '../../src/core/theme';
 import { CalendarEvent, Note, Task } from '../../src/core/models';
 import { useProductivityStore } from '../../src/store/useProductivityStore';
@@ -344,25 +345,7 @@ export default function ProductivityScreen() {
       }
       if (item.type === 'event') {
         const event = item.item as CalendarEvent;
-        return (
-          <View style={styles.eventCard}>
-            <View style={styles.eventIcon}>
-              <Ionicons name="calendar-outline" size={16} color={T.primary.DEFAULT} />
-            </View>
-            <View style={styles.eventBody}>
-              <AppText style={styles.eventTitle}>{event.title}</AppText>
-              <AppText style={styles.eventMeta}>
-                {new Intl.DateTimeFormat(i18n.language, {
-                  weekday: 'short',
-                  month: 'short',
-                  day: 'numeric',
-                  hour: event.is_all_day ? undefined : '2-digit',
-                  minute: event.is_all_day ? undefined : '2-digit',
-                }).format(new Date(event.start_time))}
-              </AppText>
-            </View>
-          </View>
-        );
+        return <EventCard event={event} />;
       }
 
       const task = item.item as Task;
@@ -758,39 +741,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: S.xl,
     paddingBottom: 100,
     paddingTop: S.sm,
-  },
-  eventCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.surface.light,
-    borderWidth: 1,
-    borderColor: T.border.light,
-    borderRadius: R.xl,
-    padding: S.lg,
-    marginBottom: S.md,
-    ...theme.elevation.sm,
-  },
-  eventIcon: {
-    width: 32,
-    height: 32,
-    borderRadius: R.lg,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginRight: S.md,
-  },
-  eventBody: {
-    flex: 1,
-  },
-  eventTitle: {
-    color: T.onSurface.light,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-  eventMeta: {
-    color: T.onSurface.mutedLight,
-    marginTop: 2,
-    fontSize: 13,
   },
   emptyContainer: {
     alignItems: 'center',

--- a/frontend/src/components/productivity/EventCard.tsx
+++ b/frontend/src/components/productivity/EventCard.tsx
@@ -1,0 +1,93 @@
+import React, { useMemo } from 'react';
+import { View, StyleSheet, Platform } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import { AppText } from '../AppText';
+import { CalendarEvent } from '../../core/models';
+import { theme } from '../../core/theme';
+import { useTheme } from '../../hooks/useTheme';
+
+const S = theme.spacing;
+const R = theme.borderRadius;
+
+interface Props {
+  event: CalendarEvent;
+}
+
+/**
+ * Renders a calendar event as a card widget.
+ * Displays the event's title and its formatted start time.
+ *
+ * @param {Props} props - The component props.
+ * @param {CalendarEvent} props.event - The calendar event object to display.
+ */
+export const EventCard = React.memo(({ event }: Props) => {
+  const { i18n } = useTranslation();
+  const { C } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        eventCard: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          backgroundColor: C.surface,
+          borderWidth: 1,
+          borderColor: C.border,
+          borderRadius: R.xl,
+          padding: S.lg,
+          marginBottom: S.md,
+          ...Platform.select({
+            ios: theme.elevation.sm as any,
+            android: { elevation: 1 },
+            default: { elevation: 1 },
+          }),
+        },
+        eventIcon: {
+          width: 32,
+          height: 32,
+          borderRadius: R.lg,
+          backgroundColor: C.primarySurface,
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginRight: S.md,
+        },
+        eventBody: {
+          flex: 1,
+        },
+        eventTitle: {
+          color: C.text,
+          fontWeight: '700',
+          fontSize: 15,
+        },
+        eventMeta: {
+          color: C.muted,
+          marginTop: 2,
+          fontSize: 13,
+        },
+      }),
+    [C.border, C.muted, C.primarySurface, C.surface, C.text]
+  );
+
+  return (
+    <View style={styles.eventCard}>
+      <View style={styles.eventIcon}>
+        <Ionicons name="calendar-outline" size={16} color={C.primary} />
+      </View>
+      <View style={styles.eventBody}>
+        <AppText style={styles.eventTitle}>{event.title}</AppText>
+        <AppText style={styles.eventMeta}>
+          {new Intl.DateTimeFormat(i18n.language, {
+            weekday: 'short',
+            month: 'short',
+            day: 'numeric',
+            hour: event.is_all_day ? undefined : '2-digit',
+            minute: event.is_all_day ? undefined : '2-digit',
+          }).format(new Date(event.start_time))}
+        </AppText>
+      </View>
+    </View>
+  );
+});
+
+EventCard.displayName = 'EventCard';

--- a/frontend/src/components/productivity/EventCard.tsx
+++ b/frontend/src/components/productivity/EventCard.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { View, StyleSheet, Platform } from 'react-native';
+import { View, StyleSheet, Platform, ViewStyle } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import { AppText } from '../AppText';
@@ -38,7 +38,7 @@ export const EventCard = React.memo(({ event }: Props) => {
           padding: S.lg,
           marginBottom: S.md,
           ...Platform.select({
-            ios: theme.elevation.sm as any,
+            ios: theme.elevation.sm as ViewStyle,
             android: { elevation: 1 },
             default: { elevation: 1 },
           }),
@@ -69,6 +69,19 @@ export const EventCard = React.memo(({ event }: Props) => {
     [C.border, C.muted, C.primarySurface, C.surface, C.text]
   );
 
+  const formatter = useMemo(() => {
+    return new Intl.DateTimeFormat(i18n.language, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      hour: event.is_all_day ? undefined : '2-digit',
+      minute: event.is_all_day ? undefined : '2-digit',
+    });
+  }, [i18n.language, event.is_all_day]);
+
+  const date = new Date(event.start_time);
+  const formattedTime = isNaN(date.getTime()) ? 'Unknown time' : formatter.format(date);
+
   return (
     <View style={styles.eventCard}>
       <View style={styles.eventIcon}>
@@ -76,15 +89,7 @@ export const EventCard = React.memo(({ event }: Props) => {
       </View>
       <View style={styles.eventBody}>
         <AppText style={styles.eventTitle}>{event.title}</AppText>
-        <AppText style={styles.eventMeta}>
-          {new Intl.DateTimeFormat(i18n.language, {
-            weekday: 'short',
-            month: 'short',
-            day: 'numeric',
-            hour: event.is_all_day ? undefined : '2-digit',
-            minute: event.is_all_day ? undefined : '2-digit',
-          }).format(new Date(event.start_time))}
-        </AppText>
+        <AppText style={styles.eventMeta}>{formattedTime}</AppText>
       </View>
     </View>
   );

--- a/update_script.sh
+++ b/update_script.sh
@@ -1,13 +1,3 @@
-# 1. frontend/app/(main)/chat/[id].tsx
-# Change imports to use project's absolute alias.
-sed -i "s|'../../../src/components/chat/ChatRoomEmptyState'|'@/components/chat/ChatRoomEmptyState'|g" frontend/app/\(main\)/chat/\[id\].tsx
-sed -i "s|'../../../src/hooks/useChatRoomSetup'|'@/hooks/useChatRoomSetup'|g" frontend/app/\(main\)/chat/\[id\].tsx
-sed -i "s|'../../../src/utils/chatUtils'|'@/utils/chatUtils'|g" frontend/app/\(main\)/chat/\[id\].tsx
-sed -i "s|'../../../src/components/ChatBubble'|'@/components/ChatBubble'|g" frontend/app/\(main\)/chat/\[id\].tsx
-sed -i "s|'../../../src/components/ChatInputBar'|'@/components/ChatInputBar'|g" frontend/app/\(main\)/chat/\[id\].tsx
-sed -i "s|'../../../src/components/AgentActivityIndicator'|'@/components/AgentActivityIndicator'|g" frontend/app/\(main\)/chat/\[id\].tsx
-sed -i "s|'../../../src/store/useChatStore'|'@/store/useChatStore'|g" frontend/app/\(main\)/chat/\[id\].tsx
-sed -i "s|'../../../src/store/useAgentStore'|'@/store/useAgentStore'|g" frontend/app/\(main\)/chat/\[id\].tsx
-sed -i "s|'../../../src/core/api/ApiService'|'@/core/api/ApiService'|g" frontend/app/\(main\)/chat/\[id\].tsx
-sed -i "s|'../../../src/core/models'|'@/core/models'|g" frontend/app/\(main\)/chat/\[id\].tsx
-sed -i "s|'../../../src/components/agents/QuickViewAgentSheet'|'@/components/agents/QuickViewAgentSheet'|g" frontend/app/\(main\)/chat/\[id\].tsx
+#!/bin/bash
+git add backend/tests/chat/test_chat_ws.py
+git commit -m "test: verify fallback exception handling in run_room_chat_ws"

--- a/update_script.sh
+++ b/update_script.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-git add backend/tests/chat/test_chat_ws.py
-git commit -m "test: verify fallback exception handling in run_room_chat_ws"


### PR DESCRIPTION
Extracted the `EventCard` logic from the monolithic `productivity.tsx` file to improve maintainability and adherence to SRP. Hardened exception handling in `service.py` to target specific `openai.OpenAIError`s while maintaining safe fallback catch blocks.

Debt Identified:
- `productivity.tsx` was an 858-line "Mega Widget" that handled excessive varied rendering logic.
- `service.py` used bare `except Exception:` blocks that obscured errors and made debugging difficult.

Refactored Code:
- Extracted EventCard into `frontend/src/components/productivity/EventCard.tsx`.
- Changed generic exception catching in `backend/app/domain/chat/service.py` vector embedding and crew logic execution.

Structural Note:
Decomposing UI widgets reduces cognitive load and test complexity. Specific exceptions prevent masked failure modes while fallback blocks prevent crashes.

---
*PR created automatically by Jules for task [11896652179723552924](https://jules.google.com/task/11896652179723552924) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat error handling now differentiates AI-service errors from other failures and shows clear in-chat error notifications with retry guidance.

* **Refactor**
  * Events UI moved to a dedicated, themed EventCard that displays localized date/time and consistent styling.

* **Tests**
  * Added tests covering chat error scenarios to validate user-facing broadcasts and logging.

* **Chores**
  * Removed legacy path-rewrite commands from an update script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->