### PR TITLE
chore(frontend): disable cleartext traffic in Expo app.json

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -16,7 +16,10 @@
       "supportsTablet": true,
       "bundleIdentifier": "com.ykdbonte.miru.dev",
       "infoPlist": {
-        "ITSAppUsesNonExemptEncryption": false
+        "ITSAppUsesNonExemptEncryption": false,
+        "NSAppTransportSecurity": {
+          "NSAllowsArbitraryLoads": false
+        }
       }
     },
     "android": {
@@ -27,7 +30,8 @@
         "monochromeImage": "./assets/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "package": "com.miru.app"
+      "package": "com.miru.app",
+      "usesCleartextTraffic": false
     },
     "web": {
       "favicon": "./assets/favicon.png"


### PR DESCRIPTION
Hardened React Native frontend by configuring Expo `app.json` to strictly disable cleartext HTTP traffic across both iOS and Android platforms, securing sensitive credentials and interactions.

---
*PR created automatically by Jules for task [8412697472511860183](https://jules.google.com/task/8412697472511860183) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced app network security configuration to enforce encrypted connections and restrict unencrypted traffic on both iOS and Android.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->