### PR TITLE
fix: explicitly cast sql parameters in match_memories

### DIFF
--- a/backend/app/infrastructure/repositories/memory_repo.py
+++ b/backend/app/infrastructure/repositories/memory_repo.py
@@ -50,8 +50,8 @@ class MemoryRepository:
         query = """
             SELECT * FROM match_memories(
                 query_embedding := $1::vector,
-                match_threshold := $2,
-                match_count := $3,
+                match_threshold := $2::float,
+                match_count := $3::int,
                 p_user_id := $4::uuid,
                 p_agent_id := $5::uuid,
                 p_room_id := $6::uuid

--- a/backend/tests/test_memory.py
+++ b/backend/tests/test_memory.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.infrastructure.repositories.memory_repo import MemoryRepository
+
+
+@pytest.mark.asyncio
+async def test_match_memories_sql_types() -> None:
+    repo = MemoryRepository()
+    mock_conn = AsyncMock()
+    mock_conn.execute_query_dict = AsyncMock(
+        return_value=[
+            {
+                "id": "00000000-0000-0000-0000-000000000000",
+                "content": "hi",
+                "embedding": "[0.1]",
+                "similarity": 0.9,
+            }
+        ]
+    )
+    uid = uuid4()
+    aid = uuid4()
+    rid = uuid4()
+    with patch("app.infrastructure.repositories.memory_repo.Tortoise") as mock_tortoise:
+        mock_tortoise.get_connection.return_value = mock_conn
+        result = await repo.match_memories([0.1, 0.2], 0.5, 5, uid, aid, rid)
+    assert len(result) == 1
+    assert result[0].content == "hi"
+    assert not hasattr(result[0], "similarity")
+    mock_conn.execute_query_dict.assert_awaited_once()
+    call_args = mock_conn.execute_query_dict.call_args
+    sql_query = call_args[0][0]
+
+    assert "$1::vector" in sql_query
+    assert "$2::float" in sql_query
+    assert "$3::int" in sql_query
+    assert "$4::uuid" in sql_query
+    assert "$5::uuid" in sql_query
+    assert "$6::uuid" in sql_query


### PR DESCRIPTION
This PR fixes a Sentry-reported OperationalError where PostgreSQL failed to match the `match_memories` function signature due to unknown/implicit types on parameters like `match_threshold` and `match_count`.
It explicitly casts `$2` as `::float` and `$3` as `::int` inside `backend/app/infrastructure/repositories/memory_repo.py`.
Also includes a unit test ensuring that queries retain these casts.

Closes #598

---
*PR created automatically by Jules for task [1623298958581630639](https://jules.google.com/task/1623298958581630639) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database query parameter type handling for memory matching operations to ensure proper PostgreSQL type resolution.

* **Tests**
  * Added test coverage for memory matching SQL type casting to verify correct parameter type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->