### PR TITLE
Harden LLM Integration (Prompt Injection Defense & Semantic Caching)

### DIFF
--- a/backend/app/domain/agents/prompts.py
+++ b/backend/app/domain/agents/prompts.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-AGENT_SYSTEM_PROMPT_TEMPLATE = """You are {name}.
-Respond naturally and concisely like a real person in a chat. Never introduce yourself, announce your capabilities, or explain what you can do unless the user specifically asks. Just answer helpfully and directly.{description_section}
-Personality & Behavior:
-{personality}{goals_section}{capabilities_section}"""
+AGENT_SYSTEM_PROMPT_TEMPLATE = (
+    "You are {name}.\n"
+    "Respond naturally and concisely like a real person in a chat. "
+    "Never introduce yourself, announce your capabilities, or explain what you can do "
+    "unless the user specifically asks. Just answer helpfully and directly."
+    "{description_section}\n"
+    "Personality & Behavior:\n"
+    "{personality}{goals_section}{capabilities_section}"
+)

--- a/backend/app/domain/agents/prompts.py
+++ b/backend/app/domain/agents/prompts.py
@@ -1,0 +1,8 @@
+"""Prompt templates for the agents domain."""
+
+from __future__ import annotations
+
+AGENT_SYSTEM_PROMPT_TEMPLATE = """You are {name}.
+Respond naturally and concisely like a real person in a chat. Never introduce yourself, announce your capabilities, or explain what you can do unless the user specifically asks. Just answer helpfully and directly.{description_section}
+Personality & Behavior:
+{personality}{goals_section}{capabilities_section}"""

--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from app.domain.agents.models import Agent, AgentIntegration, Capability, Integration
+from app.domain.agents.prompts import AGENT_SYSTEM_PROMPT_TEMPLATE
 from app.domain.agents.schemas import (
     AgentCreate,
     AgentGenerationResponse,
@@ -88,30 +89,31 @@ class AgentService:
         capability_ids: list[str] | None = None,
     ) -> str:
         """Build a rich system prompt from agent profile fields."""
-        sections = [
-            f"You are {name}.",
-            (
-                "Respond naturally and concisely like a real person in a chat. "
-                "Never introduce yourself, announce your capabilities, or explain what you can do "
-                "unless the user specifically asks. Just answer helpfully and directly."
-            ),
-        ]
-        if description:
-            sections.append(description)
-        sections.append(f"\nPersonality & Behavior:\n{personality}")
+        description_section = f"\n{description}" if description else ""
+
+        goals_section = ""
         if goals:
             goal_list = "\n".join(f"- {g}" for g in goals)
-            sections.append(f"\nYour Goals:\n{goal_list}")
+            goals_section = f"\nYour Goals:\n{goal_list}"
+
+        capabilities_section = ""
         if capability_ids:
             all_caps = await self.list_capabilities()
             cap_names = [c.name for c in all_caps if c.id in capability_ids]
             cap_list = ", ".join(cap_names)
-            sections.append(
+            capabilities_section = (
                 f"\nYou have access to the following tools: {cap_list}. "
                 "Use them proactively when the user's request calls for it, "
                 "but do not mention or advertise them."
             )
-        return "\n".join(sections)
+
+        return AGENT_SYSTEM_PROMPT_TEMPLATE.format(
+            name=name,
+            personality=personality,
+            description_section=description_section,
+            goals_section=goals_section,
+            capabilities_section=capabilities_section,
+        )
 
     async def create_agent(self, agent_data: AgentCreate, user_id: UUID) -> AgentResponse:
         """Onboard a new agent with a built system prompt."""

--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -89,17 +89,23 @@ class AgentService:
         capability_ids: list[str] | None = None,
     ) -> str:
         """Build a rich system prompt from agent profile fields."""
-        description_section = f"\n{description}" if description else ""
+        # Sanitize personality and description to prevent newline injection
+        safe_personality = personality.replace("\n", " ")
+        safe_description = description.replace("\n", " ") if description else ""
+        description_section = f"\n{safe_description}" if safe_description else ""
 
         goals_section = ""
         if goals:
-            goal_list = "\n".join(f"- {g}" for g in goals)
+            # Sanitize each goal string
+            safe_goals = [g.replace("\n", " ") for g in goals]
+            goal_list = "\n".join(f"- {g}" for g in safe_goals)
             goals_section = f"\nYour Goals:\n{goal_list}"
 
         capabilities_section = ""
         if capability_ids:
             all_caps = await self.list_capabilities()
-            cap_names = [c.name for c in all_caps if c.id in capability_ids]
+            # Sanitize capability names
+            cap_names = [c.name.replace("\n", " ") for c in all_caps if c.id in capability_ids]
             cap_list = ", ".join(cap_names)
             capabilities_section = (
                 f"\nYou have access to the following tools: {cap_list}. "
@@ -108,8 +114,8 @@ class AgentService:
             )
 
         return AGENT_SYSTEM_PROMPT_TEMPLATE.format(
-            name=name,
-            personality=personality,
+            name=name.replace("\n", " "),
+            personality=safe_personality,
             description_section=description_section,
             goals_section=goals_section,
             capabilities_section=capabilities_section,

--- a/backend/app/infrastructure/external/openrouter.py
+++ b/backend/app/infrastructure/external/openrouter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import typing
+from collections import OrderedDict
 from typing import TYPE_CHECKING, TypeVar
 
 import openai
@@ -27,6 +28,27 @@ class ChatResponse(BaseModel):
     message: str
 
 
+class LRUCache:
+    """A simple dictionary-based LRU cache for async methods."""
+
+    def __init__(self, maxsize: int = 100):
+        self.cache: OrderedDict[str, typing.Any] = OrderedDict()
+        self.maxsize = maxsize
+
+    def get(self, key: str) -> typing.Any | None:
+        if key in self.cache:
+            self.cache.move_to_end(key)
+            return self.cache[key]
+        return None
+
+    def set(self, key: str, value: typing.Any) -> None:
+        if key in self.cache:
+            self.cache.move_to_end(key)
+        self.cache[key] = value
+        if len(self.cache) > self.maxsize:
+            self.cache.popitem(last=False)
+
+
 class OpenRouterClient:
     def __init__(self, api_key: str):
         # We defer imports to bypass Python 3.13 circular import bugs at startup
@@ -45,6 +67,8 @@ class OpenRouterClient:
             self.openai_client,
             mode=instructor.Mode.OPENROUTER_STRUCTURED_OUTPUTS,
         )
+        # Initialize an LRU cache for semantic deduplication (e.g. embeddings)
+        self._embed_cache = LRUCache(maxsize=100)
 
     async def chat_completion(self, messages: list[ChatCompletionMessageParam], model: str) -> str:
         # Internally enforce strict JSON structured output even for generic strings
@@ -65,12 +89,19 @@ class OpenRouterClient:
         reraise=True,
     )
     async def embed(self, text: str, model: str) -> list[float]:
+        cache_key = f"{model}:{text}"
+        cached_val = self._embed_cache.get(cache_key)
+        if cached_val is not None:
+            return typing.cast("list[float]", cached_val)
+
         response = await self.openai_client.embeddings.create(
             model=model,
             input=text,
             encoding_format="float",
         )
-        return response.data[0].embedding
+        embedding = response.data[0].embedding
+        self._embed_cache.set(cache_key, embedding)
+        return embedding
 
     @retry(
         stop=stop_after_attempt(3),

--- a/backend/app/infrastructure/external/openrouter.py
+++ b/backend/app/infrastructure/external/openrouter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import typing
 from collections import OrderedDict
@@ -29,19 +30,37 @@ class ChatResponse(BaseModel):
 
 
 class LRUCache:
-    """A simple dictionary-based LRU cache for async methods."""
+    """A simple dictionary-based LRU cache for async methods.
+
+    This cache limits its size and ejects the least recently used entry
+    when maxsize is exceeded.
+    """
 
     def __init__(self, maxsize: int = 100):
         self.cache: OrderedDict[str, typing.Any] = OrderedDict()
         self.maxsize = maxsize
 
     def get(self, key: str) -> typing.Any | None:
+        """Retrieve an item from the cache.
+
+        Args:
+            key: The key used to identify the cached value.
+
+        Returns:
+            The cached value if present, or None.
+        """
         if key in self.cache:
             self.cache.move_to_end(key)
             return self.cache[key]
         return None
 
     def set(self, key: str, value: typing.Any) -> None:
+        """Store an item in the cache.
+
+        Args:
+            key: The key to associate with the value.
+            value: The value to store.
+        """
         if key in self.cache:
             self.cache.move_to_end(key)
         self.cache[key] = value
@@ -69,6 +88,7 @@ class OpenRouterClient:
         )
         # Initialize an LRU cache for semantic deduplication (e.g. embeddings)
         self._embed_cache = LRUCache(maxsize=100)
+        self._embed_inflight: dict[str, asyncio.Future] = {}
 
     async def chat_completion(self, messages: list[ChatCompletionMessageParam], model: str) -> str:
         # Internally enforce strict JSON structured output even for generic strings
@@ -89,19 +109,34 @@ class OpenRouterClient:
         reraise=True,
     )
     async def embed(self, text: str, model: str) -> list[float]:
-        cache_key = f"{model}:{text}"
+        text_digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        cache_key = f"{model}:{text_digest}"
+
         cached_val = self._embed_cache.get(cache_key)
         if cached_val is not None:
             return typing.cast("list[float]", cached_val)
 
-        response = await self.openai_client.embeddings.create(
-            model=model,
-            input=text,
-            encoding_format="float",
-        )
-        embedding = response.data[0].embedding
-        self._embed_cache.set(cache_key, embedding)
-        return embedding
+        if cache_key in self._embed_inflight:
+            return await self._embed_inflight[cache_key]
+
+        future: asyncio.Future = asyncio.Future()
+        self._embed_inflight[cache_key] = future
+
+        try:
+            response = await self.openai_client.embeddings.create(
+                model=model,
+                input=text,
+                encoding_format="float",
+            )
+            embedding = response.data[0].embedding
+            self._embed_cache.set(cache_key, embedding)
+            future.set_result(embedding)
+            return embedding
+        except Exception as e:
+            future.set_exception(e)
+            raise
+        finally:
+            self._embed_inflight.pop(cache_key, None)
 
     @retry(
         stop=stop_after_attempt(3),

--- a/backend/tests/test_infrastructure.py
+++ b/backend/tests/test_infrastructure.py
@@ -111,6 +111,7 @@ async def test_client_embed() -> None:
 
     client = OpenRouterClient.__new__(OpenRouterClient)
     client._embed_cache = LRUCache()
+    client._embed_inflight = {}
     mock_openai = AsyncMock()
     embedding_data = MagicMock()
     embedding_data.embedding = [0.5, 0.6]
@@ -119,8 +120,13 @@ async def test_client_embed() -> None:
     mock_openai.embeddings.create = AsyncMock(return_value=mock_response)
     client.openai_client = mock_openai
 
-    result = await client.embed("text", "model")
-    assert result == [0.5, 0.6]
+    result1 = await client.embed("text", "model")
+    assert result1 == [0.5, 0.6]
+
+    result2 = await client.embed("text", "model")
+    assert result2 == [0.5, 0.6]
+
+    mock_openai.embeddings.create.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_infrastructure.py
+++ b/backend/tests/test_infrastructure.py
@@ -107,9 +107,10 @@ async def test_client_chat_completion_delegates_to_structured() -> None:
 
 @pytest.mark.asyncio
 async def test_client_embed() -> None:
-    from app.infrastructure.external.openrouter import OpenRouterClient
+    from app.infrastructure.external.openrouter import LRUCache, OpenRouterClient
 
     client = OpenRouterClient.__new__(OpenRouterClient)
+    client._embed_cache = LRUCache()
     mock_openai = AsyncMock()
     embedding_data = MagicMock()
     embedding_data.embedding = [0.5, 0.6]

--- a/test_lru.py
+++ b/test_lru.py
@@ -1,0 +1,5 @@
+import functools
+
+@functools.lru_cache(maxsize=100)
+def sync_func(x):
+    return x*2

--- a/test_lru.py
+++ b/test_lru.py
@@ -1,5 +1,0 @@
-import functools
-
-@functools.lru_cache(maxsize=100)
-def sync_func(x):
-    return x*2


### PR DESCRIPTION
This submission focuses on hardening the bridge between the codebase and the LLM, focusing on prompt injection defense, token efficiency, and structured output validation.
- Extracted raw string concatenation for the agent's system prompt into an isolated and robust template in `backend/app/domain/agents/prompts.py`
- Implemented an `LRUCache` caching layer within `backend/app/infrastructure/external/openrouter.py` to memoize and store results of standard `embed` requests from the OpenRouter LLM, drastically cutting redundant API calls.
- Ran formatting, linting, type-checks (`mypy`), and the backend testing suite successfully.

---
*PR created automatically by Jules for task [9616382198459720214](https://jules.google.com/task/9616382198459720214) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced embedding caching system with automatic deduplication to minimize redundant API calls and significantly enhance performance.

* **Improvements**
  * Enhanced system prompt configuration for chat agents with flexible, parameterized template support.
  * Improved input normalization in agent operations and concurrent request handling for embeddings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->