### PR TITLE
chore(security): disable cleartext HTTP traffic in Expo app.json

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -16,7 +16,10 @@
       "supportsTablet": true,
       "bundleIdentifier": "com.ykdbonte.miru.dev",
       "infoPlist": {
-        "ITSAppUsesNonExemptEncryption": false
+        "ITSAppUsesNonExemptEncryption": false,
+        "NSAppTransportSecurity": {
+          "NSAllowsArbitraryLoads": false
+        }
       }
     },
     "android": {
@@ -27,7 +30,8 @@
         "monochromeImage": "./assets/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "package": "com.miru.app"
+      "package": "com.miru.app",
+      "usesCleartextTraffic": false
     },
     "web": {
       "favicon": "./assets/favicon.png"


### PR DESCRIPTION
Configured Expo `app.json` to strictly disable cleartext HTTP traffic on both iOS and Android. This mitigates MitM attack vectors and enforces TLS encryption for all network communication originating from the mobile app.

Changes:
- Added `NSAppTransportSecurity: { NSAllowsArbitraryLoads: false }` to `ios.infoPlist`.
- Added `usesCleartextTraffic: false` to `android`.

---
*PR created automatically by Jules for task [17943564188461106894](https://jules.google.com/task/17943564188461106894) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS security configuration to enforce HTTPS-only connections.
  * Updated Android security configuration to disable cleartext traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->