### PR TITLE
fix(security): implement global exception handler to mask internal errors

### DIFF
--- a/backend/app/api/exception_handlers.py
+++ b/backend/app/api/exception_handlers.py
@@ -1,0 +1,22 @@
+"""Global exception handlers for FastAPI to prevent leaking sensitive information."""
+
+import logging
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+
+async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Handle all unhandled exceptions globally, log traceback, and return safe 500 error."""
+    logger.exception(f"Unhandled exception during request {request.method} {request.url.path}")
+    return JSONResponse(
+        status_code=500,
+        content={"error": "internal_server_error", "message": "An unexpected error occurred."},
+    )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Register all exception handlers to the FastAPI app."""
+    app.add_exception_handler(Exception, global_exception_handler)

--- a/backend/app/api/exception_handlers.py
+++ b/backend/app/api/exception_handlers.py
@@ -1,16 +1,26 @@
 """Global exception handlers for FastAPI to prevent leaking sensitive information."""
 
-import logging
+from __future__ import annotations
 
-from fastapi import FastAPI, Request
+import logging
+from typing import TYPE_CHECKING
+
 from fastapi.responses import JSONResponse
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI, Request
 
 logger = logging.getLogger(__name__)
 
 
-async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse | None:
     """Handle all unhandled exceptions globally, log traceback, and return safe 500 error."""
-    logger.exception(f"Unhandled exception during request {request.method} {request.url.path}")
+    scope_type = request.scope.get("type")
+    if scope_type == "websocket":
+        logger.exception("Unhandled exception during websocket %s", request.url.path)
+        raise exc
+
+    logger.exception("Unhandled exception during request %s %s", request.method, request.url.path)
     return JSONResponse(
         status_code=500,
         content={"error": "internal_server_error", "message": "An unexpected error occurred."},

--- a/backend/app/api/exception_handlers.py
+++ b/backend/app/api/exception_handlers.py
@@ -29,4 +29,6 @@ async def global_exception_handler(request: Request, exc: Exception) -> JSONResp
 
 def register_exception_handlers(app: FastAPI) -> None:
     """Register all exception handlers to the FastAPI app."""
-    app.add_exception_handler(Exception, global_exception_handler)
+    # We use a cast or ignore type check since Starlette's add_exception_handler is strictly typed
+    # for Request vs WebSocket handlers, but a single global handler may be invoked for both
+    app.add_exception_handler(Exception, global_exception_handler)  # type: ignore[arg-type]

--- a/backend/app/api/exception_handlers.py
+++ b/backend/app/api/exception_handlers.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastapi.responses import JSONResponse
 
@@ -31,4 +31,7 @@ def register_exception_handlers(app: FastAPI) -> None:
     """Register all exception handlers to the FastAPI app."""
     # We use a cast or ignore type check since Starlette's add_exception_handler is strictly typed
     # for Request vs WebSocket handlers, but a single global handler may be invoked for both
-    app.add_exception_handler(Exception, global_exception_handler)  # type: ignore[arg-type]
+    # pyright ignores don't work cleanly across IDEs and CI so we will cast to Any
+    import typing
+
+    app.add_exception_handler(Exception, typing.cast("Any", global_exception_handler))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, cast
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.api.exception_handlers import register_exception_handlers
 from app.api.v1.agents import router as agents_router
 from app.api.v1.auth import router as auth_router
 from app.api.v1.chat import router as chat_router
@@ -63,6 +64,8 @@ app = FastAPI(
     version="0.2.0",
     lifespan=lifespan,
 )
+
+register_exception_handlers(app)
 
 app.add_middleware(
     cast("Any", CORSMiddleware),

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,42 @@
+{
+  "name": "backend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "pyright": "^1.1.409"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pyright": {
+      "version": "1.1.409",
+      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.409.tgz",
+      "integrity": "sha512-13VFQyw4mJzshZxcxiYbNjo1hG/WHSRDj70Y3lbJEHqCkI2dvBAUTti8VV6Ezsr5gT93pFvC0e/jAQS4JdHarA==",
+      "license": "MIT",
+      "bin": {
+        "pyright": "index.js",
+        "pyright-langserver": "langserver.index.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    }
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "pyright": "^1.1.409"
+  }
+}

--- a/backend/tests/test_exception_handlers.py
+++ b/backend/tests/test_exception_handlers.py
@@ -34,9 +34,11 @@ async def test_global_exception_handler_http():
 
     # Verify the response
     assert isinstance(response, JSONResponse)
+    assert response is not None
     assert response.status_code == 500
 
     # fastapi.responses.JSONResponse doesn't have a content property, we have to decode the body
+    assert isinstance(response.body, bytes)
     body = json.loads(response.body.decode("utf-8"))
     assert body["error"] == "internal_server_error"
     assert body["message"] == "An unexpected error occurred."

--- a/backend/tests/test_exception_handlers.py
+++ b/backend/tests/test_exception_handlers.py
@@ -1,0 +1,78 @@
+"""Tests for the global exception handler."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from app.api.exception_handlers import global_exception_handler, register_exception_handlers
+
+
+@pytest.mark.asyncio
+async def test_global_exception_handler_http():
+    """Test that HTTP exceptions return a 500 JSON response."""
+    # Create a mock Request
+    mock_request = MagicMock(spec=Request)
+    mock_request.scope = {"type": "http"}
+    mock_request.method = "GET"
+    mock_request.url.path = "/test/path"
+
+    exc = ValueError("Test error")
+
+    # Patch the logger to avoid spamming the console and to verify it was called
+    with patch("app.api.exception_handlers.logger") as mock_logger:
+        response = await global_exception_handler(mock_request, exc)
+
+    # Verify logger was called
+    mock_logger.exception.assert_called_once_with(
+        "Unhandled exception during request %s %s", "GET", "/test/path"
+    )
+
+    # Verify the response
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 500
+
+    # fastapi.responses.JSONResponse doesn't have a content property, we have to decode the body
+    body = json.loads(response.body.decode("utf-8"))
+    assert body["error"] == "internal_server_error"
+    assert body["message"] == "An unexpected error occurred."
+
+
+@pytest.mark.asyncio
+async def test_global_exception_handler_websocket():
+    """Test that WebSocket exceptions are re-raised."""
+    # Create a mock Request
+    mock_request = MagicMock(spec=Request)
+    mock_request.scope = {"type": "websocket"}
+    mock_request.url.path = "/test/ws"
+
+    exc = ValueError("Test error")
+
+    # Patch the logger
+    with (
+        patch("app.api.exception_handlers.logger") as mock_logger,
+        pytest.raises(ValueError, match="Test error"),
+    ):
+        await global_exception_handler(mock_request, exc)
+
+    # Verify logger was called with websocket specific message
+    mock_logger.exception.assert_called_once_with(
+        "Unhandled exception during websocket %s", "/test/ws"
+    )
+
+
+def test_register_exception_handlers():
+    """Test that the handler is registered to the app."""
+    mock_app = MagicMock()
+    register_exception_handlers(mock_app)
+
+    # We should have called add_exception_handler with Exception and our handler
+    mock_app.add_exception_handler.assert_called_once()
+    args, _ = mock_app.add_exception_handler.call_args
+    assert args[0] is Exception
+    # The second arg is cast to Any, so it's harder to check exactly, but we know it's a function
+    assert callable(args[1])

--- a/test_pyright.sh
+++ b/test_pyright.sh
@@ -1,0 +1,3 @@
+cd backend
+npm install pyright
+./node_modules/.bin/pyright app/api/exception_handlers.py


### PR DESCRIPTION
Added a global exception handler (`exception_handlers.py`) registered in `main.py` that intercepts unhandled `Exception` instances. It logs the full stack trace for internal visibility while returning a safe, sanitized `500 Internal Server Error` JSON payload to the client. This complies with the 'Backend Security Error Masking Standard' to prevent leaking internal infrastructure details.

---
*PR created automatically by Jules for task [18067618981943622775](https://jules.google.com/task/18067618981943622775) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized global error handling that returns a consistent, user-friendly JSON error for unexpected server errors and improves error logging with request details.
* **Tests**
  * Added tests validating HTTP error responses, logging behavior, and exception-handler registration.
* **Chores**
  * Added a script and configuration to run a static type checker as part of backend checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->