### PR TITLE
Refactor AgentService to Enforce Clean Architecture via AgentRepository

### DIFF
--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from app.domain.agents.models import Agent, AgentIntegration, Capability, Integration
+from app.domain.agents.models import Agent, Capability, Integration
 from app.domain.agents.schemas import (
     AgentCreate,
     AgentGenerationResponse,
@@ -123,37 +123,11 @@ class AgentService:
             capability_ids=agent_data.capabilities,
         )
 
-        agent = await Agent.create(
-            user_id=user_id,
-            name=agent_data.name,
-            personality=agent_data.personality,
-            description=agent_data.description,
-            goals=agent_data.goals,
-            system_prompt=system_prompt,
-        )
+        fields = agent_data.model_dump()
+        fields["system_prompt"] = system_prompt
 
-        if agent_data.capabilities:
-            caps = await Capability.filter(id__in=agent_data.capabilities)
-            await agent.capabilities.add(*caps)
-
-        if agent_data.integrations:
-            integrations = await Integration.filter(id__in=agent_data.integrations)
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=agent_data.integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
-
-        # Refetch with relations so the response is fully populated.
-        refetched = await self.repo.get_by_id(agent.pk)
-        assert refetched is not None
-        return _build_agent_response(refetched)
+        agent = await self.repo.create_agent_with_relations(user_id, **fields)
+        return _build_agent_response(agent)
 
     async def list_agents(self, user_id: UUID) -> list[AgentResponse]:
         """List all agents for a user."""
@@ -192,38 +166,13 @@ class AgentService:
 
         fields = data.model_dump(exclude_none=True)
 
-        # --- capabilities ---
-        new_capability_ids: list[str] | None = fields.pop("capabilities", None)
+        # Rebuild system prompt if relations or profile fields change
+        new_capability_ids: list[str] | None = fields.get("capabilities")
         if new_capability_ids is not None:
-            caps = await Capability.filter(id__in=new_capability_ids)
-            await agent.capabilities.clear()
-            if caps:
-                await agent.capabilities.add(*caps)
             effective_cap_ids = new_capability_ids
         else:
-            effective_cap_ids = [
-                str(c_id) for c_id in await agent.capabilities.all().values_list("id", flat=True)
-            ]
+            effective_cap_ids = [str(cap.pk) for cap in agent.capabilities.related_objects]
 
-        # --- integrations ---
-        new_integration_ids: list[str] | None = fields.pop("integrations", None)
-        new_integration_configs: dict = fields.pop("integration_configs", None) or {}
-        if new_integration_ids is not None:
-            await AgentIntegration.filter(agent=agent).delete()
-            integrations = await Integration.filter(id__in=new_integration_ids)
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=new_integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
-
-        # Merge profile fields with current values so build_system_prompt has full context
         name = fields.get("name", agent.name)
         personality = fields.get("personality", agent.personality)
         description = fields.get("description", agent.description)
@@ -238,7 +187,7 @@ class AgentService:
         )
         fields["system_prompt"] = updated_prompt
 
-        updated = await self.repo.update_agent(agent_id, user_id, **fields)
+        updated = await self.repo.update_agent_with_relations(agent_id, user_id, **fields)
         if not updated:
             return None
         return _build_agent_response(updated)

--- a/backend/app/domain/chat/crew_orchestrator.py
+++ b/backend/app/domain/chat/crew_orchestrator.py
@@ -68,7 +68,7 @@ class CrewOrchestrator:
     """Handles the creation and execution of CrewAI tasks and agents."""
 
     @staticmethod
-    def get_crew_llm() -> _OpenRouterLLM:
+    def get_crew_llm() -> LLM:
         """Build a CrewAI LLM instance backed by OpenRouter."""
         settings = get_settings()
         return _OpenRouterLLM(

--- a/backend/app/infrastructure/repositories/agent_repo.py
+++ b/backend/app/infrastructure/repositories/agent_repo.py
@@ -10,6 +10,7 @@ from tortoise.transactions import in_transaction
 
 from app.domain.agents.models import (
     Agent,
+    AgentIntegration,
     AgentTemplate,
     Capability,
     Integration,
@@ -37,6 +38,45 @@ class AgentRepository:
         return await Agent.get_or_none(id=agent_id).prefetch_related(
             "capabilities", "agent_integrations__integration"
         )
+
+    async def create_agent_with_relations(self, user_id: UUID | str, **fields: object) -> Agent:
+        """Create a new agent with capabilities and integrations."""
+        if isinstance(user_id, str):
+            user_id = UUID(user_id)
+
+        capability_ids = fields.pop("capabilities", [])
+        integration_ids = fields.pop("integrations", [])
+        integration_configs = fields.pop("integration_configs", {})
+
+        # Ensure only allowed model fields remain in fields dict
+        model_fields = {k: v for k, v in fields.items() if k in self._ALLOWED_AGENT_FIELDS}
+        model_fields["user_id"] = user_id
+
+        async with in_transaction():
+            agent = await Agent.create(**model_fields)
+
+            if capability_ids:
+                caps = await Capability.filter(id__in=capability_ids)
+                await agent.capabilities.add(*caps)
+
+            if integration_ids:
+                integrations = await Integration.filter(id__in=integration_ids)
+                agent_integrations = [
+                    AgentIntegration(
+                        agent=agent,
+                        integration=integration,
+                        config=integration_configs.get(str(integration.id), {}),
+                        enabled=True,
+                    )
+                    for integration in integrations
+                ]
+                if agent_integrations:
+                    await AgentIntegration.bulk_create(agent_integrations)
+
+        # Explicitly refetch to eagerly load the M2M relations correctly
+        refetched = await self.get_by_id(agent.pk)
+        assert refetched is not None
+        return refetched
 
     async def list_by_user(self, user_id: UUID | str) -> list[Agent]:
         """List all agents for a user, excluding soft-deleted ones."""
@@ -88,6 +128,60 @@ class AgentRepository:
                     setattr(agent, key, value)
             await agent.save()
         return agent
+
+    async def update_agent_with_relations(
+        self, agent_id: UUID | str, user_id: UUID | str, **fields: object
+    ) -> Agent | None:
+        """Update an agent's fields, capabilities, and integrations."""
+        if isinstance(agent_id, str):
+            agent_id = UUID(agent_id)
+        if isinstance(user_id, str):
+            user_id = UUID(user_id)
+
+        new_capability_ids = fields.pop("capabilities", None)
+        new_integration_ids = fields.pop("integrations", None)
+        new_integration_configs = fields.pop("integration_configs", None) or {}
+
+        # Ensure only allowed fields remain for normal updates
+        unknown = set(fields) - self._ALLOWED_AGENT_FIELDS
+        if unknown:
+            raise ValueError(f"update_agent received unknown fields: {unknown}")
+
+        async with in_transaction():
+            agent = await Agent.get_or_none(id=agent_id, user_id=user_id).prefetch_related(
+                "capabilities", "agent_integrations__integration"
+            )
+            if not agent:
+                return None
+
+            if new_capability_ids is not None:
+                caps = await Capability.filter(id__in=new_capability_ids)
+                await agent.capabilities.clear()
+                if caps:
+                    await agent.capabilities.add(*caps)
+
+            if new_integration_ids is not None:
+                await AgentIntegration.filter(agent=agent).delete()
+                integrations = await Integration.filter(id__in=new_integration_ids)
+                agent_integrations = [
+                    AgentIntegration(
+                        agent=agent,
+                        integration=integration,
+                        config=new_integration_configs.get(str(integration.id), {}),
+                        enabled=True,
+                    )
+                    for integration in integrations
+                ]
+                if agent_integrations:
+                    await AgentIntegration.bulk_create(agent_integrations)
+
+            for key, value in fields.items():
+                if value is not None:
+                    setattr(agent, key, value)
+            await agent.save()
+
+        # Explicitly refetch to eagerly load the M2M relations correctly
+        return await self.get_by_id(agent.pk)
 
     async def delete_agent(self, agent_id: UUID | str, user_id: UUID | str) -> bool:
         """Soft-delete an agent by setting deleted_at. Only deletes the owner's agent."""

--- a/backend/app/infrastructure/repositories/agent_repo.py
+++ b/backend/app/infrastructure/repositories/agent_repo.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from datetime import UTC, datetime
+from typing import Any
 from uuid import UUID
 
 from tortoise.transactions import in_transaction
@@ -39,7 +40,7 @@ class AgentRepository:
             "capabilities", "agent_integrations__integration"
         )
 
-    async def create_agent_with_relations(self, user_id: UUID | str, **fields: object) -> Agent:
+    async def create_agent_with_relations(self, user_id: UUID | str, **fields: Any) -> Agent:
         """Create a new agent with capabilities and integrations."""
         if isinstance(user_id, str):
             user_id = UUID(user_id)
@@ -109,7 +110,7 @@ class AgentRepository:
     )
 
     async def update_agent(
-        self, agent_id: UUID | str, user_id: UUID | str, **fields: object
+        self, agent_id: UUID | str, user_id: UUID | str, **fields: Any
     ) -> Agent | None:
         """Update an agent's fields. Only updates the owner's agent."""
         unknown = set(fields) - self._ALLOWED_AGENT_FIELDS
@@ -130,7 +131,7 @@ class AgentRepository:
         return agent
 
     async def update_agent_with_relations(
-        self, agent_id: UUID | str, user_id: UUID | str, **fields: object
+        self, agent_id: UUID | str, user_id: UUID | str, **fields: Any
     ) -> Agent | None:
         """Update an agent's fields, capabilities, and integrations."""
         if isinstance(agent_id, str):

--- a/backend/tests/agents/test_agent_lifecycle.py
+++ b/backend/tests/agents/test_agent_lifecycle.py
@@ -164,7 +164,7 @@ async def test_update_agent_repo_returns_none():
     user_id = get_deterministic_uuid()
     agent_data = AgentCreate(name="Test Agent", personality="Helpful")
     initial_agent = await service.create_agent(agent_data, user_id)
-    with patch.object(repo, "update_agent", new_callable=AsyncMock) as mock_update:
+    with patch.object(repo, "update_agent_with_relations", new_callable=AsyncMock) as mock_update:
         mock_update.return_value = None
         update_data = AgentUpdate(name="Updated Agent")
         response = await service.update_agent(str(initial_agent.id), user_id, update_data)


### PR DESCRIPTION
**Violation Summary**: The `AgentService` in the Application layer contained direct imports and execution of Infrastructure/ORM logic (`Agent.create`, `AgentIntegration.bulk_create`, `Capability.filter`, etc). This violated the Dependency Inversion principle and Clean Architecture layer contracts.

**Architectural Note**: This move satisfies the Layer Contract by shifting direct data access, active record operations, and Many-To-Many relationship handling out of the Application layer (`service.py`) and into the Infrastructure layer (`agent_repo.py`), ensuring that domain services interact purely with domain models and repository interfaces. The use of transaction blocks inside the repository further safeguards data integrity without leaking database concerns into the business logic.

---
*PR created automatically by Jules for task [9589607281260205263](https://jules.google.com/task/9589607281260205263) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Agent creation and update now handle capabilities and integrations together in a single, atomic operation, improving data consistency and ensuring linked agent data and prompts stay in sync.

* **Tests**
  * Tests updated to reflect the consolidated agent operations and to validate behavior when an agent update yields no result.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/669)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->