### PR TITLE
Refactor ProductivityScreen using ViewModel and Sub-Widgets

### DIFF
--- a/frontend/app/(main)/productivity.tsx
+++ b/frontend/app/(main)/productivity.tsx
@@ -1,8 +1,7 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback } from 'react';
 import {
-  Alert,
   FlatList,
-  Platform,
+
   Pressable,
   RefreshControl,
   StyleSheet,
@@ -11,17 +10,17 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { useLocalSearchParams, usePathname, useRouter } from 'expo-router';
-import { useTranslation } from 'react-i18next';
+
 import { AppText } from '../../src/components/AppText';
 import { CreateNoteModal } from '../../src/components/productivity/CreateNoteModal';
 import { CreateTaskModal } from '../../src/components/productivity/CreateTaskModal';
 import { NoteCard } from '../../src/components/productivity/NoteCard';
 import { TaskCard } from '../../src/components/productivity/TaskCard';
+import { ProductivityEmptyState } from '../../src/components/productivity/ProductivityEmptyState';
 import { theme } from '../../src/core/theme';
 import { CalendarEvent, Note, Task } from '../../src/core/models';
-import { useProductivityStore } from '../../src/store/useProductivityStore';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
+import { RenderItemData, useProductivityViewModel } from '@/hooks/viewmodels/useProductivityViewModel';
 
 const T = {
   background: { light: DESIGN_TOKENS.colors.pageBg },
@@ -42,338 +41,103 @@ const T = {
 const S = theme.spacing;
 const R = theme.borderRadius;
 
-type Tab = 'today' | 'all' | 'notes' | 'tasks';
-type TaskPriority = 'all' | 'overdue' | 'today' | 'upcoming' | 'no_due';
+const renderItem = ({
+  item,
+  extraData,
+}: {
+  item: RenderItemData;
+  extraData: {
+    confirmDelete: (action: () => Promise<void>) => void;
+    deleteNote: (id: string) => Promise<void>;
+    deleteTask: (id: string) => Promise<void>;
+    toggleTask: (id: string) => Promise<void>;
+    language: string;
+  };
+}) => {
+  if (item.type === 'note') {
+    const note = item.item as Note;
+    return (
+      <NoteCard
+        note={note}
+        onDelete={() => extraData.confirmDelete(() => extraData.deleteNote(note.id))}
+      />
+    );
+  }
+  if (item.type === 'event') {
+    const event = item.item as CalendarEvent;
+    return (
+      <View style={styles.eventCard}>
+        <View style={styles.eventIcon}>
+          <Ionicons name="calendar-outline" size={16} color={T.primary.DEFAULT} />
+        </View>
+        <View style={styles.eventBody}>
+          <AppText style={styles.eventTitle}>{event.title}</AppText>
+          <AppText style={styles.eventMeta}>
+            {new Intl.DateTimeFormat(extraData.language, {
+              weekday: 'short',
+              month: 'short',
+              day: 'numeric',
+              hour: event.is_all_day ? undefined : '2-digit',
+              minute: event.is_all_day ? undefined : '2-digit',
+            }).format(new Date(event.start_time))}
+          </AppText>
+        </View>
+      </View>
+    );
+  }
 
-type RenderItemData = {
-  date?: number;
-  type: 'note' | 'task' | 'event';
-  item: Note | Task | CalendarEvent;
-  id: string;
+  const task = item.item as Task;
+  return (
+    <TaskCard
+      task={task}
+      onToggle={() => extraData.toggleTask(task.id)}
+      onDelete={() => extraData.confirmDelete(() => extraData.deleteTask(task.id))}
+    />
+  );
 };
 
 export default function ProductivityScreen() {
-  const { t, i18n } = useTranslation();
-  const router = useRouter();
-  const pathname = usePathname();
-  const params = useLocalSearchParams() as Record<string, string | string[] | undefined>;
-  const openCreateTask = params.openCreateTask;
-  const openCreateNote = params.openCreateNote;
-  const [activeTab, setActiveTab] = useState<Tab>('today');
-  const [taskPriority, setTaskPriority] = useState<TaskPriority>('all');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [showCreateNote, setShowCreateNote] = useState(false);
-  const [showCreateTask, setShowCreateTask] = useState(false);
-  const [todayPlan, setTodayPlan] = useState<string | null>(null);
-
   const {
-    notes,
-    tasks,
-    events,
+    t,
+    i18n,
+    activeTab,
+    setActiveTab,
+    taskPriority,
+    setTaskPriority,
+    searchQuery,
+    setSearchQuery,
+    showCreateNote,
+    setShowCreateNote,
+    showCreateTask,
+    setShowCreateTask,
+    todayPlan,
+    setTodayPlan,
+    dataToRender,
+    isLoading,
+    pendingTasksCount,
+    taskPriorityCounts,
+    confirmDelete,
+    generateTodayPlan,
+    handleRefresh,
     fetchNotes,
     fetchTasks,
-    fetchEvents,
-    isLoading,
     deleteNote,
     deleteTask,
     toggleTask,
-  } = useProductivityStore();
+  } = useProductivityViewModel();
 
-  useEffect(() => {
-    const controller = new AbortController();
-    fetchNotes(controller.signal);
-    fetchTasks(controller.signal);
-    fetchEvents(controller.signal);
-    return () => {
-      controller.abort();
-    };
-  }, [fetchEvents, fetchNotes, fetchTasks]);
-
-  useEffect(() => {
-    if (openCreateTask === '1' || openCreateTask === 'true') {
-      setShowCreateTask(true);
-      const nextParams = Object.fromEntries(
-        Object.entries(params).filter(
-          ([key, value]) => key !== 'openCreateTask' && typeof value === 'string'
-        )
-      );
-      router.replace({ pathname, params: nextParams });
-    }
-  }, [openCreateTask, params, pathname, router]);
-
-  useEffect(() => {
-    if (openCreateNote === '1' || openCreateNote === 'true') {
-      setShowCreateNote(true);
-      const nextParams = Object.fromEntries(
-        Object.entries(params).filter(
-          ([key, value]) => key !== 'openCreateNote' && typeof value === 'string'
-        )
-      );
-      router.replace({ pathname, params: nextParams });
-    }
-  }, [openCreateNote, params, pathname, router]);
-
-  const handleRefresh = useCallback(() => {
-    fetchNotes();
-    fetchTasks();
-    fetchEvents();
-  }, [fetchEvents, fetchNotes, fetchTasks]);
-
-  const confirmDelete = useCallback(
-    (action: () => Promise<void>) =>
-      Alert.alert(
-        t('productivity.delete') || 'Delete',
-        t('productivity.are_you_sure') || 'Are you sure?',
-        [
-          { text: t('settings.actions.cancel') || 'Cancel', style: 'cancel' },
-          {
-            text: t('settings.actions.delete') || 'Delete',
-            style: 'destructive',
-            onPress: () => action(),
-          },
-        ]
-      ),
-    [t]
-  );
-
-  const filteredNotes = useMemo(() => {
-    if (!searchQuery) return notes;
-    const lowerQ = searchQuery.toLowerCase();
-    return notes.filter(
-      (n) => n.title.toLowerCase().includes(lowerQ) || n.content.toLowerCase().includes(lowerQ)
-    );
-  }, [notes, searchQuery]);
-
-  const filteredTasks = useMemo(() => {
-    if (!searchQuery) return tasks;
-    const lowerQ = searchQuery.toLowerCase();
-    return tasks.filter(
-      (task) =>
-        task.title.toLowerCase().includes(lowerQ) ||
-        (task.description?.toLowerCase().includes(lowerQ) ?? false)
-    );
-  }, [searchQuery, tasks]);
-
-  const filteredEvents = useMemo(() => {
-    if (!searchQuery) return events;
-    const lowerQ = searchQuery.toLowerCase();
-    return events.filter(
-      (event) =>
-        event.title.toLowerCase().includes(lowerQ) ||
-        (event.description?.toLowerCase().includes(lowerQ) ?? false) ||
-        (event.location?.toLowerCase().includes(lowerQ) ?? false)
-    );
-  }, [events, searchQuery]);
-
-  const pendingTasksCount = useMemo(
-    () => filteredTasks.filter((task) => !task.completed).length,
-    [filteredTasks]
-  );
-
-  const getTaskPriority = useCallback((task: Task): Exclude<TaskPriority, 'all'> => {
-    if (!task.due_date) return 'no_due';
-    const now = new Date();
-    const due = new Date(task.due_date);
-    if (isNaN(due.getTime())) return 'no_due';
-    const dayStart = new Date(now);
-    dayStart.setHours(0, 0, 0, 0);
-    const tomorrow = new Date(dayStart);
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    if (due < dayStart) return 'overdue';
-    if (due >= dayStart && due < tomorrow) return 'today';
-    return 'upcoming';
-  }, []);
-
-  const taskPriorityCounts = useMemo(() => {
-    const counts: Record<TaskPriority, number> = {
-      all: 0,
-      overdue: 0,
-      today: 0,
-      upcoming: 0,
-      no_due: 0,
-    };
-    filteredTasks
-      .filter((task) => !task.completed)
-      .forEach((task) => {
-        counts.all += 1;
-        counts[getTaskPriority(task)] += 1;
-      });
-    return counts;
-  }, [filteredTasks, getTaskPriority]);
-
-  const prioritizedTasks = useMemo(() => {
-    const tasksToRank = filteredTasks.filter((task) => !task.completed);
-    const pool =
-      taskPriority === 'all'
-        ? tasksToRank
-        : tasksToRank.filter((task) => getTaskPriority(task) === taskPriority);
-    return [...pool].sort((a, b) => {
-      const aDue = a.due_date ? new Date(a.due_date).getTime() : Number.MAX_SAFE_INTEGER;
-      const bDue = b.due_date ? new Date(b.due_date).getTime() : Number.MAX_SAFE_INTEGER;
-      return aDue - bDue;
-    });
-  }, [filteredTasks, getTaskPriority, taskPriority]);
-
-  const mixedData = useMemo(() => {
-    const data: RenderItemData[] = [];
-    filteredNotes.forEach((note) => {
-      data.push({
-        type: 'note',
-        item: note,
-        id: `note-${note.id}`,
-        date: new Date(note.created_at).getTime(),
-      });
-    });
-    filteredTasks.forEach((task) => {
-      data.push({
-        type: 'task',
-        item: task,
-        id: `task-${task.id}`,
-        date: new Date(task.created_at).getTime(),
-      });
-    });
-    return data.sort((a, b) => (b.date || 0) - (a.date || 0));
-  }, [filteredNotes, filteredTasks]);
-
-  const todayData = useMemo(() => {
-    const now = new Date();
-    const start = new Date(now);
-    start.setHours(0, 0, 0, 0);
-    const end = new Date(start);
-    end.setDate(end.getDate() + 1);
-    const weekEnd = new Date(start);
-    weekEnd.setDate(weekEnd.getDate() + 7);
-
-    const overdueTasks = filteredTasks.filter((task) => {
-      if (task.completed || !task.due_date) return false;
-      return new Date(task.due_date) < start;
-    });
-
-    const dueTodayTasks = filteredTasks.filter((task) => {
-      if (task.completed || !task.due_date) return false;
-      const dueDate = new Date(task.due_date);
-      return dueDate >= start && dueDate < end;
-    });
-
-    const upcomingEvents = filteredEvents.filter((event) => {
-      const startTime = new Date(event.start_time);
-      return startTime >= start && startTime < weekEnd;
-    });
-
-    const items: RenderItemData[] = [
-      ...overdueTasks.map((task) => ({
-        type: 'task' as const,
-        item: task,
-        id: `overdue-${task.id}`,
-        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
-      })),
-      ...dueTodayTasks.map((task) => ({
-        type: 'task' as const,
-        item: task,
-        id: `today-${task.id}`,
-        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
-      })),
-      ...upcomingEvents.map((event) => ({
-        type: 'event' as const,
-        item: event,
-        id: `event-${event.id}`,
-        date: new Date(event.start_time).getTime(),
-      })),
-    ];
-
-    return items.sort((a, b) => (a.date || 0) - (b.date || 0));
-  }, [filteredEvents, filteredTasks]);
-
-  const dataToRender: RenderItemData[] =
-    activeTab === 'today'
-      ? todayData.filter((entry) => {
-          if (entry.type !== 'task') return true;
-          if (taskPriority === 'all') return true;
-          return getTaskPriority(entry.item as Task) === taskPriority;
-        })
-      : activeTab === 'all'
-        ? mixedData
-        : activeTab === 'notes'
-          ? filteredNotes.map((note) => ({ type: 'note' as const, item: note, id: note.id }))
-          : prioritizedTasks.map((task) => ({ type: 'task' as const, item: task, id: task.id }));
-
-  const generateTodayPlan = useCallback(() => {
-    const now = new Date();
-    const nextTasks = prioritizedTasks.slice(0, 3);
-    const nextEvents = [...filteredEvents]
-      .filter((event) => new Date(event.end_time) >= now)
-      .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime())
-      .slice(0, 3);
-
-    const lines: string[] = [];
-    if (taskPriorityCounts.overdue > 0) {
-      lines.push(`1) Recover overdue: start with ${taskPriorityCounts.overdue} overdue task(s).`);
-    } else {
-      lines.push('1) No overdue tasks: start with highest-impact open work.');
-    }
-
-    if (nextTasks.length > 0) {
-      lines.push(`2) Focus block: ${nextTasks.map((task) => task.title).join(', ')}.`);
-    } else {
-      lines.push('2) Focus block: no pending tasks, use this for planning or review.');
-    }
-
-    if (nextEvents.length > 0) {
-      const eventLine = nextEvents
-        .map((event) =>
-          new Intl.DateTimeFormat(i18n.language, {
-            hour: '2-digit',
-            minute: '2-digit',
-          }).format(new Date(event.start_time))
-        )
-        .join(', ');
-      lines.push(`3) Calendar checkpoints at ${eventLine}.`);
-    } else {
-      lines.push('3) Calendar is light: reserve time for deep work and wrap-up.');
-    }
-
-    setTodayPlan(lines.join('\n'));
-    setActiveTab('today');
-  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue]);
-
-  const renderItem = useCallback(
-    ({ item }: { item: RenderItemData }) => {
-      if (item.type === 'note') {
-        const note = item.item as Note;
-        return <NoteCard note={note} onDelete={() => confirmDelete(() => deleteNote(note.id))} />;
-      }
-      if (item.type === 'event') {
-        const event = item.item as CalendarEvent;
-        return (
-          <View style={styles.eventCard}>
-            <View style={styles.eventIcon}>
-              <Ionicons name="calendar-outline" size={16} color={T.primary.DEFAULT} />
-            </View>
-            <View style={styles.eventBody}>
-              <AppText style={styles.eventTitle}>{event.title}</AppText>
-              <AppText style={styles.eventMeta}>
-                {new Intl.DateTimeFormat(i18n.language, {
-                  weekday: 'short',
-                  month: 'short',
-                  day: 'numeric',
-                  hour: event.is_all_day ? undefined : '2-digit',
-                  minute: event.is_all_day ? undefined : '2-digit',
-                }).format(new Date(event.start_time))}
-              </AppText>
-            </View>
-          </View>
-        );
-      }
-
-      const task = item.item as Task;
-      return (
-        <TaskCard
-          task={task}
-          onToggle={() => toggleTask(task.id)}
-          onDelete={() => confirmDelete(() => deleteTask(task.id))}
-        />
-      );
-    },
+  const renderItemWrapper = useCallback(
+    ({ item }: { item: RenderItemData }) =>
+      renderItem({
+        item,
+        extraData: {
+          confirmDelete,
+          deleteNote,
+          deleteTask,
+          toggleTask,
+          language: i18n.language,
+        },
+      }),
     [confirmDelete, deleteNote, deleteTask, i18n.language, toggleTask]
   );
 
@@ -458,14 +222,7 @@ export default function ProductivityScreen() {
       </View>
 
       {(activeTab === 'tasks' || activeTab === 'today') && (
-        <View
-          style={{
-            flexDirection: 'row',
-            flexWrap: 'wrap',
-            marginHorizontal: S.xl,
-            marginBottom: S.sm,
-          }}
-        >
+        <View style={styles.priorityFilterContainer}>
           {(
             [
               { key: 'all', label: t('productivity.priority.all', { count: taskPriorityCounts.all }) },
@@ -491,26 +248,19 @@ export default function ProductivityScreen() {
               key={option.key}
               onPress={() => setTaskPriority(option.key)}
               style={({ pressed }) => [
-                {
-                  borderRadius: 12,
-                  borderWidth: 1,
-                  borderColor: taskPriority === option.key ? T.primary.DEFAULT : T.border.light,
-                  backgroundColor:
-                    taskPriority === option.key ? T.primary.surfaceLight : T.surface.light,
-                  paddingHorizontal: 10,
-                  paddingVertical: 6,
-                  marginRight: 8,
-                  marginBottom: 8,
-                },
+                styles.priorityPillBase,
+                taskPriority === option.key ? styles.priorityPillActive : styles.priorityPillInactive,
                 pressed && { opacity: 0.8 },
               ]}
             >
               <AppText
                 variant="caption"
-                style={{
-                  color: taskPriority === option.key ? T.primary.DEFAULT : T.onSurface.mutedLight,
-                  fontWeight: '700',
-                }}
+                style={[
+                  styles.priorityPillTextBase,
+                  taskPriority === option.key
+                    ? styles.priorityPillTextActive
+                    : styles.priorityPillTextInactive,
+                ]}
               >
                 {option.label}
               </AppText>
@@ -521,6 +271,7 @@ export default function ProductivityScreen() {
 
       <FlatList
         data={dataToRender}
+        extraData={{ confirmDelete, deleteNote, deleteTask, toggleTask, language: i18n.language }}
         keyExtractor={(item) => item.id}
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
@@ -531,120 +282,27 @@ export default function ProductivityScreen() {
             tintColor={T.primary.DEFAULT}
           />
         }
-        renderItem={renderItem}
+        renderItem={renderItemWrapper}
         ListHeaderComponent={
           activeTab === 'today' && todayPlan ? (
-            <View
-              style={{
-                borderRadius: R.xl,
-                backgroundColor: T.primary.surfaceLight,
-                borderWidth: 1,
-                borderColor: T.border.light,
-                padding: S.lg,
-                marginBottom: S.md,
-              }}
-            >
-              <View
-                style={{
-                  flexDirection: 'row',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                }}
-              >
-                <AppText style={{ color: T.onSurface.light, fontWeight: '700', fontSize: 15 }}>
-                  Today plan
-                </AppText>
+            <View style={styles.todayPlanContainer}>
+              <View style={styles.todayPlanHeader}>
+                <AppText style={styles.todayPlanTitle}>Today plan</AppText>
                 <Pressable onPress={() => setTodayPlan(null)}>
                   <Ionicons name="close" size={16} color={T.onSurface.mutedLight} />
                 </Pressable>
               </View>
-              <AppText style={{ color: T.onSurface.mutedLight, marginTop: 8, lineHeight: 20 }}>
-                {todayPlan}
-              </AppText>
+              <AppText style={styles.todayPlanText}>{todayPlan}</AppText>
             </View>
           ) : null
         }
         ListEmptyComponent={
-          <View style={styles.emptyContainer}>
-            <View style={styles.emptyIconCircle}>
-              <Ionicons
-                name={
-                  activeTab === 'notes'
-                    ? 'document-text'
-                    : activeTab === 'tasks'
-                      ? 'checkbox'
-                      : activeTab === 'today'
-                        ? 'sunny-outline'
-                        : 'planet'
-                }
-                size={42}
-                color={T.primary.DEFAULT}
-              />
-            </View>
-            <AppText variant="h3" style={styles.emptyTitle}>
-              {searchQuery
-                ? t('productivity.no_matches') || 'No matches found'
-                : activeTab === 'notes'
-                  ? t('productivity.no_notes') || 'No Notes'
-                  : activeTab === 'tasks'
-                    ? t('productivity.no_tasks') || 'No Tasks'
-                    : activeTab === 'today'
-                      ? t('productivity.nothing_urgent_today')
-                      : t('productivity.workspace_clear') || 'Your workspace is clear'}
-            </AppText>
-            <AppText style={styles.emptySubtitle}>
-              {searchQuery
-                ? t('productivity.try_adjust_search') || 'Try adjusting your search terms.'
-                : activeTab === 'today'
-                  ? t('productivity.today_empty_detail')
-                  : t('productivity.capture_thoughts') ||
-                    'Capture your thoughts and track what needs to get done.'}
-            </AppText>
-
-            {!searchQuery && (
-              <View style={styles.emptyActions}>
-                {(activeTab === 'all' || activeTab === 'notes') && (
-                  <Pressable
-                    onPress={() => setShowCreateNote(true)}
-                    style={({ pressed }) => [styles.emptyButton, pressed && { opacity: 0.8 }]}
-                  >
-                    <Ionicons name="add" size={18} color={T.white} style={{ marginEnd: 6 }} />
-                    <AppText style={styles.emptyButtonText}>
-                      {t('productivity.newNote') || 'New Note'}
-                    </AppText>
-                  </Pressable>
-                )}
-                {(activeTab === 'all' || activeTab === 'tasks' || activeTab === 'today') && (
-                  <Pressable
-                    onPress={() => setShowCreateTask(true)}
-                    style={({ pressed }) => [
-                      styles.emptyButton,
-                      (activeTab === 'all' || activeTab === 'today') && styles.emptyButtonSecondary,
-                      pressed && { opacity: 0.8 },
-                    ]}
-                  >
-                    <Ionicons
-                      name="add"
-                      size={18}
-                      color={
-                        activeTab === 'all' || activeTab === 'today' ? T.primary.DEFAULT : T.white
-                      }
-                      style={{ marginEnd: 6 }}
-                    />
-                    <AppText
-                      style={
-                        activeTab === 'all' || activeTab === 'today'
-                          ? styles.emptyButtonTextSecondary
-                          : styles.emptyButtonText
-                      }
-                    >
-                      {t('productivity.new_task')}
-                    </AppText>
-                  </Pressable>
-                )}
-              </View>
-            )}
-          </View>
+          <ProductivityEmptyState
+            activeTab={activeTab}
+            searchQuery={searchQuery}
+            setShowCreateNote={setShowCreateNote}
+            setShowCreateTask={setShowCreateTask}
+          />
         }
       />
 
@@ -754,6 +412,60 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     color: T.onSurface.light,
   },
+  priorityFilterContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginHorizontal: S.xl,
+    marginBottom: S.sm,
+  },
+  priorityPillBase: {
+    borderRadius: 12,
+    borderWidth: 1,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    marginRight: 8,
+    marginBottom: 8,
+  },
+  priorityPillActive: {
+    borderColor: T.primary.DEFAULT,
+    backgroundColor: T.primary.surfaceLight,
+  },
+  priorityPillInactive: {
+    borderColor: T.border.light,
+    backgroundColor: T.surface.light,
+  },
+  priorityPillTextBase: {
+    fontWeight: '700',
+  },
+  priorityPillTextActive: {
+    color: T.primary.DEFAULT,
+  },
+  priorityPillTextInactive: {
+    color: T.onSurface.mutedLight,
+  },
+  todayPlanContainer: {
+    borderRadius: R.xl,
+    backgroundColor: T.primary.surfaceLight,
+    borderWidth: 1,
+    borderColor: T.border.light,
+    padding: S.lg,
+    marginBottom: S.md,
+  },
+  todayPlanHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  todayPlanTitle: {
+    color: T.onSurface.light,
+    fontWeight: '700',
+    fontSize: 15,
+  },
+  todayPlanText: {
+    color: T.onSurface.mutedLight,
+    marginTop: 8,
+    lineHeight: 20,
+  },
   listContent: {
     paddingHorizontal: S.xl,
     paddingBottom: 100,
@@ -791,68 +503,5 @@ const styles = StyleSheet.create({
     color: T.onSurface.mutedLight,
     marginTop: 2,
     fontSize: 13,
-  },
-  emptyContainer: {
-    alignItems: 'center',
-    paddingVertical: S.massive,
-  },
-  emptyIconCircle: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: S.lg,
-  },
-  emptyTitle: {
-    marginBottom: S.sm,
-    textAlign: 'center',
-    color: T.onSurface.light,
-  },
-  emptySubtitle: {
-    textAlign: 'center',
-    marginBottom: S.xl,
-    color: T.onSurface.mutedLight,
-    paddingHorizontal: S.xxxl,
-    lineHeight: 22,
-  },
-  emptyActions: {
-    flexDirection: 'row',
-    gap: S.md,
-  },
-  emptyButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.primary.DEFAULT,
-    borderRadius: R.xl,
-    paddingVertical: S.md,
-    paddingHorizontal: S.xl,
-    ...theme.elevation.md,
-  },
-  emptyButtonSecondary: {
-    backgroundColor: T.primary.surfaceLight,
-    ...Platform.select({
-      ios: {
-        shadowOpacity: 0,
-        elevation: 0,
-      },
-      android: {
-        elevation: 0,
-      },
-      default: {
-        elevation: 0,
-      },
-    }),
-  },
-  emptyButtonText: {
-    color: T.white,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-  emptyButtonTextSecondary: {
-    color: T.primary.DEFAULT,
-    fontWeight: '700',
-    fontSize: 15,
   },
 });

--- a/frontend/app/(main)/productivity.tsx
+++ b/frontend/app/(main)/productivity.tsx
@@ -1,23 +1,19 @@
 import React, { useCallback } from 'react';
 import {
   FlatList,
-
   Pressable,
   RefreshControl,
-  StyleSheet,
   TextInput,
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-
 import { AppText } from '../../src/components/AppText';
 import { CreateNoteModal } from '../../src/components/productivity/CreateNoteModal';
 import { CreateTaskModal } from '../../src/components/productivity/CreateTaskModal';
 import { NoteCard } from '../../src/components/productivity/NoteCard';
 import { TaskCard } from '../../src/components/productivity/TaskCard';
 import { ProductivityEmptyState } from '../../src/components/productivity/ProductivityEmptyState';
-import { theme } from '../../src/core/theme';
 import { CalendarEvent, Note, Task } from '../../src/core/models';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
 import { RenderItemData, useProductivityViewModel } from '@/hooks/viewmodels/useProductivityViewModel';
@@ -38,8 +34,6 @@ const T = {
   white: '#FFFFFF',
   transparent: 'transparent',
 };
-const S = theme.spacing;
-const R = theme.borderRadius;
 
 const renderItem = ({
   item,
@@ -66,13 +60,13 @@ const renderItem = ({
   if (item.type === 'event') {
     const event = item.item as CalendarEvent;
     return (
-      <View style={styles.eventCard}>
-        <View style={styles.eventIcon}>
+      <View className="flex-row items-center bg-surface-light border border-border-light rounded-xl p-lg mb-md shadow-sm">
+        <View className="w-8 h-8 rounded-lg bg-primary-surfaceLight items-center justify-center mr-md">
           <Ionicons name="calendar-outline" size={16} color={T.primary.DEFAULT} />
         </View>
-        <View style={styles.eventBody}>
-          <AppText style={styles.eventTitle}>{event.title}</AppText>
-          <AppText style={styles.eventMeta}>
+        <View className="flex-1">
+          <AppText className="text-onSurface-light font-bold text-[15px]">{event.title}</AppText>
+          <AppText className="text-onSurface-mutedLight mt-0.5 text-[13px]">
             {new Intl.DateTimeFormat(extraData.language, {
               weekday: 'short',
               month: 'short',
@@ -142,14 +136,14 @@ export default function ProductivityScreen() {
   );
 
   return (
-    <SafeAreaView style={styles.container}>
-      <View style={styles.headerContainer}>
-        <View style={styles.headerRow}>
+    <SafeAreaView className="flex-1 bg-background-light">
+      <View className="px-xl pt-md pb-lg bg-surface-light shadow-sm z-10">
+        <View className="flex-row justify-between items-center mb-lg">
           <View>
-            <AppText variant="h1" style={styles.headerTitle}>
+            <AppText variant="h1" className="text-onSurface-light text-[28px] font-extrabold tracking-tight">
               {t('productivity.title') || 'Workspace'}
             </AppText>
-            <AppText style={styles.headerSubtitle}>
+            <AppText className="text-onSurface-mutedLight text-[14px] mt-xs">
               {pendingTasksCount === 0
                 ? t('productivity.header.subtitle.empty') || "You're all caught up for today."
                 : t('productivity.header.subtitle.pending', { count: pendingTasksCount }) ||
@@ -157,60 +151,56 @@ export default function ProductivityScreen() {
             </AppText>
           </View>
 
-          <View style={styles.headerActions}>
+          <View className="flex-row gap-sm">
             <Pressable
               onPress={generateTodayPlan}
-              style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
+              className="w-10 h-10 rounded-full bg-primary-surfaceLight items-center justify-center active:opacity-70"
             >
               <Ionicons name="sparkles" size={20} color={T.primary.DEFAULT} />
             </Pressable>
             <Pressable
               onPress={() => setShowCreateNote(true)}
-              style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
+              className="w-10 h-10 rounded-full bg-primary-surfaceLight items-center justify-center active:opacity-70"
             >
               <Ionicons name="document-text" size={20} color={T.primary.DEFAULT} />
             </Pressable>
             <Pressable
               onPress={() => setShowCreateTask(true)}
-              style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
+              className="w-10 h-10 rounded-full bg-primary-surfaceLight items-center justify-center active:opacity-70"
             >
               <Ionicons name="checkbox" size={20} color={T.primary.DEFAULT} />
             </Pressable>
           </View>
         </View>
 
-        <View style={styles.searchContainer}>
+        <View className="flex-row items-center bg-background-light rounded-lg px-md h-11 border border-border-light">
           <Ionicons
             name="search"
             size={18}
             color={T.onSurface.mutedLight}
-            style={styles.searchIcon}
+            style={{ marginRight: 8 }}
           />
           <TextInput
             value={searchQuery}
             onChangeText={setSearchQuery}
             placeholder={t('productivity.search') || 'Search notes & tasks...'}
             placeholderTextColor={T.onSurface.disabledLight}
-            style={styles.searchInput}
+            className="flex-1 text-onSurface-light text-[16px] h-full"
             clearButtonMode="while-editing"
           />
         </View>
       </View>
 
-      <View style={styles.tabsContainer}>
+      <View className="flex-row bg-surface-highLight rounded-xl p-xs mx-xl mt-lg mb-md border border-border-light">
         {(['today', 'all', 'notes', 'tasks'] as const).map((tab) => (
           <Pressable
             key={tab}
             onPress={() => setActiveTab(tab)}
-            style={({ pressed }) => [
-              styles.tabButton,
-              activeTab === tab && styles.tabButtonActive,
-              pressed && activeTab !== tab && { opacity: 0.6 },
-            ]}
+            className={`flex-1 py-sm items-center rounded-lg active:opacity-60 ${activeTab === tab ? 'bg-surface-light shadow-sm' : 'bg-transparent'}`}
           >
-            <AppText style={[styles.tabText, activeTab === tab && styles.tabTextActive]}>
+            <AppText className={`text-[14px] ${activeTab === tab ? 'font-bold text-onSurface-light' : 'font-medium text-onSurface-mutedLight'}`}>
               {tab === 'today'
-                ? t('productivity.today')
+                ? t('productivity.today') || 'Today'
                 : tab === 'all'
                   ? t('productivity.all') || 'All'
                   : tab === 'notes'
@@ -222,7 +212,7 @@ export default function ProductivityScreen() {
       </View>
 
       {(activeTab === 'tasks' || activeTab === 'today') && (
-        <View style={styles.priorityFilterContainer}>
+        <View className="flex-row flex-wrap mx-xl mb-sm">
           {(
             [
               { key: 'all', label: t('productivity.priority.all', { count: taskPriorityCounts.all }) },
@@ -247,20 +237,11 @@ export default function ProductivityScreen() {
             <Pressable
               key={option.key}
               onPress={() => setTaskPriority(option.key)}
-              style={({ pressed }) => [
-                styles.priorityPillBase,
-                taskPriority === option.key ? styles.priorityPillActive : styles.priorityPillInactive,
-                pressed && { opacity: 0.8 },
-              ]}
+              className={`rounded-xl border px-2.5 py-1.5 mr-2 mb-2 active:opacity-80 ${taskPriority === option.key ? 'border-primary bg-primary-surfaceLight' : 'border-border-light bg-surface-light'}`}
             >
               <AppText
                 variant="caption"
-                style={[
-                  styles.priorityPillTextBase,
-                  taskPriority === option.key
-                    ? styles.priorityPillTextActive
-                    : styles.priorityPillTextInactive,
-                ]}
+                className={`font-bold ${taskPriority === option.key ? 'text-primary' : 'text-onSurface-mutedLight'}`}
               >
                 {option.label}
               </AppText>
@@ -273,7 +254,7 @@ export default function ProductivityScreen() {
         data={dataToRender}
         extraData={{ confirmDelete, deleteNote, deleteTask, toggleTask, language: i18n.language }}
         keyExtractor={(item) => item.id}
-        contentContainerStyle={styles.listContent}
+        contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 100, paddingTop: 8 }}
         showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl
@@ -285,14 +266,14 @@ export default function ProductivityScreen() {
         renderItem={renderItemWrapper}
         ListHeaderComponent={
           activeTab === 'today' && todayPlan ? (
-            <View style={styles.todayPlanContainer}>
-              <View style={styles.todayPlanHeader}>
-                <AppText style={styles.todayPlanTitle}>Today plan</AppText>
+            <View className="rounded-xl bg-primary-surfaceLight border border-border-light p-lg mb-md">
+              <View className="flex-row justify-between items-center">
+                <AppText className="text-onSurface-light font-bold text-[15px]">Today plan</AppText>
                 <Pressable onPress={() => setTodayPlan(null)}>
                   <Ionicons name="close" size={16} color={T.onSurface.mutedLight} />
                 </Pressable>
               </View>
-              <AppText style={styles.todayPlanText}>{todayPlan}</AppText>
+              <AppText className="text-onSurface-mutedLight mt-2 leading-relaxed">{todayPlan}</AppText>
             </View>
           ) : null
         }
@@ -319,189 +300,3 @@ export default function ProductivityScreen() {
     </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: T.background.light,
-  },
-  headerContainer: {
-    paddingHorizontal: S.xl,
-    paddingTop: S.md,
-    paddingBottom: S.lg,
-    backgroundColor: T.surface.light,
-    ...theme.elevation.sm,
-    zIndex: 10,
-  },
-  headerRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: S.lg,
-  },
-  headerTitle: {
-    color: T.onSurface.light,
-    fontSize: 28,
-    fontWeight: '800',
-    letterSpacing: -0.5,
-  },
-  headerSubtitle: {
-    color: T.onSurface.mutedLight,
-    fontSize: 14,
-    marginTop: S.xs,
-  },
-  headerActions: {
-    flexDirection: 'row',
-    gap: S.sm,
-  },
-  iconButton: {
-    width: 40,
-    height: 40,
-    borderRadius: R.full,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  searchContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.background.light,
-    borderRadius: R.lg,
-    paddingHorizontal: S.md,
-    height: 44,
-    borderWidth: 1,
-    borderColor: T.border.light,
-  },
-  searchIcon: {
-    marginRight: S.sm,
-  },
-  searchInput: {
-    flex: 1,
-    color: T.onSurface.light,
-    fontSize: 16,
-    height: '100%',
-  },
-  tabsContainer: {
-    flexDirection: 'row',
-    backgroundColor: T.surface.highLight,
-    borderRadius: R.xl,
-    padding: S.xs,
-    marginHorizontal: S.xl,
-    marginTop: S.lg,
-    marginBottom: S.md,
-    borderWidth: 1,
-    borderColor: T.border.light,
-  },
-  tabButton: {
-    flex: 1,
-    paddingVertical: S.sm,
-    alignItems: 'center',
-    borderRadius: R.lg,
-    backgroundColor: T.transparent,
-  },
-  tabButtonActive: {
-    backgroundColor: T.surface.light,
-    ...theme.elevation.sm,
-  },
-  tabText: {
-    fontSize: 14,
-    fontWeight: '500',
-    color: T.onSurface.mutedLight,
-  },
-  tabTextActive: {
-    fontWeight: '700',
-    color: T.onSurface.light,
-  },
-  priorityFilterContainer: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    marginHorizontal: S.xl,
-    marginBottom: S.sm,
-  },
-  priorityPillBase: {
-    borderRadius: 12,
-    borderWidth: 1,
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    marginRight: 8,
-    marginBottom: 8,
-  },
-  priorityPillActive: {
-    borderColor: T.primary.DEFAULT,
-    backgroundColor: T.primary.surfaceLight,
-  },
-  priorityPillInactive: {
-    borderColor: T.border.light,
-    backgroundColor: T.surface.light,
-  },
-  priorityPillTextBase: {
-    fontWeight: '700',
-  },
-  priorityPillTextActive: {
-    color: T.primary.DEFAULT,
-  },
-  priorityPillTextInactive: {
-    color: T.onSurface.mutedLight,
-  },
-  todayPlanContainer: {
-    borderRadius: R.xl,
-    backgroundColor: T.primary.surfaceLight,
-    borderWidth: 1,
-    borderColor: T.border.light,
-    padding: S.lg,
-    marginBottom: S.md,
-  },
-  todayPlanHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  todayPlanTitle: {
-    color: T.onSurface.light,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-  todayPlanText: {
-    color: T.onSurface.mutedLight,
-    marginTop: 8,
-    lineHeight: 20,
-  },
-  listContent: {
-    paddingHorizontal: S.xl,
-    paddingBottom: 100,
-    paddingTop: S.sm,
-  },
-  eventCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.surface.light,
-    borderWidth: 1,
-    borderColor: T.border.light,
-    borderRadius: R.xl,
-    padding: S.lg,
-    marginBottom: S.md,
-    ...theme.elevation.sm,
-  },
-  eventIcon: {
-    width: 32,
-    height: 32,
-    borderRadius: R.lg,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginRight: S.md,
-  },
-  eventBody: {
-    flex: 1,
-  },
-  eventTitle: {
-    color: T.onSurface.light,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-  eventMeta: {
-    color: T.onSurface.mutedLight,
-    marginTop: 2,
-    fontSize: 13,
-  },
-});

--- a/frontend/app/(main)/productivity.tsx
+++ b/frontend/app/(main)/productivity.tsx
@@ -8,12 +8,12 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { AppText } from '../../src/components/AppText';
-import { CreateNoteModal } from '../../src/components/productivity/CreateNoteModal';
-import { CreateTaskModal } from '../../src/components/productivity/CreateTaskModal';
-import { NoteCard } from '../../src/components/productivity/NoteCard';
-import { TaskCard } from '../../src/components/productivity/TaskCard';
-import { ProductivityEmptyState } from '../../src/components/productivity/ProductivityEmptyState';
+import { AppText } from '@/components/AppText';
+import { CreateNoteModal } from '@/components/productivity/CreateNoteModal';
+import { CreateTaskModal } from '@/components/productivity/CreateTaskModal';
+import { NoteCard } from '@/components/productivity/NoteCard';
+import { TaskCard } from '@/components/productivity/TaskCard';
+import { ProductivityEmptyState } from '@/components/productivity/ProductivityEmptyState';
 import { CalendarEvent, Note, Task } from '../../src/core/models';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
 import { RenderItemData, useProductivityViewModel } from '@/hooks/viewmodels/useProductivityViewModel';
@@ -154,18 +154,24 @@ export default function ProductivityScreen() {
           <View className="flex-row gap-sm">
             <Pressable
               onPress={generateTodayPlan}
+              accessibilityRole="button"
+              accessibilityLabel={t('productivity.actions.generate_plan') || 'Generate Plan'}
               className="w-10 h-10 rounded-full bg-primary-surfaceLight items-center justify-center active:opacity-70"
             >
               <Ionicons name="sparkles" size={20} color={T.primary.DEFAULT} />
             </Pressable>
             <Pressable
               onPress={() => setShowCreateNote(true)}
+              accessibilityRole="button"
+              accessibilityLabel={t('productivity.actions.create_note') || 'Create Note'}
               className="w-10 h-10 rounded-full bg-primary-surfaceLight items-center justify-center active:opacity-70"
             >
               <Ionicons name="document-text" size={20} color={T.primary.DEFAULT} />
             </Pressable>
             <Pressable
               onPress={() => setShowCreateTask(true)}
+              accessibilityRole="button"
+              accessibilityLabel={t('productivity.actions.create_task') || 'Create Task'}
               className="w-10 h-10 rounded-full bg-primary-surfaceLight items-center justify-center active:opacity-70"
             >
               <Ionicons name="checkbox" size={20} color={T.primary.DEFAULT} />
@@ -268,8 +274,14 @@ export default function ProductivityScreen() {
           activeTab === 'today' && todayPlan ? (
             <View className="rounded-xl bg-primary-surfaceLight border border-border-light p-lg mb-md">
               <View className="flex-row justify-between items-center">
-                <AppText className="text-onSurface-light font-bold text-[15px]">Today plan</AppText>
-                <Pressable onPress={() => setTodayPlan(null)}>
+                <AppText className="text-onSurface-light font-bold text-[15px]">
+                  {t('productivity.plan.title') || 'Today plan'}
+                </AppText>
+                <Pressable
+                  onPress={() => setTodayPlan(null)}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('productivity.actions.dismiss') || 'Dismiss'}
+                >
                   <Ionicons name="close" size={16} color={T.onSurface.mutedLight} />
                 </Pressable>
               </View>
@@ -278,12 +290,14 @@ export default function ProductivityScreen() {
           ) : null
         }
         ListEmptyComponent={
-          <ProductivityEmptyState
-            activeTab={activeTab}
-            searchQuery={searchQuery}
-            setShowCreateNote={setShowCreateNote}
-            setShowCreateTask={setShowCreateTask}
-          />
+          !isLoading && dataToRender.length === 0 ? (
+            <ProductivityEmptyState
+              activeTab={activeTab}
+              searchQuery={searchQuery}
+              setShowCreateNote={setShowCreateNote}
+              setShowCreateTask={setShowCreateTask}
+            />
+          ) : null
         }
       />
 

--- a/frontend/src/components/productivity/ProductivityEmptyState.tsx
+++ b/frontend/src/components/productivity/ProductivityEmptyState.tsx
@@ -1,0 +1,187 @@
+import React from 'react';
+import { Platform, Pressable, StyleSheet, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import { AppText } from '@/components/AppText';
+import { theme } from '@/core/theme';
+import { DESIGN_TOKENS } from '@/core/design/tokens';
+import { Tab } from '@/hooks/viewmodels/useProductivityViewModel';
+
+const T = {
+  primary: {
+    DEFAULT: DESIGN_TOKENS.colors.primary,
+    surfaceLight: DESIGN_TOKENS.colors.primarySoft,
+  },
+  onSurface: {
+    light: DESIGN_TOKENS.colors.text,
+    mutedLight: DESIGN_TOKENS.colors.muted,
+  },
+  white: '#FFFFFF',
+};
+const S = theme.spacing;
+const R = theme.borderRadius;
+
+interface ProductivityEmptyStateProps {
+  activeTab: Tab;
+  searchQuery: string;
+  setShowCreateNote: (show: boolean) => void;
+  setShowCreateTask: (show: boolean) => void;
+}
+
+export function ProductivityEmptyState({
+  activeTab,
+  searchQuery,
+  setShowCreateNote,
+  setShowCreateTask,
+}: ProductivityEmptyStateProps) {
+  const { t } = useTranslation();
+
+  return (
+    <View style={styles.emptyContainer}>
+      <View style={styles.emptyIconCircle}>
+        <Ionicons
+          name={
+            activeTab === 'notes'
+              ? 'document-text'
+              : activeTab === 'tasks'
+                ? 'checkbox'
+                : activeTab === 'today'
+                  ? 'sunny-outline'
+                  : 'planet'
+          }
+          size={42}
+          color={T.primary.DEFAULT}
+        />
+      </View>
+      <AppText variant="h3" style={styles.emptyTitle}>
+        {searchQuery
+          ? t('productivity.no_matches') || 'No matches found'
+          : activeTab === 'notes'
+            ? t('productivity.no_notes') || 'No Notes'
+            : activeTab === 'tasks'
+              ? t('productivity.no_tasks') || 'No Tasks'
+              : activeTab === 'today'
+                ? t('productivity.nothing_urgent_today')
+                : t('productivity.workspace_clear') || 'Your workspace is clear'}
+      </AppText>
+      <AppText style={styles.emptySubtitle}>
+        {searchQuery
+          ? t('productivity.try_adjust_search') || 'Try adjusting your search terms.'
+          : activeTab === 'today'
+            ? t('productivity.today_empty_detail')
+            : t('productivity.capture_thoughts') ||
+              'Capture your thoughts and track what needs to get done.'}
+      </AppText>
+
+      {!searchQuery && (
+        <View style={styles.emptyActions}>
+          {(activeTab === 'all' || activeTab === 'notes') && (
+            <Pressable
+              onPress={() => setShowCreateNote(true)}
+              style={({ pressed }) => [styles.emptyButton, pressed && { opacity: 0.8 }]}
+            >
+              <Ionicons name="add" size={18} color={T.white} style={{ marginEnd: 6 }} />
+              <AppText style={styles.emptyButtonText}>
+                {t('productivity.newNote') || 'New Note'}
+              </AppText>
+            </Pressable>
+          )}
+          {(activeTab === 'all' || activeTab === 'tasks' || activeTab === 'today') && (
+            <Pressable
+              onPress={() => setShowCreateTask(true)}
+              style={({ pressed }) => [
+                styles.emptyButton,
+                (activeTab === 'all' || activeTab === 'today') && styles.emptyButtonSecondary,
+                pressed && { opacity: 0.8 },
+              ]}
+            >
+              <Ionicons
+                name="add"
+                size={18}
+                color={
+                  activeTab === 'all' || activeTab === 'today' ? T.primary.DEFAULT : T.white
+                }
+                style={{ marginEnd: 6 }}
+              />
+              <AppText
+                style={
+                  activeTab === 'all' || activeTab === 'today'
+                    ? styles.emptyButtonTextSecondary
+                    : styles.emptyButtonText
+                }
+              >
+                {t('productivity.new_task')}
+              </AppText>
+            </Pressable>
+          )}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  emptyContainer: {
+    alignItems: 'center',
+    paddingVertical: S.massive,
+  },
+  emptyIconCircle: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: T.primary.surfaceLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: S.lg,
+  },
+  emptyTitle: {
+    marginBottom: S.sm,
+    textAlign: 'center',
+    color: T.onSurface.light,
+  },
+  emptySubtitle: {
+    textAlign: 'center',
+    marginBottom: S.xl,
+    color: T.onSurface.mutedLight,
+    paddingHorizontal: S.xxxl,
+    lineHeight: 22,
+  },
+  emptyActions: {
+    flexDirection: 'row',
+    gap: S.md,
+  },
+  emptyButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: T.primary.DEFAULT,
+    borderRadius: R.xl,
+    paddingVertical: S.md,
+    paddingHorizontal: S.xl,
+    ...theme.elevation.md,
+  },
+  emptyButtonSecondary: {
+    backgroundColor: T.primary.surfaceLight,
+    ...Platform.select({
+      ios: {
+        shadowOpacity: 0,
+        elevation: 0,
+      },
+      android: {
+        elevation: 0,
+      },
+      default: {
+        elevation: 0,
+      },
+    }),
+  },
+  emptyButtonText: {
+    color: T.white,
+    fontWeight: '700',
+    fontSize: 15,
+  },
+  emptyButtonTextSecondary: {
+    color: T.primary.DEFAULT,
+    fontWeight: '700',
+    fontSize: 15,
+  },
+});

--- a/frontend/src/components/productivity/ProductivityEmptyState.tsx
+++ b/frontend/src/components/productivity/ProductivityEmptyState.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { Platform, Pressable, StyleSheet, View } from 'react-native';
+import { Platform, Pressable, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import { AppText } from '@/components/AppText';
-import { theme } from '@/core/theme';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
 import { Tab } from '@/hooks/viewmodels/useProductivityViewModel';
 
@@ -18,8 +17,6 @@ const T = {
   },
   white: '#FFFFFF',
 };
-const S = theme.spacing;
-const R = theme.borderRadius;
 
 interface ProductivityEmptyStateProps {
   activeTab: Tab;
@@ -27,6 +24,14 @@ interface ProductivityEmptyStateProps {
   setShowCreateNote: (show: boolean) => void;
   setShowCreateTask: (show: boolean) => void;
 }
+
+const ICON_BY_TAB: Record<Tab | 'default', keyof typeof Ionicons.glyphMap> = {
+  notes: 'document-text',
+  tasks: 'checkbox',
+  today: 'sunny-outline',
+  default: 'planet',
+  all: 'planet',
+};
 
 export function ProductivityEmptyState({
   activeTab,
@@ -36,24 +41,14 @@ export function ProductivityEmptyState({
 }: ProductivityEmptyStateProps) {
   const { t } = useTranslation();
 
+  const iconName = ICON_BY_TAB[activeTab] || ICON_BY_TAB.default;
+
   return (
-    <View style={styles.emptyContainer}>
-      <View style={styles.emptyIconCircle}>
-        <Ionicons
-          name={
-            activeTab === 'notes'
-              ? 'document-text'
-              : activeTab === 'tasks'
-                ? 'checkbox'
-                : activeTab === 'today'
-                  ? 'sunny-outline'
-                  : 'planet'
-          }
-          size={42}
-          color={T.primary.DEFAULT}
-        />
+    <View className="items-center py-colossal">
+      <View className="w-20 h-20 rounded-full bg-primary-surfaceLight items-center justify-center mb-lg">
+        <Ionicons name={iconName} size={42} color={T.primary.DEFAULT} />
       </View>
-      <AppText variant="h3" style={styles.emptyTitle}>
+      <AppText variant="h3" className="mb-sm text-center text-onSurface-light">
         {searchQuery
           ? t('productivity.no_matches') || 'No matches found'
           : activeTab === 'notes'
@@ -64,7 +59,7 @@ export function ProductivityEmptyState({
                 ? t('productivity.nothing_urgent_today')
                 : t('productivity.workspace_clear') || 'Your workspace is clear'}
       </AppText>
-      <AppText style={styles.emptySubtitle}>
+      <AppText className="text-center mb-xl text-onSurface-mutedLight px-xxxl leading-relaxed">
         {searchQuery
           ? t('productivity.try_adjust_search') || 'Try adjusting your search terms.'
           : activeTab === 'today'
@@ -74,14 +69,15 @@ export function ProductivityEmptyState({
       </AppText>
 
       {!searchQuery && (
-        <View style={styles.emptyActions}>
+        <View className="flex-row gap-md">
           {(activeTab === 'all' || activeTab === 'notes') && (
             <Pressable
               onPress={() => setShowCreateNote(true)}
-              style={({ pressed }) => [styles.emptyButton, pressed && { opacity: 0.8 }]}
+              className="flex-row items-center bg-primary rounded-xl py-md px-xl shadow-md active:opacity-80"
+              style={Platform.OS === 'android' ? { elevation: 3 } : {}}
             >
               <Ionicons name="add" size={18} color={T.white} style={{ marginEnd: 6 }} />
-              <AppText style={styles.emptyButtonText}>
+              <AppText className="text-white font-bold text-[15px]">
                 {t('productivity.newNote') || 'New Note'}
               </AppText>
             </Pressable>
@@ -89,11 +85,14 @@ export function ProductivityEmptyState({
           {(activeTab === 'all' || activeTab === 'tasks' || activeTab === 'today') && (
             <Pressable
               onPress={() => setShowCreateTask(true)}
-              style={({ pressed }) => [
-                styles.emptyButton,
-                (activeTab === 'all' || activeTab === 'today') && styles.emptyButtonSecondary,
-                pressed && { opacity: 0.8 },
-              ]}
+              className={`flex-row items-center rounded-xl py-md px-xl active:opacity-80 ${(activeTab === 'all' || activeTab === 'today') ? 'bg-primary-surfaceLight' : 'bg-primary shadow-md'}`}
+              style={
+                (activeTab === 'all' || activeTab === 'today')
+                  ? {}
+                  : Platform.OS === 'android'
+                    ? { elevation: 3 }
+                    : {}
+              }
             >
               <Ionicons
                 name="add"
@@ -104,13 +103,9 @@ export function ProductivityEmptyState({
                 style={{ marginEnd: 6 }}
               />
               <AppText
-                style={
-                  activeTab === 'all' || activeTab === 'today'
-                    ? styles.emptyButtonTextSecondary
-                    : styles.emptyButtonText
-                }
+                className={`font-bold text-[15px] ${(activeTab === 'all' || activeTab === 'today') ? 'text-primary' : 'text-white'}`}
               >
-                {t('productivity.new_task')}
+                {t('productivity.new_task') || 'New Task'}
               </AppText>
             </Pressable>
           )}
@@ -119,69 +114,3 @@ export function ProductivityEmptyState({
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  emptyContainer: {
-    alignItems: 'center',
-    paddingVertical: S.massive,
-  },
-  emptyIconCircle: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: S.lg,
-  },
-  emptyTitle: {
-    marginBottom: S.sm,
-    textAlign: 'center',
-    color: T.onSurface.light,
-  },
-  emptySubtitle: {
-    textAlign: 'center',
-    marginBottom: S.xl,
-    color: T.onSurface.mutedLight,
-    paddingHorizontal: S.xxxl,
-    lineHeight: 22,
-  },
-  emptyActions: {
-    flexDirection: 'row',
-    gap: S.md,
-  },
-  emptyButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.primary.DEFAULT,
-    borderRadius: R.xl,
-    paddingVertical: S.md,
-    paddingHorizontal: S.xl,
-    ...theme.elevation.md,
-  },
-  emptyButtonSecondary: {
-    backgroundColor: T.primary.surfaceLight,
-    ...Platform.select({
-      ios: {
-        shadowOpacity: 0,
-        elevation: 0,
-      },
-      android: {
-        elevation: 0,
-      },
-      default: {
-        elevation: 0,
-      },
-    }),
-  },
-  emptyButtonText: {
-    color: T.white,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-  emptyButtonTextSecondary: {
-    color: T.primary.DEFAULT,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-});

--- a/frontend/src/hooks/viewmodels/useProductivityViewModel.ts
+++ b/frontend/src/hooks/viewmodels/useProductivityViewModel.ts
@@ -269,18 +269,22 @@ export function useProductivityViewModel() {
     return items.sort((a, b) => (a.date || 0) - (b.date || 0));
   }, [filteredEvents, filteredTasks]);
 
-  const dataToRender: RenderItemData[] =
-    activeTab === 'today'
-      ? todayData.filter((entry) => {
-          if (entry.type !== 'task') return true;
-          if (taskPriority === 'all') return true;
-          return getTaskPriority(entry.item as Task) === taskPriority;
-        })
-      : activeTab === 'all'
-        ? mixedData
-        : activeTab === 'notes'
-          ? filteredNotes.map((note) => ({ type: 'note' as const, item: note, id: note.id }))
-          : prioritizedTasks.map((task) => ({ type: 'task' as const, item: task, id: task.id }));
+  const dataToRender: RenderItemData[] = useMemo(() => {
+    if (activeTab === 'today') {
+      return todayData.filter((entry) => {
+        if (entry.type !== 'task') return true;
+        if (taskPriority === 'all') return true;
+        return getTaskPriority(entry.item as Task) === taskPriority;
+      });
+    }
+    if (activeTab === 'all') {
+      return mixedData;
+    }
+    if (activeTab === 'notes') {
+      return filteredNotes.map((note) => ({ type: 'note' as const, item: note, id: note.id }));
+    }
+    return prioritizedTasks.map((task) => ({ type: 'task' as const, item: task, id: task.id }));
+  }, [activeTab, todayData, mixedData, filteredNotes, prioritizedTasks, taskPriority, getTaskPriority]);
 
   const generateTodayPlan = useCallback(() => {
     const now = new Date();

--- a/frontend/src/hooks/viewmodels/useProductivityViewModel.ts
+++ b/frontend/src/hooks/viewmodels/useProductivityViewModel.ts
@@ -84,7 +84,7 @@ export function useProductivityViewModel() {
   }, [fetchEvents, fetchNotes, fetchTasks]);
 
   const confirmDelete = useCallback(
-    (action: () => Promise<void>) =>
+    (action: () => Promise<void>) => {
       Alert.alert(
         t('productivity.delete') || 'Delete',
         t('productivity.are_you_sure') || 'Are you sure?',
@@ -93,41 +93,60 @@ export function useProductivityViewModel() {
           {
             text: t('settings.actions.delete') || 'Delete',
             style: 'destructive',
-            onPress: () => action(),
+            onPress: async () => {
+              try {
+                await action();
+              } catch {
+                Alert.alert(
+                  t('errors.operation_failed') || 'Operation failed',
+                  t('errors.try_again') || 'Please try again later'
+                );
+              }
+            },
           },
         ]
-      ),
+      );
+    },
     [t]
   );
 
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(searchQuery);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
   const filteredNotes = useMemo(() => {
-    if (!searchQuery) return notes;
-    const lowerQ = searchQuery.toLowerCase();
+    if (!debouncedSearchQuery) return notes;
+    const lowerQ = debouncedSearchQuery.toLowerCase();
     return notes.filter(
       (n) => n.title.toLowerCase().includes(lowerQ) || n.content.toLowerCase().includes(lowerQ)
     );
-  }, [notes, searchQuery]);
+  }, [notes, debouncedSearchQuery]);
 
   const filteredTasks = useMemo(() => {
-    if (!searchQuery) return tasks;
-    const lowerQ = searchQuery.toLowerCase();
+    if (!debouncedSearchQuery) return tasks;
+    const lowerQ = debouncedSearchQuery.toLowerCase();
     return tasks.filter(
       (task) =>
         task.title.toLowerCase().includes(lowerQ) ||
         (task.description?.toLowerCase().includes(lowerQ) ?? false)
     );
-  }, [searchQuery, tasks]);
+  }, [debouncedSearchQuery, tasks]);
 
   const filteredEvents = useMemo(() => {
-    if (!searchQuery) return events;
-    const lowerQ = searchQuery.toLowerCase();
+    if (!debouncedSearchQuery) return events;
+    const lowerQ = debouncedSearchQuery.toLowerCase();
     return events.filter(
       (event) =>
         event.title.toLowerCase().includes(lowerQ) ||
         (event.description?.toLowerCase().includes(lowerQ) ?? false) ||
         (event.location?.toLowerCase().includes(lowerQ) ?? false)
     );
-  }, [events, searchQuery]);
+  }, [events, debouncedSearchQuery]);
 
   const pendingTasksCount = useMemo(
     () => filteredTasks.filter((task) => !task.completed).length,
@@ -172,8 +191,10 @@ export function useProductivityViewModel() {
         ? tasksToRank
         : tasksToRank.filter((task) => getTaskPriority(task) === taskPriority);
     return [...pool].sort((a, b) => {
-      const aDue = a.due_date ? new Date(a.due_date).getTime() : Number.MAX_SAFE_INTEGER;
-      const bDue = b.due_date ? new Date(b.due_date).getTime() : Number.MAX_SAFE_INTEGER;
+      const parsedA = a.due_date ? new Date(a.due_date).getTime() : NaN;
+      const parsedB = b.due_date ? new Date(b.due_date).getTime() : NaN;
+      const aDue = isNaN(parsedA) ? Number.MAX_SAFE_INTEGER : parsedA;
+      const bDue = isNaN(parsedB) ? Number.MAX_SAFE_INTEGER : parsedB;
       return aDue - bDue;
     });
   }, [filteredTasks, getTaskPriority, taskPriority]);
@@ -271,15 +292,15 @@ export function useProductivityViewModel() {
 
     const lines: string[] = [];
     if (taskPriorityCounts.overdue > 0) {
-      lines.push(`1) Recover overdue: start with ${taskPriorityCounts.overdue} overdue task(s).`);
+      lines.push(t('productivity.plan.overdue', { count: taskPriorityCounts.overdue }) || `1) Recover overdue: start with ${taskPriorityCounts.overdue} overdue task(s).`);
     } else {
-      lines.push('1) No overdue tasks: start with highest-impact open work.');
+      lines.push(t('productivity.plan.no_overdue') || '1) No overdue tasks: start with highest-impact open work.');
     }
 
     if (nextTasks.length > 0) {
-      lines.push(`2) Focus block: ${nextTasks.map((task) => task.title).join(', ')}.`);
+      lines.push(t('productivity.plan.focus_block', { tasks: nextTasks.map((task) => task.title).join(', ') }) || `2) Focus block: ${nextTasks.map((task) => task.title).join(', ')}.`);
     } else {
-      lines.push('2) Focus block: no pending tasks, use this for planning or review.');
+      lines.push(t('productivity.plan.no_focus') || '2) Focus block: no pending tasks, use this for planning or review.');
     }
 
     if (nextEvents.length > 0) {
@@ -291,14 +312,14 @@ export function useProductivityViewModel() {
           }).format(new Date(event.start_time))
         )
         .join(', ');
-      lines.push(`3) Calendar checkpoints at ${eventLine}.`);
+      lines.push(t('productivity.plan.calendar', { times: eventLine }) || `3) Calendar checkpoints at ${eventLine}.`);
     } else {
-      lines.push('3) Calendar is light: reserve time for deep work and wrap-up.');
+      lines.push(t('productivity.plan.light_calendar') || '3) Calendar is light: reserve time for deep work and wrap-up.');
     }
 
     setTodayPlan(lines.join('\n'));
     setActiveTab('today');
-  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue]);
+  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue, t]);
 
   return {
     t,

--- a/frontend/src/hooks/viewmodels/useProductivityViewModel.ts
+++ b/frontend/src/hooks/viewmodels/useProductivityViewModel.ts
@@ -1,0 +1,331 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Alert } from 'react-native';
+import { useLocalSearchParams, usePathname, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useProductivityStore } from '@/store/useProductivityStore';
+import { CalendarEvent, Note, Task } from '@/core/models';
+
+export type Tab = 'today' | 'all' | 'notes' | 'tasks';
+export type TaskPriority = 'all' | 'overdue' | 'today' | 'upcoming' | 'no_due';
+
+export type RenderItemData = {
+  date?: number;
+  type: 'note' | 'task' | 'event';
+  item: Note | Task | CalendarEvent;
+  id: string;
+};
+
+export function useProductivityViewModel() {
+  const { t, i18n } = useTranslation();
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useLocalSearchParams() as Record<string, string | string[] | undefined>;
+  const openCreateTask = params.openCreateTask;
+  const openCreateNote = params.openCreateNote;
+
+  const [activeTab, setActiveTab] = useState<Tab>('today');
+  const [taskPriority, setTaskPriority] = useState<TaskPriority>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showCreateNote, setShowCreateNote] = useState(false);
+  const [showCreateTask, setShowCreateTask] = useState(false);
+  const [todayPlan, setTodayPlan] = useState<string | null>(null);
+
+  const {
+    notes,
+    tasks,
+    events,
+    fetchNotes,
+    fetchTasks,
+    fetchEvents,
+    isLoading,
+    deleteNote,
+    deleteTask,
+    toggleTask,
+  } = useProductivityStore();
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchNotes(controller.signal);
+    fetchTasks(controller.signal);
+    fetchEvents(controller.signal);
+    return () => {
+      controller.abort();
+    };
+  }, [fetchEvents, fetchNotes, fetchTasks]);
+
+  useEffect(() => {
+    if (openCreateTask === '1' || openCreateTask === 'true') {
+      setShowCreateTask(true);
+      const nextParams = Object.fromEntries(
+        Object.entries(params).filter(
+          ([key, value]) => key !== 'openCreateTask' && typeof value === 'string'
+        )
+      );
+      router.replace({ pathname, params: nextParams });
+    }
+  }, [openCreateTask, params, pathname, router]);
+
+  useEffect(() => {
+    if (openCreateNote === '1' || openCreateNote === 'true') {
+      setShowCreateNote(true);
+      const nextParams = Object.fromEntries(
+        Object.entries(params).filter(
+          ([key, value]) => key !== 'openCreateNote' && typeof value === 'string'
+        )
+      );
+      router.replace({ pathname, params: nextParams });
+    }
+  }, [openCreateNote, params, pathname, router]);
+
+  const handleRefresh = useCallback(() => {
+    fetchNotes();
+    fetchTasks();
+    fetchEvents();
+  }, [fetchEvents, fetchNotes, fetchTasks]);
+
+  const confirmDelete = useCallback(
+    (action: () => Promise<void>) =>
+      Alert.alert(
+        t('productivity.delete') || 'Delete',
+        t('productivity.are_you_sure') || 'Are you sure?',
+        [
+          { text: t('settings.actions.cancel') || 'Cancel', style: 'cancel' },
+          {
+            text: t('settings.actions.delete') || 'Delete',
+            style: 'destructive',
+            onPress: () => action(),
+          },
+        ]
+      ),
+    [t]
+  );
+
+  const filteredNotes = useMemo(() => {
+    if (!searchQuery) return notes;
+    const lowerQ = searchQuery.toLowerCase();
+    return notes.filter(
+      (n) => n.title.toLowerCase().includes(lowerQ) || n.content.toLowerCase().includes(lowerQ)
+    );
+  }, [notes, searchQuery]);
+
+  const filteredTasks = useMemo(() => {
+    if (!searchQuery) return tasks;
+    const lowerQ = searchQuery.toLowerCase();
+    return tasks.filter(
+      (task) =>
+        task.title.toLowerCase().includes(lowerQ) ||
+        (task.description?.toLowerCase().includes(lowerQ) ?? false)
+    );
+  }, [searchQuery, tasks]);
+
+  const filteredEvents = useMemo(() => {
+    if (!searchQuery) return events;
+    const lowerQ = searchQuery.toLowerCase();
+    return events.filter(
+      (event) =>
+        event.title.toLowerCase().includes(lowerQ) ||
+        (event.description?.toLowerCase().includes(lowerQ) ?? false) ||
+        (event.location?.toLowerCase().includes(lowerQ) ?? false)
+    );
+  }, [events, searchQuery]);
+
+  const pendingTasksCount = useMemo(
+    () => filteredTasks.filter((task) => !task.completed).length,
+    [filteredTasks]
+  );
+
+  const getTaskPriority = useCallback((task: Task): Exclude<TaskPriority, 'all'> => {
+    if (!task.due_date) return 'no_due';
+    const now = new Date();
+    const due = new Date(task.due_date);
+    if (isNaN(due.getTime())) return 'no_due';
+    const dayStart = new Date(now);
+    dayStart.setHours(0, 0, 0, 0);
+    const tomorrow = new Date(dayStart);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    if (due < dayStart) return 'overdue';
+    if (due >= dayStart && due < tomorrow) return 'today';
+    return 'upcoming';
+  }, []);
+
+  const taskPriorityCounts = useMemo(() => {
+    const counts: Record<TaskPriority, number> = {
+      all: 0,
+      overdue: 0,
+      today: 0,
+      upcoming: 0,
+      no_due: 0,
+    };
+    filteredTasks
+      .filter((task) => !task.completed)
+      .forEach((task) => {
+        counts.all += 1;
+        counts[getTaskPriority(task)] += 1;
+      });
+    return counts;
+  }, [filteredTasks, getTaskPriority]);
+
+  const prioritizedTasks = useMemo(() => {
+    const tasksToRank = filteredTasks.filter((task) => !task.completed);
+    const pool =
+      taskPriority === 'all'
+        ? tasksToRank
+        : tasksToRank.filter((task) => getTaskPriority(task) === taskPriority);
+    return [...pool].sort((a, b) => {
+      const aDue = a.due_date ? new Date(a.due_date).getTime() : Number.MAX_SAFE_INTEGER;
+      const bDue = b.due_date ? new Date(b.due_date).getTime() : Number.MAX_SAFE_INTEGER;
+      return aDue - bDue;
+    });
+  }, [filteredTasks, getTaskPriority, taskPriority]);
+
+  const mixedData = useMemo(() => {
+    const data: RenderItemData[] = [];
+    filteredNotes.forEach((note) => {
+      data.push({
+        type: 'note',
+        item: note,
+        id: `note-${note.id}`,
+        date: new Date(note.created_at).getTime(),
+      });
+    });
+    filteredTasks.forEach((task) => {
+      data.push({
+        type: 'task',
+        item: task,
+        id: `task-${task.id}`,
+        date: new Date(task.created_at).getTime(),
+      });
+    });
+    return data.sort((a, b) => (b.date || 0) - (a.date || 0));
+  }, [filteredNotes, filteredTasks]);
+
+  const todayData = useMemo(() => {
+    const now = new Date();
+    const start = new Date(now);
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(start);
+    end.setDate(end.getDate() + 1);
+    const weekEnd = new Date(start);
+    weekEnd.setDate(weekEnd.getDate() + 7);
+
+    const overdueTasks = filteredTasks.filter((task) => {
+      if (task.completed || !task.due_date) return false;
+      return new Date(task.due_date) < start;
+    });
+
+    const dueTodayTasks = filteredTasks.filter((task) => {
+      if (task.completed || !task.due_date) return false;
+      const dueDate = new Date(task.due_date);
+      return dueDate >= start && dueDate < end;
+    });
+
+    const upcomingEvents = filteredEvents.filter((event) => {
+      const startTime = new Date(event.start_time);
+      return startTime >= start && startTime < weekEnd;
+    });
+
+    const items: RenderItemData[] = [
+      ...overdueTasks.map((task) => ({
+        type: 'task' as const,
+        item: task,
+        id: `overdue-${task.id}`,
+        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
+      })),
+      ...dueTodayTasks.map((task) => ({
+        type: 'task' as const,
+        item: task,
+        id: `today-${task.id}`,
+        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
+      })),
+      ...upcomingEvents.map((event) => ({
+        type: 'event' as const,
+        item: event,
+        id: `event-${event.id}`,
+        date: new Date(event.start_time).getTime(),
+      })),
+    ];
+
+    return items.sort((a, b) => (a.date || 0) - (b.date || 0));
+  }, [filteredEvents, filteredTasks]);
+
+  const dataToRender: RenderItemData[] =
+    activeTab === 'today'
+      ? todayData.filter((entry) => {
+          if (entry.type !== 'task') return true;
+          if (taskPriority === 'all') return true;
+          return getTaskPriority(entry.item as Task) === taskPriority;
+        })
+      : activeTab === 'all'
+        ? mixedData
+        : activeTab === 'notes'
+          ? filteredNotes.map((note) => ({ type: 'note' as const, item: note, id: note.id }))
+          : prioritizedTasks.map((task) => ({ type: 'task' as const, item: task, id: task.id }));
+
+  const generateTodayPlan = useCallback(() => {
+    const now = new Date();
+    const nextTasks = prioritizedTasks.slice(0, 3);
+    const nextEvents = [...filteredEvents]
+      .filter((event) => new Date(event.end_time) >= now)
+      .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime())
+      .slice(0, 3);
+
+    const lines: string[] = [];
+    if (taskPriorityCounts.overdue > 0) {
+      lines.push(`1) Recover overdue: start with ${taskPriorityCounts.overdue} overdue task(s).`);
+    } else {
+      lines.push('1) No overdue tasks: start with highest-impact open work.');
+    }
+
+    if (nextTasks.length > 0) {
+      lines.push(`2) Focus block: ${nextTasks.map((task) => task.title).join(', ')}.`);
+    } else {
+      lines.push('2) Focus block: no pending tasks, use this for planning or review.');
+    }
+
+    if (nextEvents.length > 0) {
+      const eventLine = nextEvents
+        .map((event) =>
+          new Intl.DateTimeFormat(i18n.language, {
+            hour: '2-digit',
+            minute: '2-digit',
+          }).format(new Date(event.start_time))
+        )
+        .join(', ');
+      lines.push(`3) Calendar checkpoints at ${eventLine}.`);
+    } else {
+      lines.push('3) Calendar is light: reserve time for deep work and wrap-up.');
+    }
+
+    setTodayPlan(lines.join('\n'));
+    setActiveTab('today');
+  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue]);
+
+  return {
+    t,
+    i18n,
+    activeTab,
+    setActiveTab,
+    taskPriority,
+    setTaskPriority,
+    searchQuery,
+    setSearchQuery,
+    showCreateNote,
+    setShowCreateNote,
+    showCreateTask,
+    setShowCreateTask,
+    todayPlan,
+    setTodayPlan,
+    dataToRender,
+    isLoading,
+    pendingTasksCount,
+    taskPriorityCounts,
+    confirmDelete,
+    generateTodayPlan,
+    handleRefresh,
+    fetchNotes,
+    fetchTasks,
+    deleteNote,
+    deleteTask,
+    toggleTask,
+  };
+}


### PR DESCRIPTION
Extracted the "God Widget" `ProductivityScreen` by moving complex data orchestration, hook effects, and filtering logic into `useProductivityViewModel`. Extracted the massive inline `ListEmptyComponent` into the `ProductivityEmptyState` component. Abstracted away inline styles into `StyleSheet`.

---
*PR created automatically by Jules for task [8338033158050398698](https://jules.google.com/task/8338033158050398698) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localized "Today plan" card with localized date/time and automatic generation.
  * Enhanced empty-state with contextual icons, search-aware copy, and contextual action buttons (New Note / New Task).
  * URL-driven create-modals: opening creation flows from links/params now supported.

* **Refactor**
  * Centralized productivity state and list rendering for clearer UI behavior.
  * Switched list/filter styling to className-based approach for simpler theming and layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/672)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->