### PR TITLE
docs: Audit and fix documentation drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ The following AI agents actively monitor and modify the Miru codebase. Their act
 **Trigger Conditions:**
 - Automatically invoked when the "PR Checks and Linting" CI workflow completes successfully on a PR branch.
 - Retries automatically every 30 minutes via a queue processor if rate-limited (label `coderabbit:queued`).
+// DOCS(miru-agent): prompt mismatch
 **Scope:** Reviews all modified files in a PR. Posts actionable comments. When 0 actionable comments are found, it triggers the `ai-approved` label.
 
 ## Project Structure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ The following AI agents actively monitor and modify the Miru codebase. Their act
 **Trigger Conditions:**
 - Automatically invoked when the "PR Checks and Linting" CI workflow completes successfully on a PR branch.
 - Retries automatically every 30 minutes via a queue processor if rate-limited (label `coderabbit:queued`).
-// DOCS(miru-agent): prompt mismatch
+<!-- DOCS(miru-agent): prompt mismatch -->
 **Scope:** Reviews all modified files in a PR. Posts actionable comments. When 0 actionable comments are found, it triggers the `ai-approved` label.
 
 ## Project Structure

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -99,7 +99,7 @@ async def _handle_send_message(
 # ---------------------------------------------------------------------------
 # WebSocket endpoint
 # ---------------------------------------------------------------------------
-# DOCS(miru-agent): undocumented endpoint
+# DOCS(miru-agent): not in OpenAPI schema
 @router.websocket("/ws/chat")
 async def websocket_chat_hub(
     websocket: WebSocket,

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -99,6 +99,7 @@ async def _handle_send_message(
 # ---------------------------------------------------------------------------
 # WebSocket endpoint
 # ---------------------------------------------------------------------------
+# DOCS(miru-agent): undocumented endpoint
 @router.websocket("/ws/chat")
 async def websocket_chat_hub(
     websocket: WebSocket,


### PR DESCRIPTION
Fixes documentation mismatch by flagging missing endpoint and AI prompt disparities per Miru agent rules.

---
*PR created automatically by Jules for task [15172606233726012067](https://jules.google.com/task/15172606233726012067) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added internal documentation noting a prompt mismatch remark for an agent trigger condition.
  * Added an internal comment clarifying that the chat WebSocket endpoint is omitted from the public API schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->