### PR TITLE
docs(api): flag undocumented websocket_chat_hub endpoint

### DIFF
--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -99,6 +99,7 @@ async def _handle_send_message(
 # ---------------------------------------------------------------------------
 # WebSocket endpoint
 # ---------------------------------------------------------------------------
+# DOCS(miru-agent): undocumented endpoint
 @router.websocket("/ws/chat")
 async def websocket_chat_hub(
     websocket: WebSocket,


### PR DESCRIPTION
Flagged the `websocket_chat_hub` endpoint with `# DOCS(miru-agent): undocumented endpoint` to ensure it is added to the OpenAPI schema in future work, as requested in the changelog.

---
*PR created automatically by Jules for task [15134797912441900494](https://jules.google.com/task/15134797912441900494) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. This update includes an internal documentation note.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/673)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->