### PR TITLE
Refactor AgentService to enforce Clean Architecture boundaries

### DIFF
--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from app.domain.agents.models import Agent, AgentIntegration, Capability, Integration
+from app.domain.agents.models import Agent, Capability, Integration
 from app.domain.agents.schemas import (
     AgentCreate,
     AgentGenerationResponse,
@@ -123,37 +123,18 @@ class AgentService:
             capability_ids=agent_data.capabilities,
         )
 
-        agent = await Agent.create(
+        agent = await self.repo.create_agent(
             user_id=user_id,
             name=agent_data.name,
             personality=agent_data.personality,
             description=agent_data.description,
             goals=agent_data.goals,
             system_prompt=system_prompt,
+            capabilities=agent_data.capabilities,
+            integrations=agent_data.integrations,
+            integration_configs=agent_data.integration_configs,
         )
-
-        if agent_data.capabilities:
-            caps = await Capability.filter(id__in=agent_data.capabilities)
-            await agent.capabilities.add(*caps)
-
-        if agent_data.integrations:
-            integrations = await Integration.filter(id__in=agent_data.integrations)
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=agent_data.integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
-
-        # Refetch with relations so the response is fully populated.
-        refetched = await self.repo.get_by_id(agent.pk)
-        assert refetched is not None
-        return _build_agent_response(refetched)
+        return _build_agent_response(agent)
 
     async def list_agents(self, user_id: UUID) -> list[AgentResponse]:
         """List all agents for a user."""
@@ -192,36 +173,14 @@ class AgentService:
 
         fields = data.model_dump(exclude_none=True)
 
-        # --- capabilities ---
         new_capability_ids: list[str] | None = fields.pop("capabilities", None)
         if new_capability_ids is not None:
-            caps = await Capability.filter(id__in=new_capability_ids)
-            await agent.capabilities.clear()
-            if caps:
-                await agent.capabilities.add(*caps)
             effective_cap_ids = new_capability_ids
         else:
-            effective_cap_ids = [
-                str(c_id) for c_id in await agent.capabilities.all().values_list("id", flat=True)
-            ]
+            effective_cap_ids = [str(c.pk) for c in agent.capabilities.related_objects]
 
-        # --- integrations ---
         new_integration_ids: list[str] | None = fields.pop("integrations", None)
-        new_integration_configs: dict = fields.pop("integration_configs", None) or {}
-        if new_integration_ids is not None:
-            await AgentIntegration.filter(agent=agent).delete()
-            integrations = await Integration.filter(id__in=new_integration_ids)
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=new_integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
+        new_integration_configs: dict | None = fields.pop("integration_configs", None)
 
         # Merge profile fields with current values so build_system_prompt has full context
         name = fields.get("name", agent.name)
@@ -238,7 +197,15 @@ class AgentService:
         )
         fields["system_prompt"] = updated_prompt
 
-        updated = await self.repo.update_agent(agent_id, user_id, **fields)
+        updated = await self.repo.update_agent(
+            agent_id=agent_id,
+            user_id=user_id,
+            capabilities=new_capability_ids,
+            integrations=new_integration_ids,
+            integration_configs=new_integration_configs,
+            **fields
+        )
+
         if not updated:
             return None
         return _build_agent_response(updated)

--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -203,7 +203,7 @@ class AgentService:
             capabilities=new_capability_ids,
             integrations=new_integration_ids,
             integration_configs=new_integration_configs,
-            **fields
+            **fields,
         )
 
         if not updated:

--- a/backend/app/infrastructure/repositories/agent_repo.py
+++ b/backend/app/infrastructure/repositories/agent_repo.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import math
 from datetime import UTC, datetime
+from typing import Any
 from uuid import UUID
 
 from tortoise.transactions import in_transaction
 
 from app.domain.agents.models import (
     Agent,
+    AgentIntegration,
     AgentTemplate,
     Capability,
     Integration,
@@ -57,6 +59,52 @@ class AgentRepository:
         await agent.save()
         return agent
 
+    async def create_agent(
+        self,
+        user_id: UUID,
+        name: str,
+        personality: str,
+        description: str | None,
+        goals: list[str],
+        system_prompt: str,
+        capabilities: list[str] | None = None,
+        integrations: list[str] | None = None,
+        integration_configs: dict[str, Any] | None = None,
+    ) -> Agent:
+        """Create a new agent along with capabilities and integrations."""
+        async with in_transaction():
+            agent = await Agent.create(
+                user_id=user_id,
+                name=name,
+                personality=personality,
+                description=description,
+                goals=goals,
+                system_prompt=system_prompt,
+            )
+
+            if capabilities:
+                caps = await Capability.filter(id__in=capabilities)
+                await agent.capabilities.add(*caps)
+
+            if integrations:
+                integration_records = await Integration.filter(id__in=integrations)
+                configs = integration_configs or {}
+                agent_integrations = [
+                    AgentIntegration(
+                        agent=agent,
+                        integration=integration,
+                        config=configs.get(str(integration.id), {}),
+                        enabled=True,
+                    )
+                    for integration in integration_records
+                ]
+                if agent_integrations:
+                    await AgentIntegration.bulk_create(agent_integrations)
+
+            refetched = await self.get_by_id(agent.pk)
+            assert refetched is not None
+            return refetched
+
     async def update_mood(self, agent_id: UUID | str, mood: str) -> None:
         """Update an agent's mood."""
         agent = await self.get_by_id(agent_id)
@@ -69,25 +117,62 @@ class AgentRepository:
     )
 
     async def update_agent(
-        self, agent_id: UUID | str, user_id: UUID | str, **fields: object
+        self,
+        agent_id: UUID | str,
+        user_id: UUID | str,
+        capabilities: list[str] | None = None,
+        integrations: list[str] | None = None,
+        integration_configs: dict[str, Any] | None = None,
+        **fields: object,
     ) -> Agent | None:
-        """Update an agent's fields. Only updates the owner's agent."""
+        """Update an agent's fields, capabilities, and integrations. Only updates the owner's agent."""
         unknown = set(fields) - self._ALLOWED_AGENT_FIELDS
         if unknown:
             raise ValueError(f"update_agent received unknown fields: {unknown}")
+
         if isinstance(agent_id, str):
             agent_id = UUID(agent_id)
         if isinstance(user_id, str):
             user_id = UUID(user_id)
-        agent = await Agent.get_or_none(id=agent_id, user_id=user_id).prefetch_related(
-            "capabilities", "agent_integrations__integration"
-        )
-        if agent:
+
+        async with in_transaction():
+            agent = await Agent.get_or_none(id=agent_id, user_id=user_id).prefetch_related(
+                "capabilities", "agent_integrations__integration"
+            )
+
+            if not agent:
+                return None
+
+            if capabilities is not None:
+                caps = await Capability.filter(id__in=capabilities)
+                await agent.capabilities.clear()
+                if caps:
+                    await agent.capabilities.add(*caps)
+
+            if integrations is not None:
+                await AgentIntegration.filter(agent=agent).delete()
+                integration_records = await Integration.filter(id__in=integrations)
+                configs = integration_configs or {}
+                agent_integrations = [
+                    AgentIntegration(
+                        agent=agent,
+                        integration=integration,
+                        config=configs.get(str(integration.id), {}),
+                        enabled=True,
+                    )
+                    for integration in integration_records
+                ]
+                if agent_integrations:
+                    await AgentIntegration.bulk_create(agent_integrations)
+
             for key, value in fields.items():
                 if value is not None:
                     setattr(agent, key, value)
+
             await agent.save()
-        return agent
+
+            # Refetch to ensure we have the latest relations for the return value
+            return await self.get_by_id(agent.pk)
 
     async def delete_agent(self, agent_id: UUID | str, user_id: UUID | str) -> bool:
         """Soft-delete an agent by setting deleted_at. Only deletes the owner's agent."""


### PR DESCRIPTION
Moved ORM database logic from the Domain/Service layer into the Infrastructure/Repository layer in `AgentService` and `AgentRepository` to conform to the Clean Architecture standards required for the project. Wrapped database creation/update flows in atomic database transactions to ensure consistency.

---
*PR created automatically by Jules for task [4572258919638505601](https://jules.google.com/task/4572258919638505601) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Agent creation and update flows reworked to use a centralized repository for persistence, improving reliability and maintainability.
  * Integration and capability handling consolidated into the repository layer for more consistent behavior.
  * Public-facing service API remains unchanged; no user-visible behavior or signatures altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->