### PR TITLE
Refactor: centralize and isolate LLM prompts

### DIFF
--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -14,6 +14,13 @@ from app.domain.agents.schemas import (
     AgentUpdate,
     MoodResponse,
 )
+from app.domain.chat.prompts import (
+    AGENT_PROFILE_SYSTEM_PROMPT,
+    AGENT_PROFILE_USER_PROMPT,
+    BUILD_SYSTEM_PROMPT_TEMPLATE,
+    MOOD_CLASSIFIER_SYSTEM_PROMPT,
+    MOOD_CLASSIFIER_USER_PROMPT,
+)
 from app.infrastructure.external.openrouter import structured_completion
 
 if TYPE_CHECKING:
@@ -88,30 +95,29 @@ class AgentService:
         capability_ids: list[str] | None = None,
     ) -> str:
         """Build a rich system prompt from agent profile fields."""
-        sections = [
-            f"You are {name}.",
-            (
-                "Respond naturally and concisely like a real person in a chat. "
-                "Never introduce yourself, announce your capabilities, or explain what you can do "
-                "unless the user specifically asks. Just answer helpfully and directly."
-            ),
-        ]
-        if description:
-            sections.append(description)
-        sections.append(f"\nPersonality & Behavior:\n{personality}")
+        goals_section = ""
         if goals:
             goal_list = "\n".join(f"- {g}" for g in goals)
-            sections.append(f"\nYour Goals:\n{goal_list}")
+            goals_section = f"\nYour Goals:\n{goal_list}\n"
+
+        tools_section = ""
         if capability_ids:
             all_caps = await self.list_capabilities()
             cap_names = [c.name for c in all_caps if c.id in capability_ids]
             cap_list = ", ".join(cap_names)
-            sections.append(
+            tools_section = (
                 f"\nYou have access to the following tools: {cap_list}. "
                 "Use them proactively when the user's request calls for it, "
-                "but do not mention or advertise them."
+                "but do not mention or advertise them.\n"
             )
-        return "\n".join(sections)
+
+        return BUILD_SYSTEM_PROMPT_TEMPLATE.format(
+            name=name,
+            description=f"{description}\n" if description else "",
+            personality=personality,
+            goals_section=goals_section,
+            tools_section=tools_section,
+        ).strip()
 
     async def create_agent(self, agent_data: AgentCreate, user_id: UUID) -> AgentResponse:
         """Onboard a new agent with a built system prompt."""
@@ -165,12 +171,9 @@ class AgentService:
         messages: list[ChatCompletionMessageParam] = [
             {
                 "role": "system",
-                "content": (
-                    "You are a creative director for AI personas. "
-                    "Create a unique, high-quality persona based on the user's keywords."
-                ),
+                "content": AGENT_PROFILE_SYSTEM_PROMPT,
             },
-            {"role": "user", "content": f"Keywords: {keywords}"},
+            {"role": "user", "content": AGENT_PROFILE_USER_PROMPT.format(keywords=keywords)},
         ]
 
         return await structured_completion(
@@ -275,13 +278,14 @@ class AgentService:
                 messages=[
                     {
                         "role": "system",
-                        "content": (
-                            f"You are a mood classifier. Given a conversation excerpt, "
-                            f"pick the single most fitting mood for the AI agent from this list: "
-                            f"{mood_list}."
+                        "content": MOOD_CLASSIFIER_SYSTEM_PROMPT.format(mood_list=mood_list),
+                    },
+                    {
+                        "role": "user",
+                        "content": MOOD_CLASSIFIER_USER_PROMPT.format(
+                            recent_history=recent_history
                         ),
                     },
-                    {"role": "user", "content": recent_history},
                 ],
                 response_model=MoodResponse,
             )

--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING
 
@@ -173,7 +174,12 @@ class AgentService:
                 "role": "system",
                 "content": AGENT_PROFILE_SYSTEM_PROMPT,
             },
-            {"role": "user", "content": AGENT_PROFILE_USER_PROMPT.format(keywords=keywords)},
+            {
+                "role": "user",
+                "content": AGENT_PROFILE_USER_PROMPT.format(
+                    keywords=json.dumps(keywords, ensure_ascii=False)
+                ),
+            },
         ]
 
         return await structured_completion(
@@ -283,7 +289,7 @@ class AgentService:
                     {
                         "role": "user",
                         "content": MOOD_CLASSIFIER_USER_PROMPT.format(
-                            recent_history=recent_history
+                            recent_history=json.dumps(recent_history, ensure_ascii=False)
                         ),
                     },
                 ],

--- a/backend/app/domain/chat/background_service.py
+++ b/backend/app/domain/chat/background_service.py
@@ -120,6 +120,7 @@ class ChatBackgroundService:
         if not self.chat_repo:
             return
 
+        from app.domain.chat.prompts import ROOM_SUMMARY_SYSTEM_PROMPT, ROOM_SUMMARY_USER_PROMPT
         from app.infrastructure.external.openrouter import structured_completion
 
         try:
@@ -144,19 +145,13 @@ class ChatBackgroundService:
             messages: list[ChatCompletionMessageParam] = [
                 {
                     "role": "system",
-                    "content": (
-                        "You are an AI tasked with maintaining a concise running summary of a chat room conversation. "
-                        "Please generate a new, comprehensive but concise summary of the ENTIRE conversation (merging the current summary with the new messages). "
-                        "Focus on the main topics discussed, user preferences revealed, and any ongoing tasks or context the agents need to remember."
+                    "content": ROOM_SUMMARY_SYSTEM_PROMPT,
+                },
+                {
+                    "role": "user",
+                    "content": ROOM_SUMMARY_USER_PROMPT.format(
+                        current_summary=current_summary, transcript=transcript
                     ),
-                },
-                {
-                    "role": "user",
-                    "content": f"CURRENT SUMMARY:\n{current_summary}",
-                },
-                {
-                    "role": "user",
-                    "content": f"LATEST MESSAGES:\n{transcript}",
                 },
             ]
 

--- a/backend/app/domain/chat/background_service.py
+++ b/backend/app/domain/chat/background_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 from typing import TYPE_CHECKING, Any
@@ -150,7 +151,8 @@ class ChatBackgroundService:
                 {
                     "role": "user",
                     "content": ROOM_SUMMARY_USER_PROMPT.format(
-                        current_summary=current_summary, transcript=transcript
+                        current_summary=json.dumps(current_summary, ensure_ascii=False),
+                        transcript=json.dumps(transcript, ensure_ascii=False),
                     ),
                 },
             ]

--- a/backend/app/domain/chat/crew_orchestrator.py
+++ b/backend/app/domain/chat/crew_orchestrator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
@@ -229,9 +230,21 @@ class CrewOrchestrator:
         )
 
         history_text = CrewOrchestrator.format_history(conversation_history)
-        history_section = HISTORY_PREFIX.format(history=history_text) if history_text else ""
-        memory_section = MEMORY_PREFIX.format(memories=memory_context) if memory_context else ""
-        summary_section = SUMMARY_PREFIX.format(summary=room_summary) if room_summary else ""
+        history_section = (
+            HISTORY_PREFIX.format(history=json.dumps(history_text, ensure_ascii=False))
+            if history_text
+            else ""
+        )
+        memory_section = (
+            MEMORY_PREFIX.format(memories=json.dumps(memory_context, ensure_ascii=False))
+            if memory_context
+            else ""
+        )
+        summary_section = (
+            SUMMARY_PREFIX.format(summary=json.dumps(room_summary, ensure_ascii=False))
+            if room_summary
+            else ""
+        )
 
         kwargs = {}
         if step_callback:
@@ -244,7 +257,7 @@ class CrewOrchestrator:
                     summary_section=summary_section,
                     memory_section=memory_section,
                     history_section=history_section,
-                    user_message=user_message,
+                    user_message=json.dumps(user_message, ensure_ascii=False),
                     locale_instruction=locale_instruction,
                 ),
                 expected_output=MULTI_AGENT_EXPECTED_OUTPUT,
@@ -262,7 +275,7 @@ class CrewOrchestrator:
                     summary_section=summary_section,
                     memory_section=memory_section,
                     history_section=history_section,
-                    user_message=user_message,
+                    user_message=json.dumps(user_message, ensure_ascii=False),
                     locale_instruction=locale_instruction,
                 ),
                 expected_output=SINGLE_AGENT_EXPECTED_OUTPUT,

--- a/backend/app/domain/chat/prompts.py
+++ b/backend/app/domain/chat/prompts.py
@@ -78,9 +78,11 @@ MOOD_CLASSIFIER_USER_PROMPT = (
 )
 
 ROOM_SUMMARY_SYSTEM_PROMPT = (
-    "You are an AI tasked with maintaining a concise running summary of a chat room conversation. "
-    "Please generate a new, comprehensive but concise summary of the ENTIRE conversation (merging the current summary with the new messages). "
-    "Focus on the main topics discussed, user preferences revealed, and any ongoing tasks or context the agents need to remember."
+    "You are an AI tasked with maintaining a concise running summary of a chat room "
+    "conversation. Please generate a new, comprehensive but concise summary of the ENTIRE "
+    "conversation (merging the current summary with the new messages). Focus on the "
+    "main topics discussed, user preferences revealed, and any ongoing tasks or "
+    "context the agents need to remember."
 )
 
 ROOM_SUMMARY_USER_PROMPT = (

--- a/backend/app/domain/chat/prompts.py
+++ b/backend/app/domain/chat/prompts.py
@@ -6,20 +6,25 @@ from __future__ import annotations
 # Prompt templates
 # ---------------------------------------------------------------------------
 
-HISTORY_PREFIX = "Recent conversation history (for context only — do not repeat it):\n{history}\n\n"
+HISTORY_PREFIX = (
+    "Recent conversation history (for context only — do not repeat it):\n"
+    "--- CONVERSATION HISTORY ---\n{history}\n--- END CONVERSATION HISTORY ---\n\n"
+)
 
 MEMORY_PREFIX = (
     "Relevant memories from past conversations (background context — do not repeat verbatim):\n"
-    "{memories}\n\n"
+    "--- MEMORIES ---\n{memories}\n--- END MEMORIES ---\n\n"
 )
 
-SUMMARY_PREFIX = "Summary of the older parts of this conversation:\n{summary}\n\n"
+SUMMARY_PREFIX = (
+    "Summary of the older parts of this conversation:\n"
+    "--- SUMMARY ---\n{summary}\n--- END SUMMARY ---\n\n"
+)
 
 MULTI_AGENT_PROMPT = (
     "{summary_section}"
     "{memory_section}"
     "{history_section}"
-    "User said: {user_message}. "
     "You are managing a group chat with specialized agents. "
     "Delegate ONLY to agents whose expertise is directly relevant to the user's request — "
     "do NOT force every agent to respond. "
@@ -32,18 +37,19 @@ MULTI_AGENT_PROMPT = (
     "Before creating, updating, or deleting tasks/notes/events, confirm intent briefly unless "
     "the user explicitly asked you to perform the action now. "
     "Return a transcript of only the agents who actually responded, "
-    "formatted as 'AgentName: message' with one blank line between agents.{locale_instruction}"
+    "formatted as 'AgentName: message' with one blank line between agents.{locale_instruction}\n\n"
+    "--- LATEST USER MESSAGE ---\n{user_message}\n--- END LATEST USER MESSAGE ---"
 )
 
 SINGLE_AGENT_PROMPT = (
     "{summary_section}"
     "{memory_section}"
     "{history_section}"
-    "User said: {user_message}. "
     "Respond naturally and helpfully as yourself. "
     "When relevant, be proactive about planning and converting intent into tasks/notes/events. "
     "Confirm before write actions unless the user explicitly requested immediate execution. "
-    "Do not introduce yourself or list your capabilities — just answer directly.{locale_instruction}"
+    "Do not introduce yourself or list your capabilities — just answer directly.{locale_instruction}\n\n"
+    "--- LATEST USER MESSAGE ---\n{user_message}\n--- END LATEST USER MESSAGE ---"
 )
 
 MULTI_AGENT_EXPECTED_OUTPUT = (
@@ -53,3 +59,49 @@ MULTI_AGENT_EXPECTED_OUTPUT = (
 )
 
 SINGLE_AGENT_EXPECTED_OUTPUT = "A direct, helpful response to the user's message."
+
+AGENT_PROFILE_SYSTEM_PROMPT = (
+    "You are a creative director for AI personas. "
+    "Create a unique, high-quality persona based on the user's keywords."
+)
+
+AGENT_PROFILE_USER_PROMPT = "--- KEYWORDS ---\n{keywords}\n--- END KEYWORDS ---"
+
+MOOD_CLASSIFIER_SYSTEM_PROMPT = (
+    "You are a mood classifier. Given a conversation excerpt, "
+    "pick the single most fitting mood for the AI agent from this list: "
+    "{mood_list}."
+)
+
+MOOD_CLASSIFIER_USER_PROMPT = "--- CONVERSATION EXCERPT ---\n{recent_history}\n--- END CONVERSATION EXCERPT ---"
+
+ROOM_SUMMARY_SYSTEM_PROMPT = (
+    "You are an AI tasked with maintaining a concise running summary of a chat room conversation. "
+    "Please generate a new, comprehensive but concise summary of the ENTIRE conversation (merging the current summary with the new messages). "
+    "Focus on the main topics discussed, user preferences revealed, and any ongoing tasks or context the agents need to remember."
+)
+
+ROOM_SUMMARY_USER_PROMPT = (
+    "--- CURRENT SUMMARY ---\n{current_summary}\n--- END CURRENT SUMMARY ---\n\n"
+    "--- LATEST MESSAGES ---\n{transcript}\n--- END LATEST MESSAGES ---"
+)
+
+GRAPH_EXTRACTION_SYSTEM_PROMPT = (
+    "You are a knowledge graph extraction system. Extract key entities and relationships from the user's text. "
+    "Be concise and precise. Focus on long-term facts, preferences, and relationships."
+)
+
+GRAPH_EXTRACTION_USER_PROMPT = "--- TEXT TO EXTRACT ---\n{text}\n--- END TEXT TO EXTRACT ---"
+
+STREAM_CHAT_USER_PROMPT = "--- LATEST USER MESSAGE ---\n{user_message}\n--- END LATEST USER MESSAGE ---"
+
+BUILD_SYSTEM_PROMPT_TEMPLATE = (
+    "You are {name}.\n"
+    "Respond naturally and concisely like a real person in a chat. "
+    "Never introduce yourself, announce your capabilities, or explain what you can do "
+    "unless the user specifically asks. Just answer helpfully and directly.\n"
+    "{description}"
+    "\nPersonality & Behavior:\n{personality}\n"
+    "{goals_section}"
+    "{tools_section}"
+)

--- a/backend/app/domain/chat/prompts.py
+++ b/backend/app/domain/chat/prompts.py
@@ -73,7 +73,9 @@ MOOD_CLASSIFIER_SYSTEM_PROMPT = (
     "{mood_list}."
 )
 
-MOOD_CLASSIFIER_USER_PROMPT = "--- CONVERSATION EXCERPT ---\n{recent_history}\n--- END CONVERSATION EXCERPT ---"
+MOOD_CLASSIFIER_USER_PROMPT = (
+    "--- CONVERSATION EXCERPT ---\n{recent_history}\n--- END CONVERSATION EXCERPT ---"
+)
 
 ROOM_SUMMARY_SYSTEM_PROMPT = (
     "You are an AI tasked with maintaining a concise running summary of a chat room conversation. "
@@ -93,7 +95,9 @@ GRAPH_EXTRACTION_SYSTEM_PROMPT = (
 
 GRAPH_EXTRACTION_USER_PROMPT = "--- TEXT TO EXTRACT ---\n{text}\n--- END TEXT TO EXTRACT ---"
 
-STREAM_CHAT_USER_PROMPT = "--- LATEST USER MESSAGE ---\n{user_message}\n--- END LATEST USER MESSAGE ---"
+STREAM_CHAT_USER_PROMPT = (
+    "--- LATEST USER MESSAGE ---\n{user_message}\n--- END LATEST USER MESSAGE ---"
+)
 
 BUILD_SYSTEM_PROMPT_TEMPLATE = (
     "You are {name}.\n"

--- a/backend/app/domain/chat/service.py
+++ b/backend/app/domain/chat/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from typing import TYPE_CHECKING
 
@@ -227,7 +228,12 @@ class ChatService:
                 }
             )
         messages.append(
-            {"role": "user", "content": STREAM_CHAT_USER_PROMPT.format(user_message=user_message)}
+            {
+                "role": "user",
+                "content": STREAM_CHAT_USER_PROMPT.format(
+                    user_message=json.dumps(user_message, ensure_ascii=False)
+                ),
+            }
         )
 
         try:

--- a/backend/app/domain/chat/service.py
+++ b/backend/app/domain/chat/service.py
@@ -17,6 +17,7 @@ from app.domain.chat.dtos import (
     RoomResponse,
     RoomSummaryResponse,
 )
+from app.domain.chat.prompts import STREAM_CHAT_USER_PROMPT
 from app.domain.chat.websocket_broadcaster import ChatWebSocketBroadcaster
 from app.infrastructure.external.openrouter import stream_chat
 
@@ -225,7 +226,9 @@ class ChatService:
                     "content": f"IMPORTANT: Please respond in the following language locale: {accept_language}",
                 }
             )
-        messages.append({"role": "user", "content": user_message})
+        messages.append(
+            {"role": "user", "content": STREAM_CHAT_USER_PROMPT.format(user_message=user_message)}
+        )
 
         try:
             response = await stream_chat(

--- a/backend/app/domain/memory/graph_service.py
+++ b/backend/app/domain/memory/graph_service.py
@@ -41,6 +41,10 @@ class GraphExtractionService:
     async def extract_graph_from_text(text: str) -> GraphExtractionSchema | None:
         """Use LLM structured output to extract graph nodes and edges from text."""
         try:
+            from app.domain.chat.prompts import (
+                GRAPH_EXTRACTION_SYSTEM_PROMPT,
+                GRAPH_EXTRACTION_USER_PROMPT,
+            )
             from app.infrastructure.external.openrouter import structured_completion
 
             # Using gpt-4o-mini for fast/cheap structured extraction
@@ -48,11 +52,11 @@ class GraphExtractionService:
                 messages=[
                     {
                         "role": "system",
-                        "content": "You are a knowledge graph extraction system. Extract key entities and relationships from the user's text. Be concise and precise. Focus on long-term facts, preferences, and relationships.",
+                        "content": GRAPH_EXTRACTION_SYSTEM_PROMPT,
                     },
                     {
                         "role": "user",
-                        "content": text,
+                        "content": GRAPH_EXTRACTION_USER_PROMPT.format(text=text),
                     },
                 ],
                 response_model=GraphExtractionSchema,

--- a/backend/app/domain/memory/graph_service.py
+++ b/backend/app/domain/memory/graph_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from uuid import UUID
 
@@ -56,7 +57,9 @@ class GraphExtractionService:
                     },
                     {
                         "role": "user",
-                        "content": GRAPH_EXTRACTION_USER_PROMPT.format(text=text),
+                        "content": GRAPH_EXTRACTION_USER_PROMPT.format(
+                            text=json.dumps(text, ensure_ascii=False)
+                        ),
                     },
                 ],
                 response_model=GraphExtractionSchema,


### PR DESCRIPTION
This PR refactors the AI integration layer to strictly adhere to the LLM Contract for prompt isolation. It moves all inline system prompts out of the service files (`agents`, `chat`, and `memory` domains) and centralizes them as constant templates in `app/domain/chat/prompts.py`. It also updates all templates to use robust, delimited blocks to separate system instructions from raw user input, heavily mitigating prompt injection risks. Unit tests have been verified locally.

---
*PR created automatically by Jules for task [17263886633635234039](https://jules.google.com/task/17263886633635234039) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and standardized prompt templates used across agents, chat, memory, graph extraction, streaming, mood classification, and background summary tasks for consistent assistant behavior.
  * Reworked how conversation history, memories, summaries, and latest user content are formatted and injected (clear labeled sections and JSON-safe serialization) to improve prompt consistency and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/655)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->