### PR TITLE
Refactor Agent Service to enforce strict Clean Architecture boundaries

### DIFF
--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from app.domain.agents.models import Agent, AgentIntegration, Capability, Integration
+from app.domain.agents.models import Agent, Capability, Integration
 from app.domain.agents.schemas import (
     AgentCreate,
     AgentGenerationResponse,
@@ -123,36 +123,21 @@ class AgentService:
             capability_ids=agent_data.capabilities,
         )
 
-        agent = await Agent.create(
+        agent_dict = {
+            "name": agent_data.name,
+            "personality": agent_data.personality,
+            "description": agent_data.description,
+            "goals": agent_data.goals,
+            "system_prompt": system_prompt,
+        }
+
+        refetched = await self.repo.create_agent(
+            agent_data=agent_dict,
             user_id=user_id,
-            name=agent_data.name,
-            personality=agent_data.personality,
-            description=agent_data.description,
-            goals=agent_data.goals,
-            system_prompt=system_prompt,
+            capability_ids=agent_data.capabilities,
+            integration_ids=agent_data.integrations,
+            integration_configs=agent_data.integration_configs,
         )
-
-        if agent_data.capabilities:
-            caps = await Capability.filter(id__in=agent_data.capabilities)
-            await agent.capabilities.add(*caps)
-
-        if agent_data.integrations:
-            integrations = await Integration.filter(id__in=agent_data.integrations)
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=agent_data.integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
-
-        # Refetch with relations so the response is fully populated.
-        refetched = await self.repo.get_by_id(agent.pk)
-        assert refetched is not None
         return _build_agent_response(refetched)
 
     async def list_agents(self, user_id: UUID) -> list[AgentResponse]:
@@ -192,36 +177,14 @@ class AgentService:
 
         fields = data.model_dump(exclude_none=True)
 
-        # --- capabilities ---
         new_capability_ids: list[str] | None = fields.pop("capabilities", None)
+        new_integration_ids: list[str] | None = fields.pop("integrations", None)
+        new_integration_configs: dict | None = fields.pop("integration_configs", None)
+
         if new_capability_ids is not None:
-            caps = await Capability.filter(id__in=new_capability_ids)
-            await agent.capabilities.clear()
-            if caps:
-                await agent.capabilities.add(*caps)
             effective_cap_ids = new_capability_ids
         else:
-            effective_cap_ids = [
-                str(c_id) for c_id in await agent.capabilities.all().values_list("id", flat=True)
-            ]
-
-        # --- integrations ---
-        new_integration_ids: list[str] | None = fields.pop("integrations", None)
-        new_integration_configs: dict = fields.pop("integration_configs", None) or {}
-        if new_integration_ids is not None:
-            await AgentIntegration.filter(agent=agent).delete()
-            integrations = await Integration.filter(id__in=new_integration_ids)
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=new_integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
+            effective_cap_ids = [str(c.pk) for c in agent.capabilities.related_objects]
 
         # Merge profile fields with current values so build_system_prompt has full context
         name = fields.get("name", agent.name)
@@ -238,7 +201,14 @@ class AgentService:
         )
         fields["system_prompt"] = updated_prompt
 
-        updated = await self.repo.update_agent(agent_id, user_id, **fields)
+        updated = await self.repo.update_agent(
+            agent_id,
+            user_id,
+            capability_ids=new_capability_ids,
+            integration_ids=new_integration_ids,
+            integration_configs=new_integration_configs,
+            **fields,
+        )
         if not updated:
             return None
         return _build_agent_response(updated)

--- a/backend/app/infrastructure/repositories/agent_repo.py
+++ b/backend/app/infrastructure/repositories/agent_repo.py
@@ -10,6 +10,7 @@ from tortoise.transactions import in_transaction
 
 from app.domain.agents.models import (
     Agent,
+    AgentIntegration,
     AgentTemplate,
     Capability,
     Integration,
@@ -57,6 +58,41 @@ class AgentRepository:
         await agent.save()
         return agent
 
+    async def create_agent(
+        self,
+        agent_data: dict,
+        user_id: UUID | str,
+        capability_ids: list[str] | None,
+        integration_ids: list[str] | None,
+        integration_configs: dict,
+    ) -> Agent:
+        """Create a new agent and its relationships."""
+        if isinstance(user_id, str):
+            user_id = UUID(user_id)
+        agent = await Agent.create(user_id=user_id, **agent_data)
+
+        if capability_ids:
+            caps = await Capability.filter(id__in=capability_ids)
+            await agent.capabilities.add(*caps)
+
+        if integration_ids:
+            integrations = await Integration.filter(id__in=integration_ids)
+            agent_integrations = [
+                AgentIntegration(
+                    agent=agent,
+                    integration=integration,
+                    config=integration_configs.get(str(integration.id), {}),
+                    enabled=True,
+                )
+                for integration in integrations
+            ]
+            if agent_integrations:
+                await AgentIntegration.bulk_create(agent_integrations)
+
+        refetched = await self.get_by_id(agent.pk)
+        assert refetched is not None
+        return refetched
+
     async def update_mood(self, agent_id: UUID | str, mood: str) -> None:
         """Update an agent's mood."""
         agent = await self.get_by_id(agent_id)
@@ -69,9 +105,15 @@ class AgentRepository:
     )
 
     async def update_agent(
-        self, agent_id: UUID | str, user_id: UUID | str, **fields: object
+        self,
+        agent_id: UUID | str,
+        user_id: UUID | str,
+        capability_ids: list[str] | None = None,
+        integration_ids: list[str] | None = None,
+        integration_configs: dict | None = None,
+        **fields: object,
     ) -> Agent | None:
-        """Update an agent's fields. Only updates the owner's agent."""
+        """Update an agent's fields and relationships. Only updates the owner's agent."""
         unknown = set(fields) - self._ALLOWED_AGENT_FIELDS
         if unknown:
             raise ValueError(f"update_agent received unknown fields: {unknown}")
@@ -79,15 +121,42 @@ class AgentRepository:
             agent_id = UUID(agent_id)
         if isinstance(user_id, str):
             user_id = UUID(user_id)
+
         agent = await Agent.get_or_none(id=agent_id, user_id=user_id).prefetch_related(
             "capabilities", "agent_integrations__integration"
         )
-        if agent:
-            for key, value in fields.items():
-                if value is not None:
-                    setattr(agent, key, value)
-            await agent.save()
-        return agent
+
+        if not agent:
+            return None
+
+        if capability_ids is not None:
+            caps = await Capability.filter(id__in=capability_ids)
+            await agent.capabilities.clear()
+            if caps:
+                await agent.capabilities.add(*caps)
+
+        if integration_ids is not None:
+            await AgentIntegration.filter(agent=agent).delete()
+            integrations = await Integration.filter(id__in=integration_ids)
+            configs = integration_configs or {}
+            agent_integrations = [
+                AgentIntegration(
+                    agent=agent,
+                    integration=integration,
+                    config=configs.get(str(integration.id), {}),
+                    enabled=True,
+                )
+                for integration in integrations
+            ]
+            if agent_integrations:
+                await AgentIntegration.bulk_create(agent_integrations)
+
+        for key, value in fields.items():
+            if value is not None:
+                setattr(agent, key, value)
+        await agent.save()
+
+        return await self.get_by_id(agent_id)
 
     async def delete_agent(self, agent_id: UUID | str, user_id: UUID | str) -> bool:
         """Soft-delete an agent by setting deleted_at. Only deletes the owner's agent."""

--- a/backend/app/infrastructure/repositories/agent_repo.py
+++ b/backend/app/infrastructure/repositories/agent_repo.py
@@ -64,30 +64,33 @@ class AgentRepository:
         user_id: UUID | str,
         capability_ids: list[str] | None,
         integration_ids: list[str] | None,
-        integration_configs: dict,
+        integration_configs: dict | None,
     ) -> Agent:
         """Create a new agent and its relationships."""
         if isinstance(user_id, str):
             user_id = UUID(user_id)
-        agent = await Agent.create(user_id=user_id, **agent_data)
 
-        if capability_ids:
-            caps = await Capability.filter(id__in=capability_ids)
-            await agent.capabilities.add(*caps)
+        async with in_transaction():
+            agent = await Agent.create(user_id=user_id, **agent_data)
 
-        if integration_ids:
-            integrations = await Integration.filter(id__in=integration_ids)
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
+            if capability_ids:
+                caps = await Capability.filter(id__in=capability_ids)
+                await agent.capabilities.add(*caps)
+
+            if integration_ids:
+                integrations = await Integration.filter(id__in=integration_ids)
+                configs = integration_configs or {}
+                agent_integrations = [
+                    AgentIntegration(
+                        agent=agent,
+                        integration=integration,
+                        config=configs.get(str(integration.id), {}),
+                        enabled=True,
+                    )
+                    for integration in integrations
+                ]
+                if agent_integrations:
+                    await AgentIntegration.bulk_create(agent_integrations)
 
         refetched = await self.get_by_id(agent.pk)
         assert refetched is not None
@@ -122,39 +125,40 @@ class AgentRepository:
         if isinstance(user_id, str):
             user_id = UUID(user_id)
 
-        agent = await Agent.get_or_none(id=agent_id, user_id=user_id).prefetch_related(
-            "capabilities", "agent_integrations__integration"
-        )
+        async with in_transaction():
+            agent = await Agent.get_or_none(id=agent_id, user_id=user_id).prefetch_related(
+                "capabilities", "agent_integrations__integration"
+            )
 
-        if not agent:
-            return None
+            if not agent:
+                return None
 
-        if capability_ids is not None:
-            caps = await Capability.filter(id__in=capability_ids)
-            await agent.capabilities.clear()
-            if caps:
-                await agent.capabilities.add(*caps)
+            if capability_ids is not None:
+                caps = await Capability.filter(id__in=capability_ids)
+                await agent.capabilities.clear()
+                if caps:
+                    await agent.capabilities.add(*caps)
 
-        if integration_ids is not None:
-            await AgentIntegration.filter(agent=agent).delete()
-            integrations = await Integration.filter(id__in=integration_ids)
-            configs = integration_configs or {}
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
+            if integration_ids is not None:
+                await AgentIntegration.filter(agent=agent).delete()
+                integrations = await Integration.filter(id__in=integration_ids)
+                configs = integration_configs or {}
+                agent_integrations = [
+                    AgentIntegration(
+                        agent=agent,
+                        integration=integration,
+                        config=configs.get(str(integration.id), {}),
+                        enabled=True,
+                    )
+                    for integration in integrations
+                ]
+                if agent_integrations:
+                    await AgentIntegration.bulk_create(agent_integrations)
 
-        for key, value in fields.items():
-            if value is not None:
-                setattr(agent, key, value)
-        await agent.save()
+            for key, value in fields.items():
+                if value is not None:
+                    setattr(agent, key, value)
+            await agent.save()
 
         return await self.get_by_id(agent_id)
 


### PR DESCRIPTION
### Violation Summary
The `AgentService` located in `backend/app/domain/agents/service.py` contained direct Tortoise ORM framework calls (`Agent.create()`, `Capability.filter()`, `AgentIntegration.bulk_create()`). This violates the "Clean Architecture Layer Contract", as the Domain Layer must be completely decoupled from Infrastructure implementation details.

### Architectural Note
All relational entity creation and updating logic was extracted from the Domain service and migrated into `AgentRepository` inside the Infrastructure layer. This ensures dependencies point strictly inward and that the application layer is shielded from ORM leakage. Effective capabilities are now mapped dynamically via prefetched `related_objects` to safely provide context to prompt builders.

---
*PR created automatically by Jules for task [13098358333953059944](https://jules.google.com/task/13098358333953059944) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved agent creation and update internals to centralize capability and integration handling, resulting in more reliable and consistent behavior when assigning capabilities and integrations.
  * No changes to public interfaces or user-facing settings; existing agent workflows remain unchanged.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/656)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->