### PR TITLE
refactor(frontend): optimize list rendering with FlatList and memoization

### DIFF
--- a/frontend/src/components/chat/ChatListHeader.tsx
+++ b/frontend/src/components/chat/ChatListHeader.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { Ionicons } from '@expo/vector-icons';
-import { ScrollView, TextInput, View } from 'react-native';
+import { FlatList, TextInput, View } from 'react-native';
 import { AppText } from '@/components/AppText';
 import { ScalePressable } from '@/components/ScalePressable';
 import { AgentPill } from '@/components/chat/AgentPill';
@@ -38,7 +38,53 @@ interface ChatListHeaderProps {
   roomCount: number;
 }
 
-export function ChatListHeader({
+type FilterItemType =
+  | { type: 'sort'; mode: SortMode; label: string; selected: boolean; onPress: () => void }
+  | { type: 'toggle'; label: string; active: boolean; onPress: () => void };
+
+interface FilterItemData {
+  item: FilterItemType;
+}
+
+const renderFilterItem = ({ item: data }: { item: FilterItemData }) => {
+  const { item } = data;
+  const isActive = item.type === 'sort' ? item.selected : item.active;
+  return (
+    <ScalePressable
+      onPress={item.onPress}
+      className={`me-2 rounded-full px-3 py-2 border ${
+        isActive ? 'bg-[#DDF4EB] border-[#147D6473]' : 'bg-[#ECF5F0] border-[#DDE8E0]'
+      }`}
+    >
+      <AppText
+        variant="caption"
+        className={`font-bold ${isActive ? 'text-[#147D64]' : 'text-[#5A7467]'}`}
+      >
+        {item.label}
+      </AppText>
+    </ScalePressable>
+  );
+};
+
+interface AgentItemData {
+  item: Agent;
+  selectedAgentId: string | null;
+  onSelectAgent: (agentId: string | null) => void;
+}
+
+const renderAgentItem = ({ item: data }: { item: AgentItemData }) => {
+  const { item: agent, selectedAgentId, onSelectAgent } = data;
+  return (
+    <View style={{ marginRight: 8 }}>
+      <AgentPill
+        agent={agent}
+        onPress={() => onSelectAgent(selectedAgentId === agent.id ? null : agent.id)}
+      />
+    </View>
+  );
+};
+
+export const ChatListHeader = React.memo(function ChatListHeader({
   t,
   query,
   onChangeQuery,
@@ -64,6 +110,72 @@ export function ChatListHeader({
     const timer = setTimeout(() => onChangeQuery(localQuery), 300);
     return () => clearTimeout(timer);
   }, [localQuery, onChangeQuery]);
+
+  const filterData: FilterItemData[] = useMemo(() => {
+    const data: FilterItemType[] = [
+      {
+        type: 'sort',
+        mode: 'recent',
+        label: t('chat.filter_recent', 'Recent'),
+        selected: sortMode === 'recent',
+        onPress: () => onChangeSortMode('recent'),
+      },
+      {
+        type: 'sort',
+        mode: 'mentions',
+        label: t('chat.filter_mentions', 'Mentions'),
+        selected: sortMode === 'mentions',
+        onPress: () => onChangeSortMode('mentions'),
+      },
+      {
+        type: 'sort',
+        mode: 'tasks',
+        label: t('chat.filter_tasks', 'Tasks'),
+        selected: sortMode === 'tasks',
+        onPress: () => onChangeSortMode('tasks'),
+      },
+      {
+        type: 'toggle',
+        label: t('chat.recent_only', '7d'),
+        active: recentOnly,
+        onPress: onToggleRecentOnly,
+      },
+      {
+        type: 'toggle',
+        label: t('chat.unread_only', 'Unread'),
+        active: unreadOnly,
+        onPress: onToggleUnreadOnly,
+      },
+    ];
+    return data.map(item => ({ item }));
+  }, [t, sortMode, onChangeSortMode, recentOnly, onToggleRecentOnly, unreadOnly, onToggleUnreadOnly]);
+
+  const agentData: AgentItemData[] = useMemo(() => {
+    return agents.map(agent => ({
+      item: agent,
+      selectedAgentId,
+      onSelectAgent,
+    }));
+  }, [agents, selectedAgentId, onSelectAgent]);
+
+  const keyExtractorFilter = useCallback((data: FilterItemData) => data.item.label, []);
+  const keyExtractorAgent = useCallback((data: AgentItemData) => data.item.id, []);
+
+  const ListHeaderComponentAgents = useCallback(() => (
+    <ScalePressable
+      onPress={() => onSelectAgent(null)}
+      className={`me-2 rounded-full px-3 py-2 border ${
+        selectedAgentId ? 'bg-[#ECF5F0] border-[#DDE8E0]' : 'bg-[#DDF4EB] border-[#147D6473]'
+      }`}
+    >
+      <AppText
+        variant="caption"
+        className={`font-bold ${selectedAgentId ? 'text-[#5A7467]' : 'text-[#147D64]'}`}
+      >
+        {t('chat.all_agents', 'All')}
+      </AppText>
+    </ScalePressable>
+  ), [selectedAgentId, onSelectAgent, t]);
 
   return (
     <>
@@ -104,53 +216,13 @@ export function ChatListHeader({
           ) : null}
         </View>
 
-        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-          {(
-            [
-              ['recent', t('chat.filter_recent', 'Recent')],
-              ['mentions', t('chat.filter_mentions', 'Mentions')],
-              ['tasks', t('chat.filter_tasks', 'Tasks')],
-            ] as [SortMode, string][]
-          ).map(([mode, label]) => {
-            const selected = sortMode === mode;
-            return (
-              <ScalePressable
-                key={mode}
-                onPress={() => onChangeSortMode(mode)}
-                className={`me-2 rounded-full px-3 py-2 border ${
-                  selected
-                    ? 'bg-[#DDF4EB] border-[#147D6473]'
-                    : 'bg-[#ECF5F0] border-[#DDE8E0]'
-                }`}
-              >
-                <AppText
-                  variant="caption"
-                  className={`font-bold ${selected ? 'text-[#147D64]' : 'text-[#5A7467]'}`}
-                >
-                  {label}
-                </AppText>
-              </ScalePressable>
-            );
-          })}
-          {(
-            [
-              [recentOnly, onToggleRecentOnly, t('chat.recent_only', '7d')],
-              [unreadOnly, onToggleUnreadOnly, t('chat.unread_only', 'Unread')],
-            ] as const
-          ).map(([active, onToggle, label]) => (
-            <ScalePressable
-              key={label}
-              onPress={onToggle}
-              className={`me-2 rounded-full px-3 py-2 border ${
-                active ? 'bg-[#DDF4EB] border-[#147D6473]' : 'bg-[#ECF5F0] border-[#DDE8E0]'
-              }`}
-            >
-              <AppText variant="caption" className={`font-bold ${active ? 'text-[#147D64]' : 'text-[#5A7467]'}`}>
-                {label}
-              </AppText>
-            </ScalePressable>
-          ))}
-        </ScrollView>
+        <FlatList
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          data={filterData}
+          renderItem={renderFilterItem}
+          keyExtractor={keyExtractorFilter}
+        />
       </View>
 
       {agents.length > 0 ? (
@@ -165,33 +237,15 @@ export function ChatListHeader({
                 : agents.length}
             </AppText>
           </View>
-          <ScrollView
+          <FlatList
             horizontal
             showsHorizontalScrollIndicator={false}
             contentContainerClassName="px-4"
-          >
-            <ScalePressable
-              onPress={() => onSelectAgent(null)}
-              className={`me-2 rounded-full px-3 py-2 border ${
-                selectedAgentId ? 'bg-[#ECF5F0] border-[#DDE8E0]' : 'bg-[#DDF4EB] border-[#147D6473]'
-              }`}
-            >
-              <AppText
-                variant="caption"
-                className={`font-bold ${selectedAgentId ? 'text-[#5A7467]' : 'text-[#147D64]'}`}
-              >
-                {t('chat.all_agents', 'All')}
-              </AppText>
-            </ScalePressable>
-            {agents.map((item) => (
-              <View key={item.id} style={{ marginRight: 8 }}>
-                <AgentPill
-                  agent={item}
-                  onPress={() => onSelectAgent(selectedAgentId === item.id ? null : item.id)}
-                />
-              </View>
-            ))}
-          </ScrollView>
+            data={agentData}
+            renderItem={renderAgentItem}
+            keyExtractor={keyExtractorAgent}
+            ListHeaderComponent={ListHeaderComponentAgents}
+          />
         </View>
       ) : null}
 
@@ -205,4 +259,4 @@ export function ChatListHeader({
       </View>
     </>
   );
-}
+});

--- a/frontend/src/components/chat/ChatListHeader.tsx
+++ b/frontend/src/components/chat/ChatListHeader.tsx
@@ -39,8 +39,8 @@ interface ChatListHeaderProps {
 }
 
 type FilterItemType =
-  | { type: 'sort'; mode: SortMode; label: string; selected: boolean; onPress: () => void }
-  | { type: 'toggle'; label: string; active: boolean; onPress: () => void };
+  | { type: 'sort'; mode: SortMode; label: string; selected: boolean; onPress: () => void; id: string }
+  | { type: 'toggle'; label: string; active: boolean; onPress: () => void; id: string };
 
 interface FilterItemData {
   item: FilterItemType;
@@ -75,7 +75,7 @@ interface AgentItemData {
 const renderAgentItem = ({ item: data }: { item: AgentItemData }) => {
   const { item: agent, selectedAgentId, onSelectAgent } = data;
   return (
-    <View style={{ marginRight: 8 }}>
+    <View className="mr-2">
       <AgentPill
         agent={agent}
         onPress={() => onSelectAgent(selectedAgentId === agent.id ? null : agent.id)}
@@ -119,6 +119,7 @@ export const ChatListHeader = React.memo(function ChatListHeader({
         label: t('chat.filter_recent', 'Recent'),
         selected: sortMode === 'recent',
         onPress: () => onChangeSortMode('recent'),
+        id: 'sort_recent',
       },
       {
         type: 'sort',
@@ -126,6 +127,7 @@ export const ChatListHeader = React.memo(function ChatListHeader({
         label: t('chat.filter_mentions', 'Mentions'),
         selected: sortMode === 'mentions',
         onPress: () => onChangeSortMode('mentions'),
+        id: 'sort_mentions',
       },
       {
         type: 'sort',
@@ -133,18 +135,21 @@ export const ChatListHeader = React.memo(function ChatListHeader({
         label: t('chat.filter_tasks', 'Tasks'),
         selected: sortMode === 'tasks',
         onPress: () => onChangeSortMode('tasks'),
+        id: 'sort_tasks',
       },
       {
         type: 'toggle',
         label: t('chat.recent_only', '7d'),
         active: recentOnly,
         onPress: onToggleRecentOnly,
+        id: 'toggle_recent_only',
       },
       {
         type: 'toggle',
         label: t('chat.unread_only', 'Unread'),
         active: unreadOnly,
         onPress: onToggleUnreadOnly,
+        id: 'toggle_unread_only',
       },
     ];
     return data.map(item => ({ item }));
@@ -158,7 +163,7 @@ export const ChatListHeader = React.memo(function ChatListHeader({
     }));
   }, [agents, selectedAgentId, onSelectAgent]);
 
-  const keyExtractorFilter = useCallback((data: FilterItemData) => data.item.label, []);
+  const keyExtractorFilter = useCallback((data: FilterItemData) => data.item.id, []);
   const keyExtractorAgent = useCallback((data: AgentItemData) => data.item.id, []);
 
   const ListHeaderComponentAgents = useCallback(() => (

--- a/frontend/src/components/chat/RoomPromptRail.tsx
+++ b/frontend/src/components/chat/RoomPromptRail.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Pressable, ScrollView, View } from 'react-native';
+import React, { useCallback, useMemo } from 'react';
+import { FlatList, Pressable, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { AppText } from '@/components/AppText';
 
@@ -23,7 +23,58 @@ interface RoomPromptRailProps {
   onContextPress?: (value: string) => void;
 }
 
-export function RoomPromptRail({
+interface PromptItemData {
+  item: PromptItem;
+  isStreaming: boolean;
+  onPromptPress: (text: string) => void;
+  onPromptLongPress: (prompt: PromptItem) => void;
+}
+
+const renderPromptItem = ({ item: data }: { item: PromptItemData }) => {
+  const { item: action, isStreaming, onPromptPress, onPromptLongPress } = data;
+  return (
+    <Pressable
+      onPress={() => onPromptPress(action.text)}
+      onLongPress={() => onPromptLongPress(action)}
+      className={`mr-2 rounded-full px-3 py-2 border ${
+        action.pinned
+          ? 'bg-[#DDF4EB] border-[#147D6455] text-[#147D64]'
+          : 'bg-[#ECF5F0] border-[#DDE8E0] text-[#13251C]'
+      } ${isStreaming ? 'opacity-60' : 'opacity-100'}`}
+      disabled={isStreaming}
+    >
+      <AppText
+        className={`text-xs font-bold ${
+          action.pinned ? 'text-[#147D64]' : 'text-[#13251C]'
+        }`}
+      >
+        {action.pinned ? '★ ' : ''}
+        {action.text}
+      </AppText>
+    </Pressable>
+  );
+};
+
+interface ContextActionData {
+  item: string;
+  onContextPress: (value: string) => void;
+}
+
+const renderContextActionItem = ({ item: data }: { item: ContextActionData }) => {
+  const { item: value, onContextPress } = data;
+  return (
+    <Pressable
+      onPress={() => onContextPress(value)}
+      className="mr-2 rounded-xl px-2.5 py-[7px] bg-[#ECF5F0] border border-[#DDE8E0]"
+    >
+      <AppText variant="caption" className="text-[#5A7467] font-bold">
+        {value}
+      </AppText>
+    </Pressable>
+  );
+};
+
+export const RoomPromptRail = React.memo(function RoomPromptRail({
   prompts,
   isStreaming,
   saveLabel,
@@ -37,6 +88,43 @@ export function RoomPromptRail({
   onContextPress,
 }: RoomPromptRailProps) {
   const { t } = useTranslation();
+
+  const promptData: PromptItemData[] = useMemo(
+    () =>
+      prompts.map((p) => ({
+        item: p,
+        isStreaming,
+        onPromptPress,
+        onPromptLongPress,
+      })),
+    [prompts, isStreaming, onPromptPress, onPromptLongPress]
+  );
+
+  const contextData: ContextActionData[] = useMemo(
+    () =>
+      contextActions && onContextPress
+        ? contextActions.map((c) => ({
+            item: c,
+            onContextPress,
+          }))
+        : [],
+    [contextActions, onContextPress]
+  );
+
+  const keyExtractorPrompt = useCallback((data: PromptItemData) => data.item.id, []);
+  const keyExtractorContext = useCallback((data: ContextActionData) => data.item, []);
+
+  const ListHeaderComponent = useCallback(() => (
+    <Pressable
+      onPress={onSave}
+      className={`mr-2 rounded-full px-3 py-2 border bg-[#DDF4EB] border-[#147D6455] ${
+        isStreaming || !canSave ? 'opacity-50' : 'opacity-100'
+      }`}
+      disabled={isStreaming || !canSave}
+    >
+      <AppText className="text-xs font-bold text-[#147D64]">{saveLabel}</AppText>
+    </Pressable>
+  ), [onSave, isStreaming, canSave, saveLabel]);
 
   return (
     <View className="px-3 pb-2">
@@ -52,65 +140,27 @@ export function RoomPromptRail({
           ) : null}
         </View>
 
-        <ScrollView
+        <FlatList
           horizontal
           showsHorizontalScrollIndicator={false}
           contentContainerClassName="px-3"
-        >
-          <Pressable
-            onPress={onSave}
-            className={`mr-2 rounded-full px-3 py-2 border bg-[#DDF4EB] border-[#147D6455] ${
-              isStreaming || !canSave ? 'opacity-50' : 'opacity-100'
-            }`}
-            disabled={isStreaming || !canSave}
-          >
-            <AppText className="text-xs font-bold text-[#147D64]">{saveLabel}</AppText>
-          </Pressable>
+          data={promptData}
+          renderItem={renderPromptItem}
+          keyExtractor={keyExtractorPrompt}
+          ListHeaderComponent={ListHeaderComponent}
+        />
 
-          {prompts.map((action) => (
-            <Pressable
-              key={action.id}
-              onPress={() => onPromptPress(action.text)}
-              onLongPress={() => onPromptLongPress(action)}
-              className={`mr-2 rounded-full px-3 py-2 border ${
-                action.pinned
-                  ? 'bg-[#DDF4EB] border-[#147D6455] text-[#147D64]'
-                  : 'bg-[#ECF5F0] border-[#DDE8E0] text-[#13251C]'
-              } ${isStreaming ? 'opacity-60' : 'opacity-100'}`}
-              disabled={isStreaming}
-            >
-              <AppText
-                className={`text-xs font-bold ${
-                  action.pinned ? 'text-[#147D64]' : 'text-[#13251C]'
-                }`}
-              >
-                {action.pinned ? '★ ' : ''}
-                {action.text}
-              </AppText>
-            </Pressable>
-          ))}
-        </ScrollView>
-
-        {contextActions && contextActions.length > 0 && onContextPress ? (
-          <ScrollView
+        {contextData.length > 0 ? (
+          <FlatList
             horizontal
             showsHorizontalScrollIndicator={false}
             contentContainerClassName="px-3 pt-2"
-          >
-            {contextActions.map((value) => (
-              <Pressable
-                key={value}
-                onPress={() => onContextPress(value)}
-                className="mr-2 rounded-xl px-2.5 py-[7px] bg-[#ECF5F0] border border-[#DDE8E0]"
-              >
-                <AppText variant="caption" className="text-[#5A7467] font-bold">
-                  {value}
-                </AppText>
-              </Pressable>
-            ))}
-          </ScrollView>
+            data={contextData}
+            renderItem={renderContextActionItem}
+            keyExtractor={keyExtractorContext}
+          />
         ) : null}
       </View>
     </View>
   );
-}
+});


### PR DESCRIPTION
Refactored `ChatListHeader.tsx` and `RoomPromptRail.tsx` to utilize `FlatList` instead of mapped arrays within `ScrollView`s. Implemented strict memoization using `React.memo`, `useMemo`, and `useCallback`, completely extracting `renderItem` handlers outside the component body to drastically reduce unnecessary re-renders and memory allocations, fulfilling the performance engineer directive.

---
*PR created automatically by Jules for task [8135604328252019191](https://jules.google.com/task/8135604328252019191) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved performance and smoother horizontal lists for chat filters, agent selection, and prompt chips.
  * More stable selection behavior (including an explicit "All" agents option).
  * Context actions now appear only when relevant.
  * Save action moved to the top of the prompt list for easier access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->