### PR TITLE
docs: update documentation to reflect actual codebase state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,8 +77,8 @@ The following AI agents actively monitor and modify the Miru codebase. Their act
 
 **Mission:** Continuous code review, enforcing style, finding bugs, and suggesting refactors.
 **Trigger Conditions:**
-- Automatically invoked when the "PR Checks and Linting" CI workflow completes successfully on a PR branch.
-- Retries automatically every 30 minutes via a queue processor if rate-limited (label `coderabbit:queued`).
+- Automatically invoked by mentioning `@coderabbitai` in a PR comment.
+- Retries automatically every 30 minutes via a queue processor if rate-limited (label `coderabbit:queued`) or via manual dispatch.
 **Scope:** Reviews all modified files in a PR. Posts actionable comments. When 0 actionable comments are found, it triggers the `ai-approved` label.
 
 ## Project Structure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 
 - **API**: Flagged undocumented `websocket_chat_hub` endpoint in `backend/app/api/v1/websocket.py` to ensure it is added to OpenAPI schema in future work.
+- **Components**: Added JSDoc blocks to `ScalePressable` and `SkeletonCard` components to document their behavior and parameters.
+- **Architecture**: Updated `README.md` to accurately reflect the actual internal file structure of the `backend/app/domain/productivity/` domain folder.
+- **Agents**: Corrected the trigger conditions for `CodeRabbit` in `AGENTS.md` to indicate it is invoked via PR comment mention rather than CI workflow completion.
 - **Architecture**: Updated `AGENTS.md` and `README.md` to accurately reflect the correct project layer structures (e.g. `use_cases/`, `entities.py`, `interfaces/` in productivity domain) and the `CodeRabbit` AI integration prompt discrepancies.
 - **Components**: Added JSDoc blocks to `AgentAvatar` and `BackendSplash` components, and improved the `useAgentStore` hook description to clarify its optimistic update strategies.
 - **Setup**: Added missing WebAuthn environment variables (`WEBAUTHN_RP_NAME` and `WEBAUTHN_EXPECTED_ORIGIN`) to the `README.md` setup table to match `.env.example`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 
 - **API**: Flagged undocumented `websocket_chat_hub` endpoint in `backend/app/api/v1/websocket.py` to ensure it is added to OpenAPI schema in future work.
-- **Components**: Added JSDoc blocks to `ScalePressable` and `SkeletonCard` components to document their behavior and parameters.
-- **Architecture**: Updated `README.md` to accurately reflect the actual internal file structure of the `backend/app/domain/productivity/` domain folder.
-- **Agents**: Corrected the trigger conditions for `CodeRabbit` in `AGENTS.md` to indicate it is invoked via PR comment mention rather than CI workflow completion.
+- **Components**: Added JSDoc blocks to `ScalePressable`, `SkeletonCard`, `AgentAvatar`, and `BackendSplash` components to document their behavior and parameters, and improved the `useAgentStore` hook description to clarify its optimistic update strategies.
 - **Architecture**: Updated `AGENTS.md` and `README.md` to accurately reflect the correct project layer structures (e.g. `use_cases/`, `entities.py`, `interfaces/` in productivity domain) and the `CodeRabbit` AI integration prompt discrepancies.
-- **Components**: Added JSDoc blocks to `AgentAvatar` and `BackendSplash` components, and improved the `useAgentStore` hook description to clarify its optimistic update strategies.
+- **Agents**: Corrected the trigger conditions for `CodeRabbit` in `AGENTS.md` to indicate it is invoked via PR comment mention rather than CI workflow completion.
 - **Setup**: Added missing WebAuthn environment variables (`WEBAUTHN_RP_NAME` and `WEBAUTHN_EXPECTED_ORIGIN`) to the `README.md` setup table to match `.env.example`.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,13 @@ miru/
 │   │   │   ├── chat/            # ChatRoom, ChatMessage, streaming
 │   │   │   ├── memory/          # Memory, graph nodes/edges, embeddings
 │   │   │   ├── notifications/   # Push notification service
-│   │   │   └── productivity/    # Tasks, Notes, Calendar Events (entities, interfaces, use_cases, models, schemas)
+│   │   │   └── productivity/    # Tasks, Notes, Calendar Events
+│   │   │       ├── dependencies.py
+│   │   │       ├── entities.py  # Pure python domain entities
+│   │   │       ├── interfaces/  # Interface boundaries for dependencies
+│   │   │       ├── models.py    # Tortoise ORM models
+│   │   │       ├── schemas.py   # Pydantic schemas
+│   │   │       └── use_cases/   # Application logic
 │   │   ├── api/v1/              # Route handlers per domain
 │   │   └── infrastructure/      # Database, external services, repositories
 │   │       ├── database/        # Supabase client, Tortoise ORM config

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -99,6 +99,7 @@ async def _handle_send_message(
 # ---------------------------------------------------------------------------
 # WebSocket endpoint
 # ---------------------------------------------------------------------------
+# DOCS(miru-agent): undocumented endpoint
 @router.websocket("/ws/chat")
 async def websocket_chat_hub(
     websocket: WebSocket,

--- a/frontend/src/components/ScalePressable.tsx
+++ b/frontend/src/components/ScalePressable.tsx
@@ -9,6 +9,15 @@ interface ScalePressableProps extends Omit<PressableProps, 'style'> {
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
+/**
+ * A Pressable component that smoothly scales down when pressed and returns to its original scale when released.
+ *
+ * @param props.children - The content to render inside the pressable area.
+ * @param props.style - Optional custom styles for the pressable container.
+ * @param props.onPressIn - Optional callback invoked when the user begins to press.
+ * @param props.onPressOut - Optional callback invoked when the user releases the press.
+ * @param props.disabled - Standard React Native disabled prop.
+ */
 export const ScalePressable = ({
   children,
   style,

--- a/frontend/src/components/SkeletonCard.tsx
+++ b/frontend/src/components/SkeletonCard.tsx
@@ -11,6 +11,14 @@ import Animated, {
 } from 'react-native-reanimated';
 import { useTheme } from '../hooks/useTheme';
 
+/**
+ * An animated placeholder box that continuously pulses to indicate loading state.
+ *
+ * @param props.width - The width of the placeholder box.
+ * @param props.height - The height of the placeholder box (defaults to 12).
+ * @param props.borderRadius - The border radius of the placeholder box (defaults to 6).
+ * @param props.delay - Animation delay in milliseconds (defaults to 0).
+ */
 function ShimmerBox({
   width,
   height = 12,
@@ -54,6 +62,12 @@ function ShimmerBox({
   );
 }
 
+/**
+ * A skeleton placeholder for an agent card to be displayed while loading data.
+ * Features animated shimmer effects.
+ *
+ * @param props.index - Optional index to stagger animations in a list.
+ */
 export function SkeletonAgentCard({ index = 0 }: { index?: number }) {
   const { C } = useTheme();
   const baseDelay = index * 120;


### PR DESCRIPTION
- Audited the `AGENTS.md` file and fixed the `CodeRabbit` trigger description to correctly reflect its PR-comment-based invocation instead of the outdated CI workflow hook.
- Examined the backend structure and corrected the layer documentation in `README.md` to show the explicit structure of `app/domain/productivity/` instead of simply an empty directory.
- Annotated the WebSocket chat endpoint in `backend/app/api/v1/websocket.py` to flag it as an undocumented endpoint.
- Audited the React Native `frontend/src/components/` directory, discovering that `ScalePressable.tsx` and `SkeletonCard.tsx` were lacking necessary JSDocs block, and successfully applied them.
- Verified test coverage remained positive, running standard regression for front-and backend code.
- Successfully documented these changes in the project `CHANGELOG.md`.

---
*PR created automatically by Jules for task [6188616695686147433](https://jules.google.com/task/6188616695686147433) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected CodeRabbit invocation description to reflect PR-comment trigger and retry behavior
  * Marked a WebSocket chat endpoint as undocumented for future OpenAPI work
  * Added/expanded JSDoc for several frontend components and hook descriptions
  * Expanded backend project structure details and added missing WebAuthn env vars to setup docs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->