### PR TITLE
docs: Miru agent documentation audit and corrections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ The following AI agents actively monitor and modify the Miru codebase. Their act
 **Note on Prompt:** Jules is instructed to strictly follow project architecture and code style: 100-char lines, type hints/explicit types, double quotes for Python, single quotes for TypeScript, specific import orders (`stdlib` → `third-party` → `first-party`), use `str | None` not `Optional[str]`, use `const` for components/internal functions, include `from __future__ import annotations`, log errors with context (`logger.exception()`), and structure domains in `backend/app/domain/<domain>/` and routes in `backend/app/api/v1/`.
 
 ### 2. CodeRabbit
+// DOCS(miru-agent): prompt mismatch
 
 **Mission:** Continuous code review, enforcing style, finding bugs, and suggesting refactors.
 **Trigger Conditions:**

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -100,6 +100,7 @@ async def _handle_send_message(
 # WebSocket endpoint
 # ---------------------------------------------------------------------------
 @router.websocket("/ws/chat")
+# DOCS(miru-agent): undocumented endpoint
 async def websocket_chat_hub(
     websocket: WebSocket,
     token: str = Query(..., description="Supabase JWT access token"),


### PR DESCRIPTION
This submission implements the Miru agent documentation audit requested by the user.

- **API Documentation**: Inspected `backend/app/api/v1/websocket.py` and flagged the undocumented `websocket_chat_hub` endpoint with `# DOCS(miru-agent): undocumented endpoint` as requested by the instructions.
- **Agent Documentation**: Inspected `.coderabbit.yaml` and `AGENTS.md`. Since the CodeRabbit instructions dictate checking for FastAPI dependency injection, Ruff, Black, and Mypy standards, and removing Flutter-only mentions—which are not documented in `AGENTS.md`—I flagged the CodeRabbit section with `// DOCS(miru-agent): prompt mismatch`.
- Verified changes by running the test suite and linters in the backend directory.

---
*PR created automatically by Jules for task [9290533878246986218](https://jules.google.com/task/9290533878246986218) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation notes to flag areas requiring further attention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->