### PR TITLE
chore(security): strictly disable cleartext traffic in Expo app.json

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -16,7 +16,10 @@
       "supportsTablet": true,
       "bundleIdentifier": "com.ykdbonte.miru.dev",
       "infoPlist": {
-        "ITSAppUsesNonExemptEncryption": false
+        "ITSAppUsesNonExemptEncryption": false,
+        "NSAppTransportSecurity": {
+          "NSAllowsArbitraryLoads": false
+        }
       }
     },
     "android": {
@@ -27,7 +30,8 @@
         "monochromeImage": "./assets/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "package": "com.miru.app"
+      "package": "com.miru.app",
+      "usesCleartextTraffic": false
     },
     "web": {
       "favicon": "./assets/favicon.png"


### PR DESCRIPTION
Security Advisory: Cleartext (HTTP) traffic could expose sensitive data to interception on unencrypted networks.

Hardened Code: 
Modified `frontend/app.json` to explicitly disable cleartext HTTP traffic across mobile platforms.
- For iOS: Added `"NSAppTransportSecurity": { "NSAllowsArbitraryLoads": false }` to `infoPlist`.
- For Android: Added `"usesCleartextTraffic": false`.

Integrity Note: This change strictly enforces HTTPS at the OS level (AndroidManifest.xml and Info.plist equivalents via Expo).

---
*PR created automatically by Jules for task [18152178154622940309](https://jules.google.com/task/18152178154622940309) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced HTTPS connections and prevented insecure cleartext HTTP traffic on iOS and Android platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->