### PR TITLE
Refactor AgentService to respect Clean Architecture Layer Contract

### DIFF
--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from app.domain.agents.models import Agent, AgentIntegration, Capability, Integration
+from app.domain.agents.models import Agent, Capability, Integration
 from app.domain.agents.schemas import (
     AgentCreate,
     AgentGenerationResponse,
@@ -123,32 +123,17 @@ class AgentService:
             capability_ids=agent_data.capabilities,
         )
 
-        agent = await Agent.create(
+        agent = await self.repo.create_agent_with_relations(
             user_id=user_id,
             name=agent_data.name,
             personality=agent_data.personality,
             description=agent_data.description,
             goals=agent_data.goals,
             system_prompt=system_prompt,
+            capability_ids=agent_data.capabilities,
+            integration_ids=agent_data.integrations,
+            integration_configs=agent_data.integration_configs,
         )
-
-        if agent_data.capabilities:
-            caps = await Capability.filter(id__in=agent_data.capabilities)
-            await agent.capabilities.add(*caps)
-
-        if agent_data.integrations:
-            integrations = await Integration.filter(id__in=agent_data.integrations)
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=agent_data.integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
 
         # Refetch with relations so the response is fully populated.
         refetched = await self.repo.get_by_id(agent.pk)
@@ -194,34 +179,14 @@ class AgentService:
 
         # --- capabilities ---
         new_capability_ids: list[str] | None = fields.pop("capabilities", None)
-        if new_capability_ids is not None:
-            caps = await Capability.filter(id__in=new_capability_ids)
-            await agent.capabilities.clear()
-            if caps:
-                await agent.capabilities.add(*caps)
-            effective_cap_ids = new_capability_ids
-        else:
-            effective_cap_ids = [
-                str(c_id) for c_id in await agent.capabilities.all().values_list("id", flat=True)
-            ]
+        effective_cap_ids = await self.repo.update_agent_capabilities(agent, new_capability_ids)
 
         # --- integrations ---
         new_integration_ids: list[str] | None = fields.pop("integrations", None)
         new_integration_configs: dict = fields.pop("integration_configs", None) or {}
         if new_integration_ids is not None:
-            await AgentIntegration.filter(agent=agent).delete()
-            integrations = await Integration.filter(id__in=new_integration_ids)
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=new_integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
+             await self.repo.update_agent_integrations(agent, new_integration_ids, new_integration_configs)
+
 
         # Merge profile fields with current values so build_system_prompt has full context
         name = fields.get("name", agent.name)

--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -185,8 +185,9 @@ class AgentService:
         new_integration_ids: list[str] | None = fields.pop("integrations", None)
         new_integration_configs: dict = fields.pop("integration_configs", None) or {}
         if new_integration_ids is not None:
-             await self.repo.update_agent_integrations(agent, new_integration_ids, new_integration_configs)
-
+            await self.repo.update_agent_integrations(
+                agent, new_integration_ids, new_integration_configs
+            )
 
         # Merge profile fields with current values so build_system_prompt has full context
         name = fields.get("name", agent.name)

--- a/backend/app/infrastructure/repositories/agent_repo.py
+++ b/backend/app/infrastructure/repositories/agent_repo.py
@@ -10,6 +10,7 @@ from tortoise.transactions import in_transaction
 
 from app.domain.agents.models import (
     Agent,
+    AgentIntegration,
     AgentTemplate,
     Capability,
     Integration,
@@ -56,6 +57,77 @@ class AgentRepository:
         """Create a new agent."""
         await agent.save()
         return agent
+
+    async def create_agent_with_relations(
+        self,
+        user_id: UUID,
+        name: str,
+        personality: str,
+        description: str | None,
+        goals: list[str],
+        system_prompt: str,
+        capability_ids: list[str],
+        integration_ids: list[str],
+        integration_configs: dict,
+    ) -> Agent:
+        """Create a new agent with capabilities and integrations."""
+        agent = await Agent.create(
+            user_id=user_id,
+            name=name,
+            personality=personality,
+            description=description,
+            goals=goals,
+            system_prompt=system_prompt,
+        )
+
+        if capability_ids:
+            caps = await Capability.filter(id__in=capability_ids)
+            await agent.capabilities.add(*caps)
+
+        if integration_ids:
+            integrations = await Integration.filter(id__in=integration_ids)
+            agent_integrations = [
+                AgentIntegration(
+                    agent=agent,
+                    integration=integration,
+                    config=integration_configs.get(str(integration.id), {}),
+                    enabled=True,
+                )
+                for integration in integrations
+            ]
+            if agent_integrations:
+                await AgentIntegration.bulk_create(agent_integrations)
+
+        return agent
+
+    async def update_agent_capabilities(self, agent: Agent, capability_ids: list[str] | None) -> list[str]:
+        """Update an agent's capabilities."""
+        if capability_ids is not None:
+            caps = await Capability.filter(id__in=capability_ids)
+            await agent.capabilities.clear()
+            if caps:
+                await agent.capabilities.add(*caps)
+            return capability_ids
+        return [str(c_id) for c_id in await agent.capabilities.all().values_list("id", flat=True)]
+
+    async def update_agent_integrations(
+        self, agent: Agent, integration_ids: list[str] | None, integration_configs: dict
+    ) -> None:
+        """Update an agent's integrations."""
+        if integration_ids is not None:
+            await AgentIntegration.filter(agent=agent).delete()
+            integrations = await Integration.filter(id__in=integration_ids)
+            agent_integrations = [
+                AgentIntegration(
+                    agent=agent,
+                    integration=integration,
+                    config=integration_configs.get(str(integration.id), {}),
+                    enabled=True,
+                )
+                for integration in integrations
+            ]
+            if agent_integrations:
+                await AgentIntegration.bulk_create(agent_integrations)
 
     async def update_mood(self, agent_id: UUID | str, mood: str) -> None:
         """Update an agent's mood."""

--- a/backend/app/infrastructure/repositories/agent_repo.py
+++ b/backend/app/infrastructure/repositories/agent_repo.py
@@ -70,66 +70,70 @@ class AgentRepository:
         integration_ids: list[str],
         integration_configs: dict,
     ) -> Agent:
-        """Create a new agent with capabilities and integrations."""
-        agent = await Agent.create(
-            user_id=user_id,
-            name=name,
-            personality=personality,
-            description=description,
-            goals=goals,
-            system_prompt=system_prompt,
-        )
+        """Create a new agent with capabilities and integrations atomically."""
+        async with in_transaction():
+            agent = await Agent.create(
+                user_id=user_id,
+                name=name,
+                personality=personality,
+                description=description,
+                goals=goals,
+                system_prompt=system_prompt,
+            )
 
-        if capability_ids:
-            caps = await Capability.filter(id__in=capability_ids)
-            await agent.capabilities.add(*caps)
+            if capability_ids:
+                caps = await Capability.filter(id__in=capability_ids)
+                if caps:
+                    await agent.capabilities.add(*caps)
 
-        if integration_ids:
-            integrations = await Integration.filter(id__in=integration_ids)
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
+            if integration_ids:
+                integrations = await Integration.filter(id__in=integration_ids)
+                agent_integrations = [
+                    AgentIntegration(
+                        agent=agent,
+                        integration=integration,
+                        config=integration_configs.get(str(integration.id), {}),
+                        enabled=True,
+                    )
+                    for integration in integrations
+                ]
+                if agent_integrations:
+                    await AgentIntegration.bulk_create(agent_integrations)
 
-        return agent
+            return agent
 
     async def update_agent_capabilities(
         self, agent: Agent, capability_ids: list[str] | None
     ) -> list[str]:
-        """Update an agent's capabilities."""
+        """Update an agent's capabilities atomically, returning the actually persisted IDs."""
         if capability_ids is not None:
-            caps = await Capability.filter(id__in=capability_ids)
-            await agent.capabilities.clear()
-            if caps:
-                await agent.capabilities.add(*caps)
-            return capability_ids
+            async with in_transaction():
+                caps = await Capability.filter(id__in=capability_ids)
+                await agent.capabilities.clear()
+                if caps:
+                    await agent.capabilities.add(*caps)
+                return [str(c.id) for c in caps]
         return [str(c_id) for c_id in await agent.capabilities.all().values_list("id", flat=True)]
 
     async def update_agent_integrations(
         self, agent: Agent, integration_ids: list[str] | None, integration_configs: dict
     ) -> None:
-        """Update an agent's integrations."""
+        """Update an agent's integrations atomically."""
         if integration_ids is not None:
-            await AgentIntegration.filter(agent=agent).delete()
-            integrations = await Integration.filter(id__in=integration_ids)
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
+            async with in_transaction():
+                await AgentIntegration.filter(agent=agent).delete()
+                integrations = await Integration.filter(id__in=integration_ids)
+                agent_integrations = [
+                    AgentIntegration(
+                        agent=agent,
+                        integration=integration,
+                        config=integration_configs.get(str(integration.id), {}),
+                        enabled=True,
+                    )
+                    for integration in integrations
+                ]
+                if agent_integrations:
+                    await AgentIntegration.bulk_create(agent_integrations)
 
     async def update_mood(self, agent_id: UUID | str, mood: str) -> None:
         """Update an agent's mood."""

--- a/backend/app/infrastructure/repositories/agent_repo.py
+++ b/backend/app/infrastructure/repositories/agent_repo.py
@@ -100,7 +100,9 @@ class AgentRepository:
 
         return agent
 
-    async def update_agent_capabilities(self, agent: Agent, capability_ids: list[str] | None) -> list[str]:
+    async def update_agent_capabilities(
+        self, agent: Agent, capability_ids: list[str] | None
+    ) -> list[str]:
         """Update an agent's capabilities."""
         if capability_ids is not None:
             caps = await Capability.filter(id__in=capability_ids)


### PR DESCRIPTION
The `AgentService` previously violated the Clean Architecture Layer Contract by executing ORM database operations directly inside the Domain layer instead of delegating data access tasks to the injected repository. I have moved these operations (`create`, `filter`, `clear`, `add`, `bulk_create`) into the infrastructure-level `AgentRepository`.

---
*PR created automatically by Jules for task [16100107314039998014](https://jules.google.com/task/16100107314039998014) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved agent management backend to make agent creation and updates more reliable and consistent, ensuring capabilities and integrations are handled atomically. This reduces errors during agent setup and yields more predictable behavior when adding or modifying agent capabilities and integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->