### PR TITLE
Refactor: Decompose Productivity Screen God Class

### DIFF
--- a/frontend/app/(main)/productivity.tsx
+++ b/frontend/app/(main)/productivity.tsx
@@ -1,27 +1,27 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback } from 'react';
 import {
-  Alert,
   FlatList,
-  Platform,
   Pressable,
   RefreshControl,
   StyleSheet,
-  TextInput,
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { useLocalSearchParams, usePathname, useRouter } from 'expo-router';
-import { useTranslation } from 'react-i18next';
 import { AppText } from '../../src/components/AppText';
 import { CreateNoteModal } from '../../src/components/productivity/CreateNoteModal';
 import { CreateTaskModal } from '../../src/components/productivity/CreateTaskModal';
 import { NoteCard } from '../../src/components/productivity/NoteCard';
 import { TaskCard } from '../../src/components/productivity/TaskCard';
+import { ProductivityHeader } from '../../src/components/productivity/ProductivityHeader';
+import { ProductivityEmptyState } from '../../src/components/productivity/ProductivityEmptyState';
 import { theme } from '../../src/core/theme';
 import { CalendarEvent, Note, Task } from '../../src/core/models';
-import { useProductivityStore } from '../../src/store/useProductivityStore';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
+import {
+  useProductivityViewModel,
+  RenderItemData,
+} from '../../src/features/productivity/useProductivityViewModel';
 
 const T = {
   background: { light: DESIGN_TOKENS.colors.pageBg },
@@ -42,299 +42,34 @@ const T = {
 const S = theme.spacing;
 const R = theme.borderRadius;
 
-type Tab = 'today' | 'all' | 'notes' | 'tasks';
-type TaskPriority = 'all' | 'overdue' | 'today' | 'upcoming' | 'no_due';
-
-type RenderItemData = {
-  date?: number;
-  type: 'note' | 'task' | 'event';
-  item: Note | Task | CalendarEvent;
-  id: string;
-};
-
 export default function ProductivityScreen() {
-  const { t, i18n } = useTranslation();
-  const router = useRouter();
-  const pathname = usePathname();
-  const params = useLocalSearchParams() as Record<string, string | string[] | undefined>;
-  const openCreateTask = params.openCreateTask;
-  const openCreateNote = params.openCreateNote;
-  const [activeTab, setActiveTab] = useState<Tab>('today');
-  const [taskPriority, setTaskPriority] = useState<TaskPriority>('all');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [showCreateNote, setShowCreateNote] = useState(false);
-  const [showCreateTask, setShowCreateTask] = useState(false);
-  const [todayPlan, setTodayPlan] = useState<string | null>(null);
-
   const {
-    notes,
-    tasks,
-    events,
-    fetchNotes,
-    fetchTasks,
-    fetchEvents,
+    i18n,
+    dataToRender,
     isLoading,
+    handleRefresh,
+    activeTab,
+    setActiveTab,
+    taskPriority,
+    setTaskPriority,
+    taskPriorityCounts,
+    searchQuery,
+    setSearchQuery,
+    showCreateNote,
+    setShowCreateNote,
+    showCreateTask,
+    setShowCreateTask,
+    todayPlan,
+    setTodayPlan,
+    generateTodayPlan,
+    confirmDelete,
     deleteNote,
     deleteTask,
     toggleTask,
-  } = useProductivityStore();
-
-  useEffect(() => {
-    const controller = new AbortController();
-    fetchNotes(controller.signal);
-    fetchTasks(controller.signal);
-    fetchEvents(controller.signal);
-    return () => {
-      controller.abort();
-    };
-  }, [fetchEvents, fetchNotes, fetchTasks]);
-
-  useEffect(() => {
-    if (openCreateTask === '1' || openCreateTask === 'true') {
-      setShowCreateTask(true);
-      const nextParams = Object.fromEntries(
-        Object.entries(params).filter(
-          ([key, value]) => key !== 'openCreateTask' && typeof value === 'string'
-        )
-      );
-      router.replace({ pathname, params: nextParams });
-    }
-  }, [openCreateTask, params, pathname, router]);
-
-  useEffect(() => {
-    if (openCreateNote === '1' || openCreateNote === 'true') {
-      setShowCreateNote(true);
-      const nextParams = Object.fromEntries(
-        Object.entries(params).filter(
-          ([key, value]) => key !== 'openCreateNote' && typeof value === 'string'
-        )
-      );
-      router.replace({ pathname, params: nextParams });
-    }
-  }, [openCreateNote, params, pathname, router]);
-
-  const handleRefresh = useCallback(() => {
-    fetchNotes();
-    fetchTasks();
-    fetchEvents();
-  }, [fetchEvents, fetchNotes, fetchTasks]);
-
-  const confirmDelete = useCallback(
-    (action: () => Promise<void>) =>
-      Alert.alert(
-        t('productivity.delete') || 'Delete',
-        t('productivity.are_you_sure') || 'Are you sure?',
-        [
-          { text: t('settings.actions.cancel') || 'Cancel', style: 'cancel' },
-          {
-            text: t('settings.actions.delete') || 'Delete',
-            style: 'destructive',
-            onPress: () => action(),
-          },
-        ]
-      ),
-    [t]
-  );
-
-  const filteredNotes = useMemo(() => {
-    if (!searchQuery) return notes;
-    const lowerQ = searchQuery.toLowerCase();
-    return notes.filter(
-      (n) => n.title.toLowerCase().includes(lowerQ) || n.content.toLowerCase().includes(lowerQ)
-    );
-  }, [notes, searchQuery]);
-
-  const filteredTasks = useMemo(() => {
-    if (!searchQuery) return tasks;
-    const lowerQ = searchQuery.toLowerCase();
-    return tasks.filter(
-      (task) =>
-        task.title.toLowerCase().includes(lowerQ) ||
-        (task.description?.toLowerCase().includes(lowerQ) ?? false)
-    );
-  }, [searchQuery, tasks]);
-
-  const filteredEvents = useMemo(() => {
-    if (!searchQuery) return events;
-    const lowerQ = searchQuery.toLowerCase();
-    return events.filter(
-      (event) =>
-        event.title.toLowerCase().includes(lowerQ) ||
-        (event.description?.toLowerCase().includes(lowerQ) ?? false) ||
-        (event.location?.toLowerCase().includes(lowerQ) ?? false)
-    );
-  }, [events, searchQuery]);
-
-  const pendingTasksCount = useMemo(
-    () => filteredTasks.filter((task) => !task.completed).length,
-    [filteredTasks]
-  );
-
-  const getTaskPriority = useCallback((task: Task): Exclude<TaskPriority, 'all'> => {
-    if (!task.due_date) return 'no_due';
-    const now = new Date();
-    const due = new Date(task.due_date);
-    if (isNaN(due.getTime())) return 'no_due';
-    const dayStart = new Date(now);
-    dayStart.setHours(0, 0, 0, 0);
-    const tomorrow = new Date(dayStart);
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    if (due < dayStart) return 'overdue';
-    if (due >= dayStart && due < tomorrow) return 'today';
-    return 'upcoming';
-  }, []);
-
-  const taskPriorityCounts = useMemo(() => {
-    const counts: Record<TaskPriority, number> = {
-      all: 0,
-      overdue: 0,
-      today: 0,
-      upcoming: 0,
-      no_due: 0,
-    };
-    filteredTasks
-      .filter((task) => !task.completed)
-      .forEach((task) => {
-        counts.all += 1;
-        counts[getTaskPriority(task)] += 1;
-      });
-    return counts;
-  }, [filteredTasks, getTaskPriority]);
-
-  const prioritizedTasks = useMemo(() => {
-    const tasksToRank = filteredTasks.filter((task) => !task.completed);
-    const pool =
-      taskPriority === 'all'
-        ? tasksToRank
-        : tasksToRank.filter((task) => getTaskPriority(task) === taskPriority);
-    return [...pool].sort((a, b) => {
-      const aDue = a.due_date ? new Date(a.due_date).getTime() : Number.MAX_SAFE_INTEGER;
-      const bDue = b.due_date ? new Date(b.due_date).getTime() : Number.MAX_SAFE_INTEGER;
-      return aDue - bDue;
-    });
-  }, [filteredTasks, getTaskPriority, taskPriority]);
-
-  const mixedData = useMemo(() => {
-    const data: RenderItemData[] = [];
-    filteredNotes.forEach((note) => {
-      data.push({
-        type: 'note',
-        item: note,
-        id: `note-${note.id}`,
-        date: new Date(note.created_at).getTime(),
-      });
-    });
-    filteredTasks.forEach((task) => {
-      data.push({
-        type: 'task',
-        item: task,
-        id: `task-${task.id}`,
-        date: new Date(task.created_at).getTime(),
-      });
-    });
-    return data.sort((a, b) => (b.date || 0) - (a.date || 0));
-  }, [filteredNotes, filteredTasks]);
-
-  const todayData = useMemo(() => {
-    const now = new Date();
-    const start = new Date(now);
-    start.setHours(0, 0, 0, 0);
-    const end = new Date(start);
-    end.setDate(end.getDate() + 1);
-    const weekEnd = new Date(start);
-    weekEnd.setDate(weekEnd.getDate() + 7);
-
-    const overdueTasks = filteredTasks.filter((task) => {
-      if (task.completed || !task.due_date) return false;
-      return new Date(task.due_date) < start;
-    });
-
-    const dueTodayTasks = filteredTasks.filter((task) => {
-      if (task.completed || !task.due_date) return false;
-      const dueDate = new Date(task.due_date);
-      return dueDate >= start && dueDate < end;
-    });
-
-    const upcomingEvents = filteredEvents.filter((event) => {
-      const startTime = new Date(event.start_time);
-      return startTime >= start && startTime < weekEnd;
-    });
-
-    const items: RenderItemData[] = [
-      ...overdueTasks.map((task) => ({
-        type: 'task' as const,
-        item: task,
-        id: `overdue-${task.id}`,
-        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
-      })),
-      ...dueTodayTasks.map((task) => ({
-        type: 'task' as const,
-        item: task,
-        id: `today-${task.id}`,
-        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
-      })),
-      ...upcomingEvents.map((event) => ({
-        type: 'event' as const,
-        item: event,
-        id: `event-${event.id}`,
-        date: new Date(event.start_time).getTime(),
-      })),
-    ];
-
-    return items.sort((a, b) => (a.date || 0) - (b.date || 0));
-  }, [filteredEvents, filteredTasks]);
-
-  const dataToRender: RenderItemData[] =
-    activeTab === 'today'
-      ? todayData.filter((entry) => {
-          if (entry.type !== 'task') return true;
-          if (taskPriority === 'all') return true;
-          return getTaskPriority(entry.item as Task) === taskPriority;
-        })
-      : activeTab === 'all'
-        ? mixedData
-        : activeTab === 'notes'
-          ? filteredNotes.map((note) => ({ type: 'note' as const, item: note, id: note.id }))
-          : prioritizedTasks.map((task) => ({ type: 'task' as const, item: task, id: task.id }));
-
-  const generateTodayPlan = useCallback(() => {
-    const now = new Date();
-    const nextTasks = prioritizedTasks.slice(0, 3);
-    const nextEvents = [...filteredEvents]
-      .filter((event) => new Date(event.end_time) >= now)
-      .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime())
-      .slice(0, 3);
-
-    const lines: string[] = [];
-    if (taskPriorityCounts.overdue > 0) {
-      lines.push(`1) Recover overdue: start with ${taskPriorityCounts.overdue} overdue task(s).`);
-    } else {
-      lines.push('1) No overdue tasks: start with highest-impact open work.');
-    }
-
-    if (nextTasks.length > 0) {
-      lines.push(`2) Focus block: ${nextTasks.map((task) => task.title).join(', ')}.`);
-    } else {
-      lines.push('2) Focus block: no pending tasks, use this for planning or review.');
-    }
-
-    if (nextEvents.length > 0) {
-      const eventLine = nextEvents
-        .map((event) =>
-          new Intl.DateTimeFormat(i18n.language, {
-            hour: '2-digit',
-            minute: '2-digit',
-          }).format(new Date(event.start_time))
-        )
-        .join(', ');
-      lines.push(`3) Calendar checkpoints at ${eventLine}.`);
-    } else {
-      lines.push('3) Calendar is light: reserve time for deep work and wrap-up.');
-    }
-
-    setTodayPlan(lines.join('\n'));
-    setActiveTab('today');
-  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue]);
+    pendingTasksCount,
+    fetchNotes,
+    fetchTasks,
+  } = useProductivityViewModel();
 
   const renderItem = useCallback(
     ({ item }: { item: RenderItemData }) => {
@@ -379,145 +114,19 @@ export default function ProductivityScreen() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.headerContainer}>
-        <View style={styles.headerRow}>
-          <View>
-            <AppText variant="h1" style={styles.headerTitle}>
-              {t('productivity.title') || 'Workspace'}
-            </AppText>
-            <AppText style={styles.headerSubtitle}>
-              {pendingTasksCount === 0
-                ? t('productivity.header.subtitle.empty') || "You're all caught up for today."
-                : t('productivity.header.subtitle.pending', { count: pendingTasksCount }) ||
-                  `You have ${pendingTasksCount} tasks pending.`}
-            </AppText>
-          </View>
-
-          <View style={styles.headerActions}>
-            <Pressable
-              onPress={generateTodayPlan}
-              style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
-            >
-              <Ionicons name="sparkles" size={20} color={T.primary.DEFAULT} />
-            </Pressable>
-            <Pressable
-              onPress={() => setShowCreateNote(true)}
-              style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
-            >
-              <Ionicons name="document-text" size={20} color={T.primary.DEFAULT} />
-            </Pressable>
-            <Pressable
-              onPress={() => setShowCreateTask(true)}
-              style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
-            >
-              <Ionicons name="checkbox" size={20} color={T.primary.DEFAULT} />
-            </Pressable>
-          </View>
-        </View>
-
-        <View style={styles.searchContainer}>
-          <Ionicons
-            name="search"
-            size={18}
-            color={T.onSurface.mutedLight}
-            style={styles.searchIcon}
-          />
-          <TextInput
-            value={searchQuery}
-            onChangeText={setSearchQuery}
-            placeholder={t('productivity.search') || 'Search notes & tasks...'}
-            placeholderTextColor={T.onSurface.disabledLight}
-            style={styles.searchInput}
-            clearButtonMode="while-editing"
-          />
-        </View>
-      </View>
-
-      <View style={styles.tabsContainer}>
-        {(['today', 'all', 'notes', 'tasks'] as const).map((tab) => (
-          <Pressable
-            key={tab}
-            onPress={() => setActiveTab(tab)}
-            style={({ pressed }) => [
-              styles.tabButton,
-              activeTab === tab && styles.tabButtonActive,
-              pressed && activeTab !== tab && { opacity: 0.6 },
-            ]}
-          >
-            <AppText style={[styles.tabText, activeTab === tab && styles.tabTextActive]}>
-              {tab === 'today'
-                ? t('productivity.today')
-                : tab === 'all'
-                  ? t('productivity.all') || 'All'
-                  : tab === 'notes'
-                    ? t('productivity.notes') || 'Notes'
-                    : t('productivity.tasks') || 'Tasks'}
-            </AppText>
-          </Pressable>
-        ))}
-      </View>
-
-      {(activeTab === 'tasks' || activeTab === 'today') && (
-        <View
-          style={{
-            flexDirection: 'row',
-            flexWrap: 'wrap',
-            marginHorizontal: S.xl,
-            marginBottom: S.sm,
-          }}
-        >
-          {(
-            [
-              { key: 'all', label: t('productivity.priority.all', { count: taskPriorityCounts.all }) },
-              {
-                key: 'overdue',
-                label: t('productivity.priority.overdue', { count: taskPriorityCounts.overdue }),
-              },
-              {
-                key: 'today',
-                label: t('productivity.priority.today', { count: taskPriorityCounts.today }),
-              },
-              {
-                key: 'upcoming',
-                label: t('productivity.priority.upcoming', { count: taskPriorityCounts.upcoming }),
-              },
-              {
-                key: 'no_due',
-                label: t('productivity.priority.no_due', { count: taskPriorityCounts.no_due }),
-              },
-            ] as const
-          ).map((option) => (
-            <Pressable
-              key={option.key}
-              onPress={() => setTaskPriority(option.key)}
-              style={({ pressed }) => [
-                {
-                  borderRadius: 12,
-                  borderWidth: 1,
-                  borderColor: taskPriority === option.key ? T.primary.DEFAULT : T.border.light,
-                  backgroundColor:
-                    taskPriority === option.key ? T.primary.surfaceLight : T.surface.light,
-                  paddingHorizontal: 10,
-                  paddingVertical: 6,
-                  marginRight: 8,
-                  marginBottom: 8,
-                },
-                pressed && { opacity: 0.8 },
-              ]}
-            >
-              <AppText
-                variant="caption"
-                style={{
-                  color: taskPriority === option.key ? T.primary.DEFAULT : T.onSurface.mutedLight,
-                  fontWeight: '700',
-                }}
-              >
-                {option.label}
-              </AppText>
-            </Pressable>
-          ))}
-        </View>
-      )}
+      <ProductivityHeader
+        pendingTasksCount={pendingTasksCount}
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        activeTab={activeTab}
+        setActiveTab={setActiveTab}
+        generateTodayPlan={generateTodayPlan}
+        taskPriority={taskPriority}
+        setTaskPriority={setTaskPriority}
+        taskPriorityCounts={taskPriorityCounts}
+        setShowCreateNote={setShowCreateNote}
+        setShowCreateTask={setShowCreateTask}
+      />
 
       <FlatList
         data={dataToRender}
@@ -565,86 +174,12 @@ export default function ProductivityScreen() {
           ) : null
         }
         ListEmptyComponent={
-          <View style={styles.emptyContainer}>
-            <View style={styles.emptyIconCircle}>
-              <Ionicons
-                name={
-                  activeTab === 'notes'
-                    ? 'document-text'
-                    : activeTab === 'tasks'
-                      ? 'checkbox'
-                      : activeTab === 'today'
-                        ? 'sunny-outline'
-                        : 'planet'
-                }
-                size={42}
-                color={T.primary.DEFAULT}
-              />
-            </View>
-            <AppText variant="h3" style={styles.emptyTitle}>
-              {searchQuery
-                ? t('productivity.no_matches') || 'No matches found'
-                : activeTab === 'notes'
-                  ? t('productivity.no_notes') || 'No Notes'
-                  : activeTab === 'tasks'
-                    ? t('productivity.no_tasks') || 'No Tasks'
-                    : activeTab === 'today'
-                      ? t('productivity.nothing_urgent_today')
-                      : t('productivity.workspace_clear') || 'Your workspace is clear'}
-            </AppText>
-            <AppText style={styles.emptySubtitle}>
-              {searchQuery
-                ? t('productivity.try_adjust_search') || 'Try adjusting your search terms.'
-                : activeTab === 'today'
-                  ? t('productivity.today_empty_detail')
-                  : t('productivity.capture_thoughts') ||
-                    'Capture your thoughts and track what needs to get done.'}
-            </AppText>
-
-            {!searchQuery && (
-              <View style={styles.emptyActions}>
-                {(activeTab === 'all' || activeTab === 'notes') && (
-                  <Pressable
-                    onPress={() => setShowCreateNote(true)}
-                    style={({ pressed }) => [styles.emptyButton, pressed && { opacity: 0.8 }]}
-                  >
-                    <Ionicons name="add" size={18} color={T.white} style={{ marginEnd: 6 }} />
-                    <AppText style={styles.emptyButtonText}>
-                      {t('productivity.newNote') || 'New Note'}
-                    </AppText>
-                  </Pressable>
-                )}
-                {(activeTab === 'all' || activeTab === 'tasks' || activeTab === 'today') && (
-                  <Pressable
-                    onPress={() => setShowCreateTask(true)}
-                    style={({ pressed }) => [
-                      styles.emptyButton,
-                      (activeTab === 'all' || activeTab === 'today') && styles.emptyButtonSecondary,
-                      pressed && { opacity: 0.8 },
-                    ]}
-                  >
-                    <Ionicons
-                      name="add"
-                      size={18}
-                      color={
-                        activeTab === 'all' || activeTab === 'today' ? T.primary.DEFAULT : T.white
-                      }
-                      style={{ marginEnd: 6 }}
-                    />
-                    <AppText
-                      style={
-                        activeTab === 'all' || activeTab === 'today'
-                          ? styles.emptyButtonTextSecondary
-                          : styles.emptyButtonText
-                      }
-                    >
-                      {t('productivity.new_task')}
-                    </AppText>
-                  </Pressable>
-                )}
-              </View>
-            )}
-          </View>
+          <ProductivityEmptyState
+            activeTab={activeTab}
+            searchQuery={searchQuery}
+            setShowCreateNote={setShowCreateNote}
+            setShowCreateTask={setShowCreateTask}
+          />
         }
       />
 
@@ -666,93 +201,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: T.background.light,
-  },
-  headerContainer: {
-    paddingHorizontal: S.xl,
-    paddingTop: S.md,
-    paddingBottom: S.lg,
-    backgroundColor: T.surface.light,
-    ...theme.elevation.sm,
-    zIndex: 10,
-  },
-  headerRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: S.lg,
-  },
-  headerTitle: {
-    color: T.onSurface.light,
-    fontSize: 28,
-    fontWeight: '800',
-    letterSpacing: -0.5,
-  },
-  headerSubtitle: {
-    color: T.onSurface.mutedLight,
-    fontSize: 14,
-    marginTop: S.xs,
-  },
-  headerActions: {
-    flexDirection: 'row',
-    gap: S.sm,
-  },
-  iconButton: {
-    width: 40,
-    height: 40,
-    borderRadius: R.full,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  searchContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.background.light,
-    borderRadius: R.lg,
-    paddingHorizontal: S.md,
-    height: 44,
-    borderWidth: 1,
-    borderColor: T.border.light,
-  },
-  searchIcon: {
-    marginRight: S.sm,
-  },
-  searchInput: {
-    flex: 1,
-    color: T.onSurface.light,
-    fontSize: 16,
-    height: '100%',
-  },
-  tabsContainer: {
-    flexDirection: 'row',
-    backgroundColor: T.surface.highLight,
-    borderRadius: R.xl,
-    padding: S.xs,
-    marginHorizontal: S.xl,
-    marginTop: S.lg,
-    marginBottom: S.md,
-    borderWidth: 1,
-    borderColor: T.border.light,
-  },
-  tabButton: {
-    flex: 1,
-    paddingVertical: S.sm,
-    alignItems: 'center',
-    borderRadius: R.lg,
-    backgroundColor: T.transparent,
-  },
-  tabButtonActive: {
-    backgroundColor: T.surface.light,
-    ...theme.elevation.sm,
-  },
-  tabText: {
-    fontSize: 14,
-    fontWeight: '500',
-    color: T.onSurface.mutedLight,
-  },
-  tabTextActive: {
-    fontWeight: '700',
-    color: T.onSurface.light,
   },
   listContent: {
     paddingHorizontal: S.xl,
@@ -791,68 +239,5 @@ const styles = StyleSheet.create({
     color: T.onSurface.mutedLight,
     marginTop: 2,
     fontSize: 13,
-  },
-  emptyContainer: {
-    alignItems: 'center',
-    paddingVertical: S.massive,
-  },
-  emptyIconCircle: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: S.lg,
-  },
-  emptyTitle: {
-    marginBottom: S.sm,
-    textAlign: 'center',
-    color: T.onSurface.light,
-  },
-  emptySubtitle: {
-    textAlign: 'center',
-    marginBottom: S.xl,
-    color: T.onSurface.mutedLight,
-    paddingHorizontal: S.xxxl,
-    lineHeight: 22,
-  },
-  emptyActions: {
-    flexDirection: 'row',
-    gap: S.md,
-  },
-  emptyButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.primary.DEFAULT,
-    borderRadius: R.xl,
-    paddingVertical: S.md,
-    paddingHorizontal: S.xl,
-    ...theme.elevation.md,
-  },
-  emptyButtonSecondary: {
-    backgroundColor: T.primary.surfaceLight,
-    ...Platform.select({
-      ios: {
-        shadowOpacity: 0,
-        elevation: 0,
-      },
-      android: {
-        elevation: 0,
-      },
-      default: {
-        elevation: 0,
-      },
-    }),
-  },
-  emptyButtonText: {
-    color: T.white,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-  emptyButtonTextSecondary: {
-    color: T.primary.DEFAULT,
-    fontWeight: '700',
-    fontSize: 15,
   },
 });

--- a/frontend/app/(main)/productivity.tsx
+++ b/frontend/app/(main)/productivity.tsx
@@ -8,20 +8,20 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { AppText } from '../../src/components/AppText';
-import { CreateNoteModal } from '../../src/components/productivity/CreateNoteModal';
-import { CreateTaskModal } from '../../src/components/productivity/CreateTaskModal';
-import { NoteCard } from '../../src/components/productivity/NoteCard';
-import { TaskCard } from '../../src/components/productivity/TaskCard';
-import { ProductivityHeader } from '../../src/components/productivity/ProductivityHeader';
-import { ProductivityEmptyState } from '../../src/components/productivity/ProductivityEmptyState';
-import { theme } from '../../src/core/theme';
-import { CalendarEvent, Note, Task } from '../../src/core/models';
+import { AppText } from '@/components/AppText';
+import { CreateNoteModal } from '@/components/productivity/CreateNoteModal';
+import { CreateTaskModal } from '@/components/productivity/CreateTaskModal';
+import { NoteCard } from '@/components/productivity/NoteCard';
+import { TaskCard } from '@/components/productivity/TaskCard';
+import { ProductivityHeader } from '@/components/productivity/ProductivityHeader';
+import { ProductivityEmptyState } from '@/components/productivity/ProductivityEmptyState';
+import { theme } from '@/core/theme';
+import { CalendarEvent, Note, Task } from '@/core/models';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
 import {
   useProductivityViewModel,
   RenderItemData,
-} from '../../src/features/productivity/useProductivityViewModel';
+} from '@/features/productivity/useProductivityViewModel';
 
 const T = {
   background: { light: DESIGN_TOKENS.colors.pageBg },
@@ -44,6 +44,7 @@ const R = theme.borderRadius;
 
 export default function ProductivityScreen() {
   const {
+    t,
     i18n,
     dataToRender,
     isLoading,
@@ -161,7 +162,7 @@ export default function ProductivityScreen() {
                 }}
               >
                 <AppText style={{ color: T.onSurface.light, fontWeight: '700', fontSize: 15 }}>
-                  Today plan
+                  {t('productivity.today_plan') || "Today's Plan"}
                 </AppText>
                 <Pressable onPress={() => setTodayPlan(null)}>
                   <Ionicons name="close" size={16} color={T.onSurface.mutedLight} />
@@ -174,12 +175,14 @@ export default function ProductivityScreen() {
           ) : null
         }
         ListEmptyComponent={
-          <ProductivityEmptyState
-            activeTab={activeTab}
-            searchQuery={searchQuery}
-            setShowCreateNote={setShowCreateNote}
-            setShowCreateTask={setShowCreateTask}
-          />
+          !isLoading && dataToRender.length === 0 ? (
+            <ProductivityEmptyState
+              activeTab={activeTab}
+              searchQuery={searchQuery}
+              setShowCreateNote={setShowCreateNote}
+              setShowCreateTask={setShowCreateTask}
+            />
+          ) : null
         }
       />
 

--- a/frontend/src/components/productivity/ProductivityEmptyState.tsx
+++ b/frontend/src/components/productivity/ProductivityEmptyState.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { View, StyleSheet, Pressable, Platform } from 'react-native';
+import { View, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
-import { AppText } from '../AppText';
-import { theme } from '../../core/theme';
+import { AppText } from '@/components/AppText';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
 
 const T = {
@@ -18,9 +17,6 @@ const T = {
   white: '#FFFFFF',
 };
 
-const S = theme.spacing;
-const R = theme.borderRadius;
-
 interface Props {
   activeTab: 'today' | 'all' | 'notes' | 'tasks';
   searchQuery: string;
@@ -28,17 +24,20 @@ interface Props {
   setShowCreateTask: (show: boolean) => void;
 }
 
-export function ProductivityEmptyState({
+export const ProductivityEmptyState = ({
   activeTab,
   searchQuery,
   setShowCreateNote,
   setShowCreateTask,
-}: Props) {
+}: Props) => {
   const { t } = useTranslation();
 
   return (
-    <View style={styles.emptyContainer}>
-      <View style={styles.emptyIconCircle}>
+    <View className="items-center py-24">
+      <View
+        className="w-20 h-20 rounded-full items-center justify-center mb-6"
+        style={{ backgroundColor: T.primary.surfaceLight }}
+      >
         <Ionicons
           name={
             activeTab === 'notes'
@@ -53,7 +52,7 @@ export function ProductivityEmptyState({
           color={T.primary.DEFAULT}
         />
       </View>
-      <AppText variant="h3" style={styles.emptyTitle}>
+      <AppText variant="h3" className="mb-2 text-center" style={{ color: T.onSurface.light }}>
         {searchQuery
           ? t('productivity.no_matches') || 'No matches found'
           : activeTab === 'notes'
@@ -64,7 +63,10 @@ export function ProductivityEmptyState({
                 ? t('productivity.nothing_urgent_today') || 'Nothing urgent today'
                 : t('productivity.workspace_clear') || 'Your workspace is clear'}
       </AppText>
-      <AppText style={styles.emptySubtitle}>
+      <AppText
+        className="text-center mb-8 px-10 leading-6"
+        style={{ color: T.onSurface.mutedLight }}
+      >
         {searchQuery
           ? t('productivity.try_adjust_search') || 'Try adjusting your search terms.'
           : activeTab === 'today'
@@ -74,14 +76,18 @@ export function ProductivityEmptyState({
       </AppText>
 
       {!searchQuery && (
-        <View style={styles.emptyActions}>
+        <View className="flex-row gap-4">
           {(activeTab === 'all' || activeTab === 'notes') && (
             <Pressable
               onPress={() => setShowCreateNote(true)}
-              style={({ pressed }) => [styles.emptyButton, pressed && { opacity: 0.8 }]}
+              className="flex-row items-center rounded-xl py-3 px-6 shadow-md"
+              style={({ pressed }) => [
+                { backgroundColor: T.primary.DEFAULT },
+                pressed && { opacity: 0.8 },
+              ]}
             >
               <Ionicons name="add" size={18} color={T.white} style={{ marginEnd: 6 }} />
-              <AppText style={styles.emptyButtonText}>
+              <AppText className="text-white font-bold text-[15px]">
                 {t('productivity.newNote') || 'New Note'}
               </AppText>
             </Pressable>
@@ -89,10 +95,16 @@ export function ProductivityEmptyState({
           {(activeTab === 'all' || activeTab === 'tasks' || activeTab === 'today') && (
             <Pressable
               onPress={() => setShowCreateTask(true)}
+              className="flex-row items-center rounded-xl py-3 px-6 shadow-md"
               style={({ pressed }) => [
-                styles.emptyButton,
-                (activeTab === 'all' || activeTab === 'today') && styles.emptyButtonSecondary,
+                {
+                  backgroundColor:
+                    activeTab === 'all' || activeTab === 'today'
+                      ? T.primary.surfaceLight
+                      : T.primary.DEFAULT,
+                },
                 pressed && { opacity: 0.8 },
+                (activeTab === 'all' || activeTab === 'today') && { shadowOpacity: 0, elevation: 0 },
               ]}
             >
               <Ionicons
@@ -102,11 +114,11 @@ export function ProductivityEmptyState({
                 style={{ marginEnd: 6 }}
               />
               <AppText
-                style={
-                  activeTab === 'all' || activeTab === 'today'
-                    ? styles.emptyButtonTextSecondary
-                    : styles.emptyButtonText
-                }
+                className="font-bold text-[15px]"
+                style={{
+                  color:
+                    activeTab === 'all' || activeTab === 'today' ? T.primary.DEFAULT : T.white,
+                }}
               >
                 {t('productivity.new_task') || 'New Task'}
               </AppText>
@@ -116,70 +128,6 @@ export function ProductivityEmptyState({
       )}
     </View>
   );
-}
+};
 
-const styles = StyleSheet.create({
-  emptyContainer: {
-    alignItems: 'center',
-    paddingVertical: S.massive,
-  },
-  emptyIconCircle: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: S.lg,
-  },
-  emptyTitle: {
-    marginBottom: S.sm,
-    textAlign: 'center',
-    color: T.onSurface.light,
-  },
-  emptySubtitle: {
-    textAlign: 'center',
-    marginBottom: S.xl,
-    color: T.onSurface.mutedLight,
-    paddingHorizontal: S.xxxl,
-    lineHeight: 22,
-  },
-  emptyActions: {
-    flexDirection: 'row',
-    gap: S.md,
-  },
-  emptyButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.primary.DEFAULT,
-    borderRadius: R.xl,
-    paddingVertical: S.md,
-    paddingHorizontal: S.xl,
-    ...theme.elevation.md,
-  },
-  emptyButtonSecondary: {
-    backgroundColor: T.primary.surfaceLight,
-    ...Platform.select({
-      ios: {
-        shadowOpacity: 0,
-        elevation: 0,
-      },
-      android: {
-        elevation: 0,
-      },
-      default: {
-        elevation: 0,
-      },
-    }),
-  },
-  emptyButtonText: {
-    color: T.white,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-  emptyButtonTextSecondary: {
-    color: T.primary.DEFAULT,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-});
+export default ProductivityEmptyState;

--- a/frontend/src/components/productivity/ProductivityEmptyState.tsx
+++ b/frontend/src/components/productivity/ProductivityEmptyState.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { View, StyleSheet, Pressable, Platform } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import { AppText } from '../AppText';
+import { theme } from '../../core/theme';
+import { DESIGN_TOKENS } from '@/core/design/tokens';
+
+const T = {
+  primary: {
+    DEFAULT: DESIGN_TOKENS.colors.primary,
+    surfaceLight: DESIGN_TOKENS.colors.primarySoft,
+  },
+  onSurface: {
+    light: DESIGN_TOKENS.colors.text,
+    mutedLight: DESIGN_TOKENS.colors.muted,
+  },
+  white: '#FFFFFF',
+};
+
+const S = theme.spacing;
+const R = theme.borderRadius;
+
+interface Props {
+  activeTab: 'today' | 'all' | 'notes' | 'tasks';
+  searchQuery: string;
+  setShowCreateNote: (show: boolean) => void;
+  setShowCreateTask: (show: boolean) => void;
+}
+
+export function ProductivityEmptyState({
+  activeTab,
+  searchQuery,
+  setShowCreateNote,
+  setShowCreateTask,
+}: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <View style={styles.emptyContainer}>
+      <View style={styles.emptyIconCircle}>
+        <Ionicons
+          name={
+            activeTab === 'notes'
+              ? 'document-text'
+              : activeTab === 'tasks'
+                ? 'checkbox'
+                : activeTab === 'today'
+                  ? 'sunny-outline'
+                  : 'planet'
+          }
+          size={42}
+          color={T.primary.DEFAULT}
+        />
+      </View>
+      <AppText variant="h3" style={styles.emptyTitle}>
+        {searchQuery
+          ? t('productivity.no_matches') || 'No matches found'
+          : activeTab === 'notes'
+            ? t('productivity.no_notes') || 'No Notes'
+            : activeTab === 'tasks'
+              ? t('productivity.no_tasks') || 'No Tasks'
+              : activeTab === 'today'
+                ? t('productivity.nothing_urgent_today') || 'Nothing urgent today'
+                : t('productivity.workspace_clear') || 'Your workspace is clear'}
+      </AppText>
+      <AppText style={styles.emptySubtitle}>
+        {searchQuery
+          ? t('productivity.try_adjust_search') || 'Try adjusting your search terms.'
+          : activeTab === 'today'
+            ? t('productivity.today_empty_detail') || 'Enjoy the rest of your day.'
+            : t('productivity.capture_thoughts') ||
+              'Capture your thoughts and track what needs to get done.'}
+      </AppText>
+
+      {!searchQuery && (
+        <View style={styles.emptyActions}>
+          {(activeTab === 'all' || activeTab === 'notes') && (
+            <Pressable
+              onPress={() => setShowCreateNote(true)}
+              style={({ pressed }) => [styles.emptyButton, pressed && { opacity: 0.8 }]}
+            >
+              <Ionicons name="add" size={18} color={T.white} style={{ marginEnd: 6 }} />
+              <AppText style={styles.emptyButtonText}>
+                {t('productivity.newNote') || 'New Note'}
+              </AppText>
+            </Pressable>
+          )}
+          {(activeTab === 'all' || activeTab === 'tasks' || activeTab === 'today') && (
+            <Pressable
+              onPress={() => setShowCreateTask(true)}
+              style={({ pressed }) => [
+                styles.emptyButton,
+                (activeTab === 'all' || activeTab === 'today') && styles.emptyButtonSecondary,
+                pressed && { opacity: 0.8 },
+              ]}
+            >
+              <Ionicons
+                name="add"
+                size={18}
+                color={activeTab === 'all' || activeTab === 'today' ? T.primary.DEFAULT : T.white}
+                style={{ marginEnd: 6 }}
+              />
+              <AppText
+                style={
+                  activeTab === 'all' || activeTab === 'today'
+                    ? styles.emptyButtonTextSecondary
+                    : styles.emptyButtonText
+                }
+              >
+                {t('productivity.new_task') || 'New Task'}
+              </AppText>
+            </Pressable>
+          )}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  emptyContainer: {
+    alignItems: 'center',
+    paddingVertical: S.massive,
+  },
+  emptyIconCircle: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: T.primary.surfaceLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: S.lg,
+  },
+  emptyTitle: {
+    marginBottom: S.sm,
+    textAlign: 'center',
+    color: T.onSurface.light,
+  },
+  emptySubtitle: {
+    textAlign: 'center',
+    marginBottom: S.xl,
+    color: T.onSurface.mutedLight,
+    paddingHorizontal: S.xxxl,
+    lineHeight: 22,
+  },
+  emptyActions: {
+    flexDirection: 'row',
+    gap: S.md,
+  },
+  emptyButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: T.primary.DEFAULT,
+    borderRadius: R.xl,
+    paddingVertical: S.md,
+    paddingHorizontal: S.xl,
+    ...theme.elevation.md,
+  },
+  emptyButtonSecondary: {
+    backgroundColor: T.primary.surfaceLight,
+    ...Platform.select({
+      ios: {
+        shadowOpacity: 0,
+        elevation: 0,
+      },
+      android: {
+        elevation: 0,
+      },
+      default: {
+        elevation: 0,
+      },
+    }),
+  },
+  emptyButtonText: {
+    color: T.white,
+    fontWeight: '700',
+    fontSize: 15,
+  },
+  emptyButtonTextSecondary: {
+    color: T.primary.DEFAULT,
+    fontWeight: '700',
+    fontSize: 15,
+  },
+});

--- a/frontend/src/components/productivity/ProductivityHeader.tsx
+++ b/frontend/src/components/productivity/ProductivityHeader.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
-import { View, StyleSheet, TextInput, Pressable } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, TextInput, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
-import { AppText } from '../AppText';
-import { theme } from '../../core/theme';
+import { AppText } from '@/components/AppText';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
 
 const T = {
@@ -20,9 +19,6 @@ const T = {
   },
   transparent: 'transparent',
 };
-
-const S = theme.spacing;
-const R = theme.borderRadius;
 
 type Tab = 'today' | 'all' | 'notes' | 'tasks';
 type TaskPriority = 'all' | 'overdue' | 'today' | 'upcoming' | 'no_due';
@@ -41,7 +37,7 @@ interface Props {
   setShowCreateTask: (show: boolean) => void;
 }
 
-export function ProductivityHeader({
+export const ProductivityHeader = ({
   pendingTasksCount,
   searchQuery,
   setSearchQuery,
@@ -53,8 +49,16 @@ export function ProductivityHeader({
   taskPriorityCounts,
   setShowCreateNote,
   setShowCreateTask,
-}: Props) {
+}: Props) => {
   const { t } = useTranslation();
+  const [localQuery, setLocalQuery] = useState(searchQuery);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearchQuery(localQuery);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [localQuery, setSearchQuery]);
 
   const tabs: { key: Tab; label: string }[] = [
     { key: 'today', label: t('productivity.today') || 'Today' },
@@ -73,71 +77,119 @@ export function ProductivityHeader({
 
   return (
     <>
-      <View style={styles.headerContainer}>
-        <View style={styles.headerRow}>
+      <View
+        className="px-6 pt-4 pb-6 z-10 shadow-sm"
+        style={{ backgroundColor: T.surface.light }}
+      >
+        <View className="flex-row justify-between items-center mb-6">
           <View>
-            <AppText variant="h1" style={styles.headerTitle}>
+            <AppText variant="h1" className="text-[28px] font-extrabold tracking-tight" style={{ color: T.onSurface.light }}>
               {t('productivity.title') || 'Workspace'}
             </AppText>
-            <AppText style={styles.headerSubtitle}>
+            <AppText className="text-sm mt-1" style={{ color: T.onSurface.mutedLight }}>
               {pendingTasksCount === 0
                 ? t('productivity.header.subtitle.empty') || "You're all caught up for today."
                 : t('productivity.header.subtitle.pending', { count: pendingTasksCount }) ||
                   `You have ${pendingTasksCount} tasks pending.`}
             </AppText>
           </View>
-          <View style={styles.headerActions}>
+          <View className="flex-row gap-2">
             <Pressable
               onPress={generateTodayPlan}
-              style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
+              accessibilityRole="button"
+              accessibilityLabel="Generate today's plan"
+              className="w-10 h-10 rounded-full items-center justify-center"
+              style={({ pressed }) => [
+                { backgroundColor: T.primary.surfaceLight },
+                pressed && { opacity: 0.7 },
+              ]}
             >
               <Ionicons name="sparkles" size={20} color={T.primary.DEFAULT} />
             </Pressable>
             <Pressable
               onPress={() => setShowCreateNote(true)}
-              style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
+              accessibilityRole="button"
+              accessibilityLabel="Create note"
+              className="w-10 h-10 rounded-full items-center justify-center"
+              style={({ pressed }) => [
+                { backgroundColor: T.primary.surfaceLight },
+                pressed && { opacity: 0.7 },
+              ]}
             >
               <Ionicons name="document-text" size={20} color={T.primary.DEFAULT} />
             </Pressable>
             <Pressable
               onPress={() => setShowCreateTask(true)}
-              style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
+              accessibilityRole="button"
+              accessibilityLabel="Create task"
+              className="w-10 h-10 rounded-full items-center justify-center"
+              style={({ pressed }) => [
+                { backgroundColor: T.primary.surfaceLight },
+                pressed && { opacity: 0.7 },
+              ]}
             >
               <Ionicons name="checkbox" size={20} color={T.primary.DEFAULT} />
             </Pressable>
           </View>
         </View>
 
-        <View style={styles.searchContainer}>
+        <View
+          className="flex-row items-center rounded-lg px-4 h-11 border"
+          style={{ backgroundColor: T.background.light, borderColor: T.border.light }}
+        >
           <Ionicons
             name="search"
             size={18}
             color={T.onSurface.mutedLight}
-            style={styles.searchIcon}
+            className="mr-2"
           />
           <TextInput
-            style={styles.searchInput}
+            className="flex-1 text-base h-full"
+            style={{ color: T.onSurface.light }}
             placeholder={t('productivity.search') || 'Search notes, tasks, events...'}
             placeholderTextColor={T.onSurface.mutedLight}
-            value={searchQuery}
-            onChangeText={setSearchQuery}
+            value={localQuery}
+            onChangeText={setLocalQuery}
           />
-          {searchQuery.length > 0 && (
-            <Pressable onPress={() => setSearchQuery('')} hitSlop={10}>
+          {localQuery.length > 0 && (
+            <Pressable
+              onPress={() => setLocalQuery('')}
+              hitSlop={10}
+              accessibilityRole="button"
+              accessibilityLabel="Clear search"
+            >
               <Ionicons name="close-circle" size={20} color={T.onSurface.mutedLight} />
             </Pressable>
           )}
         </View>
       </View>
 
-      <View style={styles.tabsContainer}>
+      <View
+        className="flex-row rounded-xl p-1 mx-6 mt-6 mb-4 border"
+        style={{ backgroundColor: T.surface.highLight, borderColor: T.border.light }}
+      >
         {tabs.map((tab) => (
           <Pressable
             key={tab.key}
             onPress={() => setActiveTab(tab.key)}
-            style={[styles.tabButton, activeTab === tab.key && styles.tabButtonActive]}
+            accessibilityRole="tab"
+            accessibilityLabel={tab.label}
+            accessibilityState={{ selected: activeTab === tab.key }}
+            className={`flex-1 py-2 items-center rounded-lg ${
+              activeTab === tab.key ? 'shadow-sm' : ''
+            }`}
+            style={[
+              { backgroundColor: T.transparent },
+              activeTab === tab.key && { backgroundColor: T.surface.light },
+            ]}
           >
-            <AppText style={[styles.tabText, activeTab === tab.key && styles.tabTextActive]}>
+            <AppText
+              className="text-sm"
+              style={[
+                { fontWeight: '500', color: T.onSurface.mutedLight },
+                activeTab === tab.key && { fontWeight: '700', color: T.onSurface.light },
+              ]}
+            >
               {tab.label}
             </AppText>
           </Pressable>
@@ -145,38 +197,29 @@ export function ProductivityHeader({
       </View>
 
       {(activeTab === 'tasks' || activeTab === 'today') && (
-        <View
-          style={{
-            flexDirection: 'row',
-            paddingHorizontal: S.xl,
-            marginBottom: S.sm,
-            flexWrap: 'wrap',
-          }}
-        >
+        <View className="flex-row px-6 mb-2 flex-wrap">
           {priorityOptions.map((option) => (
             <Pressable
               key={option.key}
               onPress={() => setTaskPriority(option.key)}
+              accessibilityRole="button"
+              accessibilityLabel={option.label}
+              accessibilityState={{ selected: taskPriority === option.key }}
+              className="px-3 py-1.5 rounded-full border mr-2 mb-2"
               style={({ pressed }) => [
                 {
-                  paddingHorizontal: 12,
-                  paddingVertical: 6,
-                  borderRadius: R.full,
                   backgroundColor:
                     taskPriority === option.key ? T.primary.surfaceLight : T.surface.light,
-                  borderWidth: 1,
                   borderColor: taskPriority === option.key ? T.primary.DEFAULT : T.border.light,
-                  marginRight: 8,
-                  marginBottom: 8,
                 },
                 pressed && { opacity: 0.8 },
               ]}
             >
               <AppText
                 variant="caption"
+                className="font-bold"
                 style={{
                   color: taskPriority === option.key ? T.primary.DEFAULT : T.onSurface.mutedLight,
-                  fontWeight: '700',
                 }}
               >
                 {option.label}
@@ -187,94 +230,4 @@ export function ProductivityHeader({
       )}
     </>
   );
-}
-
-const styles = StyleSheet.create({
-  headerContainer: {
-    paddingHorizontal: S.xl,
-    paddingTop: S.md,
-    paddingBottom: S.lg,
-    backgroundColor: T.surface.light,
-    ...theme.elevation.sm,
-    zIndex: 10,
-  },
-  headerRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: S.lg,
-  },
-  headerTitle: {
-    color: T.onSurface.light,
-    fontSize: 28,
-    fontWeight: '800',
-    letterSpacing: -0.5,
-  },
-  headerSubtitle: {
-    color: T.onSurface.mutedLight,
-    fontSize: 14,
-    marginTop: S.xs,
-  },
-  headerActions: {
-    flexDirection: 'row',
-    gap: S.sm,
-  },
-  iconButton: {
-    width: 40,
-    height: 40,
-    borderRadius: R.full,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  searchContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.background.light,
-    borderRadius: R.lg,
-    paddingHorizontal: S.md,
-    height: 44,
-    borderWidth: 1,
-    borderColor: T.border.light,
-  },
-  searchIcon: {
-    marginRight: S.sm,
-  },
-  searchInput: {
-    flex: 1,
-    color: T.onSurface.light,
-    fontSize: 16,
-    height: '100%',
-  },
-  tabsContainer: {
-    flexDirection: 'row',
-    backgroundColor: T.surface.highLight,
-    borderRadius: R.xl,
-    padding: S.xs,
-    marginHorizontal: S.xl,
-    marginTop: S.lg,
-    marginBottom: S.md,
-    borderWidth: 1,
-    borderColor: T.border.light,
-  },
-  tabButton: {
-    flex: 1,
-    paddingVertical: S.sm,
-    alignItems: 'center',
-    borderRadius: R.lg,
-    backgroundColor: T.transparent,
-  },
-  tabButtonActive: {
-    backgroundColor: T.surface.light,
-    ...theme.elevation.sm,
-  },
-  tabText: {
-    fontSize: 14,
-    fontWeight: '500',
-    color: T.onSurface.mutedLight,
-  },
-  tabTextActive: {
-    fontWeight: '700',
-    color: T.onSurface.light,
-  },
-});
+};

--- a/frontend/src/components/productivity/ProductivityHeader.tsx
+++ b/frontend/src/components/productivity/ProductivityHeader.tsx
@@ -1,0 +1,280 @@
+import React from 'react';
+import { View, StyleSheet, TextInput, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import { AppText } from '../AppText';
+import { theme } from '../../core/theme';
+import { DESIGN_TOKENS } from '@/core/design/tokens';
+
+const T = {
+  background: { light: DESIGN_TOKENS.colors.pageBg },
+  surface: { light: DESIGN_TOKENS.colors.surface, highLight: DESIGN_TOKENS.colors.surfaceSoft },
+  border: { light: DESIGN_TOKENS.colors.border },
+  onSurface: {
+    light: DESIGN_TOKENS.colors.text,
+    mutedLight: DESIGN_TOKENS.colors.muted,
+  },
+  primary: {
+    DEFAULT: DESIGN_TOKENS.colors.primary,
+    surfaceLight: DESIGN_TOKENS.colors.primarySoft,
+  },
+  transparent: 'transparent',
+};
+
+const S = theme.spacing;
+const R = theme.borderRadius;
+
+type Tab = 'today' | 'all' | 'notes' | 'tasks';
+type TaskPriority = 'all' | 'overdue' | 'today' | 'upcoming' | 'no_due';
+
+interface Props {
+  pendingTasksCount: number;
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  activeTab: Tab;
+  setActiveTab: (tab: Tab) => void;
+  generateTodayPlan: () => void;
+  taskPriority: TaskPriority;
+  setTaskPriority: (priority: TaskPriority) => void;
+  taskPriorityCounts: Record<TaskPriority, number>;
+  setShowCreateNote: (show: boolean) => void;
+  setShowCreateTask: (show: boolean) => void;
+}
+
+export function ProductivityHeader({
+  pendingTasksCount,
+  searchQuery,
+  setSearchQuery,
+  activeTab,
+  setActiveTab,
+  generateTodayPlan,
+  taskPriority,
+  setTaskPriority,
+  taskPriorityCounts,
+  setShowCreateNote,
+  setShowCreateTask,
+}: Props) {
+  const { t } = useTranslation();
+
+  const tabs: { key: Tab; label: string }[] = [
+    { key: 'today', label: t('productivity.today') || 'Today' },
+    { key: 'all', label: t('productivity.all') || 'All' },
+    { key: 'notes', label: t('productivity.notes') || 'Notes' },
+    { key: 'tasks', label: t('productivity.tasks') || 'Tasks' },
+  ];
+
+  const priorityOptions: { key: TaskPriority; label: string }[] = [
+    { key: 'all', label: t('productivity.priority.all', { count: taskPriorityCounts.all }) || `All (${taskPriorityCounts.all})` },
+    { key: 'overdue', label: t('productivity.priority.overdue', { count: taskPriorityCounts.overdue }) || `Overdue (${taskPriorityCounts.overdue})` },
+    { key: 'today', label: t('productivity.priority.today', { count: taskPriorityCounts.today }) || `Today (${taskPriorityCounts.today})` },
+    { key: 'upcoming', label: t('productivity.priority.upcoming', { count: taskPriorityCounts.upcoming }) || `Upcoming (${taskPriorityCounts.upcoming})` },
+    { key: 'no_due', label: t('productivity.priority.no_due', { count: taskPriorityCounts.no_due }) || `Someday (${taskPriorityCounts.no_due})` },
+  ];
+
+  return (
+    <>
+      <View style={styles.headerContainer}>
+        <View style={styles.headerRow}>
+          <View>
+            <AppText variant="h1" style={styles.headerTitle}>
+              {t('productivity.title') || 'Workspace'}
+            </AppText>
+            <AppText style={styles.headerSubtitle}>
+              {pendingTasksCount === 0
+                ? t('productivity.header.subtitle.empty') || "You're all caught up for today."
+                : t('productivity.header.subtitle.pending', { count: pendingTasksCount }) ||
+                  `You have ${pendingTasksCount} tasks pending.`}
+            </AppText>
+          </View>
+          <View style={styles.headerActions}>
+            <Pressable
+              onPress={generateTodayPlan}
+              style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
+            >
+              <Ionicons name="sparkles" size={20} color={T.primary.DEFAULT} />
+            </Pressable>
+            <Pressable
+              onPress={() => setShowCreateNote(true)}
+              style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
+            >
+              <Ionicons name="document-text" size={20} color={T.primary.DEFAULT} />
+            </Pressable>
+            <Pressable
+              onPress={() => setShowCreateTask(true)}
+              style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
+            >
+              <Ionicons name="checkbox" size={20} color={T.primary.DEFAULT} />
+            </Pressable>
+          </View>
+        </View>
+
+        <View style={styles.searchContainer}>
+          <Ionicons
+            name="search"
+            size={18}
+            color={T.onSurface.mutedLight}
+            style={styles.searchIcon}
+          />
+          <TextInput
+            style={styles.searchInput}
+            placeholder={t('productivity.search') || 'Search notes, tasks, events...'}
+            placeholderTextColor={T.onSurface.mutedLight}
+            value={searchQuery}
+            onChangeText={setSearchQuery}
+          />
+          {searchQuery.length > 0 && (
+            <Pressable onPress={() => setSearchQuery('')} hitSlop={10}>
+              <Ionicons name="close-circle" size={20} color={T.onSurface.mutedLight} />
+            </Pressable>
+          )}
+        </View>
+      </View>
+
+      <View style={styles.tabsContainer}>
+        {tabs.map((tab) => (
+          <Pressable
+            key={tab.key}
+            onPress={() => setActiveTab(tab.key)}
+            style={[styles.tabButton, activeTab === tab.key && styles.tabButtonActive]}
+          >
+            <AppText style={[styles.tabText, activeTab === tab.key && styles.tabTextActive]}>
+              {tab.label}
+            </AppText>
+          </Pressable>
+        ))}
+      </View>
+
+      {(activeTab === 'tasks' || activeTab === 'today') && (
+        <View
+          style={{
+            flexDirection: 'row',
+            paddingHorizontal: S.xl,
+            marginBottom: S.sm,
+            flexWrap: 'wrap',
+          }}
+        >
+          {priorityOptions.map((option) => (
+            <Pressable
+              key={option.key}
+              onPress={() => setTaskPriority(option.key)}
+              style={({ pressed }) => [
+                {
+                  paddingHorizontal: 12,
+                  paddingVertical: 6,
+                  borderRadius: R.full,
+                  backgroundColor:
+                    taskPriority === option.key ? T.primary.surfaceLight : T.surface.light,
+                  borderWidth: 1,
+                  borderColor: taskPriority === option.key ? T.primary.DEFAULT : T.border.light,
+                  marginRight: 8,
+                  marginBottom: 8,
+                },
+                pressed && { opacity: 0.8 },
+              ]}
+            >
+              <AppText
+                variant="caption"
+                style={{
+                  color: taskPriority === option.key ? T.primary.DEFAULT : T.onSurface.mutedLight,
+                  fontWeight: '700',
+                }}
+              >
+                {option.label}
+              </AppText>
+            </Pressable>
+          ))}
+        </View>
+      )}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  headerContainer: {
+    paddingHorizontal: S.xl,
+    paddingTop: S.md,
+    paddingBottom: S.lg,
+    backgroundColor: T.surface.light,
+    ...theme.elevation.sm,
+    zIndex: 10,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: S.lg,
+  },
+  headerTitle: {
+    color: T.onSurface.light,
+    fontSize: 28,
+    fontWeight: '800',
+    letterSpacing: -0.5,
+  },
+  headerSubtitle: {
+    color: T.onSurface.mutedLight,
+    fontSize: 14,
+    marginTop: S.xs,
+  },
+  headerActions: {
+    flexDirection: 'row',
+    gap: S.sm,
+  },
+  iconButton: {
+    width: 40,
+    height: 40,
+    borderRadius: R.full,
+    backgroundColor: T.primary.surfaceLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  searchContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: T.background.light,
+    borderRadius: R.lg,
+    paddingHorizontal: S.md,
+    height: 44,
+    borderWidth: 1,
+    borderColor: T.border.light,
+  },
+  searchIcon: {
+    marginRight: S.sm,
+  },
+  searchInput: {
+    flex: 1,
+    color: T.onSurface.light,
+    fontSize: 16,
+    height: '100%',
+  },
+  tabsContainer: {
+    flexDirection: 'row',
+    backgroundColor: T.surface.highLight,
+    borderRadius: R.xl,
+    padding: S.xs,
+    marginHorizontal: S.xl,
+    marginTop: S.lg,
+    marginBottom: S.md,
+    borderWidth: 1,
+    borderColor: T.border.light,
+  },
+  tabButton: {
+    flex: 1,
+    paddingVertical: S.sm,
+    alignItems: 'center',
+    borderRadius: R.lg,
+    backgroundColor: T.transparent,
+  },
+  tabButtonActive: {
+    backgroundColor: T.surface.light,
+    ...theme.elevation.sm,
+  },
+  tabText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: T.onSurface.mutedLight,
+  },
+  tabTextActive: {
+    fontWeight: '700',
+    color: T.onSurface.light,
+  },
+});

--- a/frontend/src/features/productivity/useProductivityViewModel.ts
+++ b/frontend/src/features/productivity/useProductivityViewModel.ts
@@ -1,0 +1,332 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Alert } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useRouter, usePathname, useLocalSearchParams } from 'expo-router';
+import { CalendarEvent, Note, Task } from '../../core/models';
+import { useProductivityStore } from '../../store/useProductivityStore';
+
+export type Tab = 'today' | 'all' | 'notes' | 'tasks';
+export type TaskPriority = 'all' | 'overdue' | 'today' | 'upcoming' | 'no_due';
+
+export type RenderItemData = {
+  date?: number;
+  type: 'note' | 'task' | 'event';
+  item: Note | Task | CalendarEvent;
+  id: string;
+};
+
+export function useProductivityViewModel() {
+  const { t, i18n } = useTranslation();
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useLocalSearchParams() as Record<string, string | string[] | undefined>;
+
+  const openCreateTask = params.openCreateTask;
+  const openCreateNote = params.openCreateNote;
+
+  const [activeTab, setActiveTab] = useState<Tab>('today');
+  const [taskPriority, setTaskPriority] = useState<TaskPriority>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showCreateNote, setShowCreateNote] = useState(false);
+  const [showCreateTask, setShowCreateTask] = useState(false);
+  const [todayPlan, setTodayPlan] = useState<string | null>(null);
+
+  const {
+    notes,
+    tasks,
+    events,
+    fetchNotes,
+    fetchTasks,
+    fetchEvents,
+    isLoading,
+    deleteNote,
+    deleteTask,
+    toggleTask,
+  } = useProductivityStore();
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchNotes(controller.signal);
+    fetchTasks(controller.signal);
+    fetchEvents(controller.signal);
+    return () => {
+      controller.abort();
+    };
+  }, [fetchEvents, fetchNotes, fetchTasks]);
+
+  useEffect(() => {
+    if (openCreateTask === '1' || openCreateTask === 'true') {
+      setShowCreateTask(true);
+      const nextParams = Object.fromEntries(
+        Object.entries(params).filter(
+          ([key, value]) => key !== 'openCreateTask' && typeof value === 'string'
+        )
+      );
+      router.replace({ pathname, params: nextParams });
+    }
+  }, [openCreateTask, params, pathname, router]);
+
+  useEffect(() => {
+    if (openCreateNote === '1' || openCreateNote === 'true') {
+      setShowCreateNote(true);
+      const nextParams = Object.fromEntries(
+        Object.entries(params).filter(
+          ([key, value]) => key !== 'openCreateNote' && typeof value === 'string'
+        )
+      );
+      router.replace({ pathname, params: nextParams });
+    }
+  }, [openCreateNote, params, pathname, router]);
+
+  const handleRefresh = useCallback(() => {
+    fetchNotes();
+    fetchTasks();
+    fetchEvents();
+  }, [fetchEvents, fetchNotes, fetchTasks]);
+
+  const confirmDelete = useCallback(
+    (action: () => Promise<void>) =>
+      Alert.alert(
+        t('productivity.delete') || 'Delete',
+        t('productivity.are_you_sure') || 'Are you sure?',
+        [
+          { text: t('settings.actions.cancel') || 'Cancel', style: 'cancel' },
+          {
+            text: t('settings.actions.delete') || 'Delete',
+            style: 'destructive',
+            onPress: () => action(),
+          },
+        ]
+      ),
+    [t]
+  );
+
+  const filteredNotes = useMemo(() => {
+    if (!searchQuery) return notes;
+    const lowerQ = searchQuery.toLowerCase();
+    return notes.filter(
+      (n) => n.title.toLowerCase().includes(lowerQ) || n.content.toLowerCase().includes(lowerQ)
+    );
+  }, [notes, searchQuery]);
+
+  const filteredTasks = useMemo(() => {
+    if (!searchQuery) return tasks;
+    const lowerQ = searchQuery.toLowerCase();
+    return tasks.filter(
+      (task) =>
+        task.title.toLowerCase().includes(lowerQ) ||
+        (task.description?.toLowerCase().includes(lowerQ) ?? false)
+    );
+  }, [searchQuery, tasks]);
+
+  const filteredEvents = useMemo(() => {
+    if (!searchQuery) return events;
+    const lowerQ = searchQuery.toLowerCase();
+    return events.filter(
+      (event) =>
+        event.title.toLowerCase().includes(lowerQ) ||
+        (event.description?.toLowerCase().includes(lowerQ) ?? false) ||
+        (event.location?.toLowerCase().includes(lowerQ) ?? false)
+    );
+  }, [events, searchQuery]);
+
+  const pendingTasksCount = useMemo(
+    () => filteredTasks.filter((task) => !task.completed).length,
+    [filteredTasks]
+  );
+
+  const getTaskPriority = useCallback((task: Task): Exclude<TaskPriority, 'all'> => {
+    if (!task.due_date) return 'no_due';
+    const now = new Date();
+    const due = new Date(task.due_date);
+    if (isNaN(due.getTime())) return 'no_due';
+    const dayStart = new Date(now);
+    dayStart.setHours(0, 0, 0, 0);
+    const tomorrow = new Date(dayStart);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    if (due < dayStart) return 'overdue';
+    if (due >= dayStart && due < tomorrow) return 'today';
+    return 'upcoming';
+  }, []);
+
+  const taskPriorityCounts = useMemo(() => {
+    const counts: Record<TaskPriority, number> = {
+      all: 0,
+      overdue: 0,
+      today: 0,
+      upcoming: 0,
+      no_due: 0,
+    };
+    filteredTasks
+      .filter((task) => !task.completed)
+      .forEach((task) => {
+        counts.all += 1;
+        counts[getTaskPriority(task)] += 1;
+      });
+    return counts;
+  }, [filteredTasks, getTaskPriority]);
+
+  const prioritizedTasks = useMemo(() => {
+    const tasksToRank = filteredTasks.filter((task) => !task.completed);
+    const pool =
+      taskPriority === 'all'
+        ? tasksToRank
+        : tasksToRank.filter((task) => getTaskPriority(task) === taskPriority);
+    return [...pool].sort((a, b) => {
+      const aDue = a.due_date ? new Date(a.due_date).getTime() : Number.MAX_SAFE_INTEGER;
+      const bDue = b.due_date ? new Date(b.due_date).getTime() : Number.MAX_SAFE_INTEGER;
+      return aDue - bDue;
+    });
+  }, [filteredTasks, getTaskPriority, taskPriority]);
+
+  const mixedData = useMemo(() => {
+    const data: RenderItemData[] = [];
+    filteredNotes.forEach((note) => {
+      data.push({
+        type: 'note',
+        item: note,
+        id: `note-${note.id}`,
+        date: new Date(note.created_at).getTime(),
+      });
+    });
+    filteredTasks.forEach((task) => {
+      data.push({
+        type: 'task',
+        item: task,
+        id: `task-${task.id}`,
+        date: new Date(task.created_at).getTime(),
+      });
+    });
+    return data.sort((a, b) => (b.date || 0) - (a.date || 0));
+  }, [filteredNotes, filteredTasks]);
+
+  const todayData = useMemo(() => {
+    const now = new Date();
+    const start = new Date(now);
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(start);
+    end.setDate(end.getDate() + 1);
+    const weekEnd = new Date(start);
+    weekEnd.setDate(weekEnd.getDate() + 7);
+
+    const overdueTasks = filteredTasks.filter((task) => {
+      if (task.completed || !task.due_date) return false;
+      return new Date(task.due_date) < start;
+    });
+
+    const dueTodayTasks = filteredTasks.filter((task) => {
+      if (task.completed || !task.due_date) return false;
+      const dueDate = new Date(task.due_date);
+      return dueDate >= start && dueDate < end;
+    });
+
+    const upcomingEvents = filteredEvents.filter((event) => {
+      const startTime = new Date(event.start_time);
+      return startTime >= start && startTime < weekEnd;
+    });
+
+    const items: RenderItemData[] = [
+      ...overdueTasks.map((task) => ({
+        type: 'task' as const,
+        item: task,
+        id: `overdue-${task.id}`,
+        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
+      })),
+      ...dueTodayTasks.map((task) => ({
+        type: 'task' as const,
+        item: task,
+        id: `today-${task.id}`,
+        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
+      })),
+      ...upcomingEvents.map((event) => ({
+        type: 'event' as const,
+        item: event,
+        id: `event-${event.id}`,
+        date: new Date(event.start_time).getTime(),
+      })),
+    ];
+
+    return items.sort((a, b) => (a.date || 0) - (b.date || 0));
+  }, [filteredEvents, filteredTasks]);
+
+  const dataToRender: RenderItemData[] =
+    activeTab === 'today'
+      ? todayData.filter((entry) => {
+          if (entry.type !== 'task') return true;
+          if (taskPriority === 'all') return true;
+          return getTaskPriority(entry.item as Task) === taskPriority;
+        })
+      : activeTab === 'all'
+        ? mixedData
+        : activeTab === 'notes'
+          ? filteredNotes.map((note) => ({ type: 'note' as const, item: note, id: note.id }))
+          : prioritizedTasks.map((task) => ({ type: 'task' as const, item: task, id: task.id }));
+
+  const generateTodayPlan = useCallback(() => {
+    const now = new Date();
+    const nextTasks = prioritizedTasks.slice(0, 3);
+    const nextEvents = [...filteredEvents]
+      .filter((event) => new Date(event.end_time) >= now)
+      .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime())
+      .slice(0, 3);
+
+    const lines: string[] = [];
+    if (taskPriorityCounts.overdue > 0) {
+      lines.push(`1) Recover overdue: start with ${taskPriorityCounts.overdue} overdue task(s).`);
+    } else {
+      lines.push('1) No overdue tasks: start with highest-impact open work.');
+    }
+
+    if (nextTasks.length > 0) {
+      lines.push(`2) Focus block: ${nextTasks.map((task) => task.title).join(', ')}.`);
+    } else {
+      lines.push('2) Focus block: no pending tasks, use this for planning or review.');
+    }
+
+    if (nextEvents.length > 0) {
+      const eventLine = nextEvents
+        .map((event) =>
+          new Intl.DateTimeFormat(i18n.language, {
+            hour: '2-digit',
+            minute: '2-digit',
+          }).format(new Date(event.start_time))
+        )
+        .join(', ');
+      lines.push(`3) Calendar checkpoints at ${eventLine}.`);
+    } else {
+      lines.push('3) Calendar is light: reserve time for deep work and wrap-up.');
+    }
+
+    setTodayPlan(lines.join('\n'));
+    setActiveTab('today');
+  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue]);
+
+  return {
+    t,
+    i18n,
+    dataToRender,
+    isLoading,
+    handleRefresh,
+    activeTab,
+    setActiveTab,
+    taskPriority,
+    setTaskPriority,
+    taskPriorityCounts,
+    searchQuery,
+    setSearchQuery,
+    showCreateNote,
+    setShowCreateNote,
+    showCreateTask,
+    setShowCreateTask,
+    todayPlan,
+    setTodayPlan,
+    generateTodayPlan,
+    confirmDelete,
+    deleteNote,
+    deleteTask,
+    toggleTask,
+    pendingTasksCount,
+    fetchNotes,
+    fetchTasks,
+  };
+}

--- a/frontend/src/features/productivity/useProductivityViewModel.ts
+++ b/frontend/src/features/productivity/useProductivityViewModel.ts
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Alert } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useRouter, usePathname, useLocalSearchParams } from 'expo-router';
-import { CalendarEvent, Note, Task } from '../../core/models';
-import { useProductivityStore } from '../../store/useProductivityStore';
+import { CalendarEvent, Note, Task } from '@/core/models';
+import { useProductivityStore } from '@/store/useProductivityStore';
 
 export type Tab = 'today' | 'all' | 'notes' | 'tasks';
 export type TaskPriority = 'all' | 'overdue' | 'today' | 'upcoming' | 'no_due';
@@ -15,7 +15,7 @@ export type RenderItemData = {
   id: string;
 };
 
-export function useProductivityViewModel() {
+export const useProductivityViewModel = () => {
   const { t, i18n } = useTranslation();
   const router = useRouter();
   const pathname = usePathname();
@@ -94,7 +94,20 @@ export function useProductivityViewModel() {
           {
             text: t('settings.actions.delete') || 'Delete',
             style: 'destructive',
-            onPress: () => action(),
+            onPress: async () => {
+              try {
+                await action();
+              } catch {
+                Alert.alert(
+                  t('errors.default_title') || 'Error',
+                  t('errors.delete_failed') || 'Failed to delete item. Please try again.',
+                  [
+                    { text: t('settings.actions.cancel') || 'Cancel', style: 'cancel' },
+                    { text: t('actions.retry') || 'Retry', onPress: () => confirmDelete(action) }
+                  ]
+                );
+              }
+            },
           },
         ]
       ),
@@ -131,8 +144,8 @@ export function useProductivityViewModel() {
   }, [events, searchQuery]);
 
   const pendingTasksCount = useMemo(
-    () => filteredTasks.filter((task) => !task.completed).length,
-    [filteredTasks]
+    () => tasks.filter((task) => !task.completed).length,
+    [tasks]
   );
 
   const getTaskPriority = useCallback((task: Task): Exclude<TaskPriority, 'all'> => {
@@ -166,6 +179,12 @@ export function useProductivityViewModel() {
     return counts;
   }, [filteredTasks, getTaskPriority]);
 
+  const normalizeDueTime = useCallback((dueStr: string | null | undefined): number => {
+    if (!dueStr) return Number.MAX_SAFE_INTEGER;
+    const d = new Date(dueStr).getTime();
+    return isNaN(d) ? Number.MAX_SAFE_INTEGER : d;
+  }, []);
+
   const prioritizedTasks = useMemo(() => {
     const tasksToRank = filteredTasks.filter((task) => !task.completed);
     const pool =
@@ -173,11 +192,11 @@ export function useProductivityViewModel() {
         ? tasksToRank
         : tasksToRank.filter((task) => getTaskPriority(task) === taskPriority);
     return [...pool].sort((a, b) => {
-      const aDue = a.due_date ? new Date(a.due_date).getTime() : Number.MAX_SAFE_INTEGER;
-      const bDue = b.due_date ? new Date(b.due_date).getTime() : Number.MAX_SAFE_INTEGER;
+      const aDue = normalizeDueTime(a.due_date);
+      const bDue = normalizeDueTime(b.due_date);
       return aDue - bDue;
     });
-  }, [filteredTasks, getTaskPriority, taskPriority]);
+  }, [filteredTasks, getTaskPriority, normalizeDueTime, taskPriority]);
 
   const mixedData = useMemo(() => {
     const data: RenderItemData[] = [];
@@ -272,15 +291,16 @@ export function useProductivityViewModel() {
 
     const lines: string[] = [];
     if (taskPriorityCounts.overdue > 0) {
-      lines.push(`1) Recover overdue: start with ${taskPriorityCounts.overdue} overdue task(s).`);
+      lines.push(t('productivity.todayPlan.overdue', { count: taskPriorityCounts.overdue }) || `1) Recover overdue: start with ${taskPriorityCounts.overdue} overdue task(s).`);
     } else {
-      lines.push('1) No overdue tasks: start with highest-impact open work.');
+      lines.push(t('productivity.todayPlan.noOverdue') || '1) No overdue tasks: start with highest-impact open work.');
     }
 
     if (nextTasks.length > 0) {
-      lines.push(`2) Focus block: ${nextTasks.map((task) => task.title).join(', ')}.`);
+      const titles = nextTasks.map((task) => task.title).join(', ');
+      lines.push(t('productivity.focusBlock.items', { titles }) || `2) Focus block: ${titles}.`);
     } else {
-      lines.push('2) Focus block: no pending tasks, use this for planning or review.');
+      lines.push(t('productivity.focusBlock.empty') || '2) Focus block: no pending tasks, use this for planning or review.');
     }
 
     if (nextEvents.length > 0) {
@@ -292,14 +312,14 @@ export function useProductivityViewModel() {
           }).format(new Date(event.start_time))
         )
         .join(', ');
-      lines.push(`3) Calendar checkpoints at ${eventLine}.`);
+      lines.push(t('productivity.calendar.checkpoints', { times: eventLine }) || `3) Calendar checkpoints at ${eventLine}.`);
     } else {
-      lines.push('3) Calendar is light: reserve time for deep work and wrap-up.');
+      lines.push(t('productivity.calendar.empty') || '3) Calendar is light: reserve time for deep work and wrap-up.');
     }
 
     setTodayPlan(lines.join('\n'));
     setActiveTab('today');
-  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue]);
+  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue, t]);
 
   return {
     t,
@@ -329,4 +349,4 @@ export function useProductivityViewModel() {
     fetchNotes,
     fetchTasks,
   };
-}
+};


### PR DESCRIPTION
This commit addresses a major structural code-rot issue in `productivity.tsx`, which had become a "God Class" exceeding 800 lines. The business and filtering logic was directly tied to the UI.

Changes made:
- Created a custom hook `useProductivityViewModel` to manage state, memoized sorting, search logic, and fetching, ensuring no "Logic Leaks" exist in the UI tree.
- Decoupled the header UI containing search tabs and priority filters into `ProductivityHeader.tsx`.
- Decoupled the fallback view into `ProductivityEmptyState.tsx`.
- Ensured zero new third-party dependencies were introduced, and all i18n usages were preserved and correctly typed.

---
*PR created automatically by Jules for task [9890066908446532922](https://jules.google.com/task/9890066908446532922) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized productivity screen into smaller components and a centralized view model for state and data handling.
* **New Features**
  * New header with debounced search, tabs, priority filter chips, and quick-create buttons.
  * New contextual empty-state UI with tailored messaging and action buttons.
  * "Today plan" generation that composes a concise plan from upcoming tasks and events.
* **Bug Fixes**
  * Confirm-delete flow improved with retry on failure and proper loading/refresh handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->