### PR TITLE
Refactor: Decouple Productivity Screen into ViewModel

### DIFF
--- a/frontend/app/(main)/productivity.tsx
+++ b/frontend/app/(main)/productivity.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  ActivityIndicator,
   FlatList,
   Platform,
   Pressable,
@@ -94,9 +95,11 @@ const ProductivityListItem = React.memo(function ProductivityListItem({
 const TodayPlanHeader = ({
   todayPlan,
   setTodayPlan,
+  t,
 }: {
   todayPlan: string | null;
   setTodayPlan: (plan: string | null) => void;
+  t: (key: string, options?: any) => string;
 }) => {
   if (!todayPlan) return null;
   return (
@@ -118,9 +121,13 @@ const TodayPlanHeader = ({
         }}
       >
         <AppText style={{ color: T.onSurface.light, fontWeight: '700', fontSize: 15 }}>
-          Today plan
+          {t('productivity.today_plan') || 'Today plan'}
         </AppText>
-        <Pressable onPress={() => setTodayPlan(null)}>
+        <Pressable
+          onPress={() => setTodayPlan(null)}
+          accessibilityRole="button"
+          accessibilityLabel={t('settings.actions.dismiss') || 'Dismiss'}
+        >
           <Ionicons name="close" size={16} color={T.onSurface.mutedLight} />
         </Pressable>
       </View>
@@ -424,17 +431,23 @@ export default function ProductivityScreen() {
         )}
         ListHeaderComponent={
           activeTab === 'today' ? (
-            <TodayPlanHeader todayPlan={todayPlan} setTodayPlan={setTodayPlan} />
+            <TodayPlanHeader todayPlan={todayPlan} setTodayPlan={setTodayPlan} t={t} />
           ) : null
         }
         ListEmptyComponent={
-          <ProductivityEmptyState
-            activeTab={activeTab}
-            searchQuery={searchQuery}
-            setShowCreateNote={setShowCreateNote}
-            setShowCreateTask={setShowCreateTask}
-            t={t}
-          />
+          isLoading ? (
+            <View style={styles.emptyContainer}>
+              <ActivityIndicator size="large" color={T.primary.DEFAULT} />
+            </View>
+          ) : (
+            <ProductivityEmptyState
+              activeTab={activeTab}
+              searchQuery={searchQuery}
+              setShowCreateNote={setShowCreateNote}
+              setShowCreateTask={setShowCreateTask}
+              t={t}
+            />
+          )
         }
       />
 

--- a/frontend/app/(main)/productivity.tsx
+++ b/frontend/app/(main)/productivity.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React from 'react';
 import {
-  Alert,
   FlatList,
   Platform,
   Pressable,
@@ -11,17 +10,15 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { useLocalSearchParams, usePathname, useRouter } from 'expo-router';
-import { useTranslation } from 'react-i18next';
 import { AppText } from '../../src/components/AppText';
 import { CreateNoteModal } from '../../src/components/productivity/CreateNoteModal';
 import { CreateTaskModal } from '../../src/components/productivity/CreateTaskModal';
 import { NoteCard } from '../../src/components/productivity/NoteCard';
 import { TaskCard } from '../../src/components/productivity/TaskCard';
 import { theme } from '../../src/core/theme';
-import { CalendarEvent, Note, Task } from '../../src/core/models';
-import { useProductivityStore } from '../../src/store/useProductivityStore';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
+import { useProductivityViewModel, RenderItemData, Tab, TaskPriority } from '@/hooks/viewmodels/useProductivityViewModel';
+import { CalendarEvent, Note, Task } from '@/core/models';
 
 const T = {
   background: { light: DESIGN_TOKENS.colors.pageBg },
@@ -42,340 +39,224 @@ const T = {
 const S = theme.spacing;
 const R = theme.borderRadius;
 
-type Tab = 'today' | 'all' | 'notes' | 'tasks';
-type TaskPriority = 'all' | 'overdue' | 'today' | 'upcoming' | 'no_due';
+const ProductivityListItem = React.memo(function ProductivityListItem({
+  itemData,
+  confirmDelete,
+  deleteNote,
+  deleteTask,
+  toggleTask,
+  language,
+}: {
+  itemData: RenderItemData;
+  confirmDelete: (action: () => Promise<void>) => void;
+  deleteNote: (id: string) => Promise<void>;
+  deleteTask: (id: string) => Promise<void>;
+  toggleTask: (id: string) => Promise<void>;
+  language: string;
+}) {
+  if (itemData.type === 'note') {
+    const note = itemData.item as Note;
+    return <NoteCard note={note} onDelete={() => confirmDelete(() => deleteNote(note.id))} />;
+  }
+  if (itemData.type === 'event') {
+    const event = itemData.item as CalendarEvent;
+    return (
+      <View style={styles.eventCard}>
+        <View style={styles.eventIcon}>
+          <Ionicons name="calendar-outline" size={16} color={T.primary.DEFAULT} />
+        </View>
+        <View style={styles.eventBody}>
+          <AppText style={styles.eventTitle}>{event.title}</AppText>
+          <AppText style={styles.eventMeta}>
+            {new Intl.DateTimeFormat(language, {
+              weekday: 'short',
+              month: 'short',
+              day: 'numeric',
+              hour: event.is_all_day ? undefined : '2-digit',
+              minute: event.is_all_day ? undefined : '2-digit',
+            }).format(new Date(event.start_time))}
+          </AppText>
+        </View>
+      </View>
+    );
+  }
 
-type RenderItemData = {
-  date?: number;
-  type: 'note' | 'task' | 'event';
-  item: Note | Task | CalendarEvent;
-  id: string;
+  const task = itemData.item as Task;
+  return (
+    <TaskCard
+      task={task}
+      onToggle={() => toggleTask(task.id)}
+      onDelete={() => confirmDelete(() => deleteTask(task.id))}
+    />
+  );
+});
+
+const TodayPlanHeader = ({
+  todayPlan,
+  setTodayPlan,
+}: {
+  todayPlan: string | null;
+  setTodayPlan: (plan: string | null) => void;
+}) => {
+  if (!todayPlan) return null;
+  return (
+    <View
+      style={{
+        borderRadius: R.xl,
+        backgroundColor: T.primary.surfaceLight,
+        borderWidth: 1,
+        borderColor: T.border.light,
+        padding: S.lg,
+        marginBottom: S.md,
+      }}
+    >
+      <View
+        style={{
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <AppText style={{ color: T.onSurface.light, fontWeight: '700', fontSize: 15 }}>
+          Today plan
+        </AppText>
+        <Pressable onPress={() => setTodayPlan(null)}>
+          <Ionicons name="close" size={16} color={T.onSurface.mutedLight} />
+        </Pressable>
+      </View>
+      <AppText style={{ color: T.onSurface.mutedLight, marginTop: 8, lineHeight: 20 }}>
+        {todayPlan}
+      </AppText>
+    </View>
+  );
+};
+
+const ProductivityEmptyState = ({
+  activeTab,
+  searchQuery,
+  setShowCreateNote,
+  setShowCreateTask,
+  t,
+}: {
+  activeTab: Tab;
+  searchQuery: string;
+  setShowCreateNote: (show: boolean) => void;
+  setShowCreateTask: (show: boolean) => void;
+  t: (key: string, options?: any) => string;
+}) => {
+  return (
+    <View style={styles.emptyContainer}>
+      <View style={styles.emptyIconCircle}>
+        <Ionicons
+          name={
+            activeTab === 'notes'
+              ? 'document-text'
+              : activeTab === 'tasks'
+                ? 'checkbox'
+                : activeTab === 'today'
+                  ? 'sunny-outline'
+                  : 'planet'
+          }
+          size={42}
+          color={T.primary.DEFAULT}
+        />
+      </View>
+      <AppText variant="h3" style={styles.emptyTitle}>
+        {searchQuery
+          ? t('productivity.no_matches') || 'No matches found'
+          : activeTab === 'notes'
+            ? t('productivity.no_notes') || 'No Notes'
+            : activeTab === 'tasks'
+              ? t('productivity.no_tasks') || 'No Tasks'
+              : activeTab === 'today'
+                ? t('productivity.nothing_urgent_today') || 'Nothing Urgent Today'
+                : t('productivity.workspace_clear') || 'Your workspace is clear'}
+      </AppText>
+      <AppText style={styles.emptySubtitle}>
+        {searchQuery
+          ? t('productivity.try_adjust_search') || 'Try adjusting your search terms.'
+          : activeTab === 'today'
+            ? t('productivity.today_empty_detail') || 'Enjoy your day.'
+            : t('productivity.capture_thoughts') ||
+              'Capture your thoughts and track what needs to get done.'}
+      </AppText>
+
+      {!searchQuery && (
+        <View style={styles.emptyActions}>
+          {(activeTab === 'all' || activeTab === 'notes') && (
+            <Pressable
+              onPress={() => setShowCreateNote(true)}
+              style={({ pressed }) => [styles.emptyButton, pressed && { opacity: 0.8 }]}
+            >
+              <Ionicons name="add" size={18} color={T.white} style={{ marginEnd: 6 }} />
+              <AppText style={styles.emptyButtonText}>
+                {t('productivity.newNote') || 'New Note'}
+              </AppText>
+            </Pressable>
+          )}
+          {(activeTab === 'all' || activeTab === 'tasks' || activeTab === 'today') && (
+            <Pressable
+              onPress={() => setShowCreateTask(true)}
+              style={({ pressed }) => [
+                styles.emptyButton,
+                (activeTab === 'all' || activeTab === 'today') && styles.emptyButtonSecondary,
+                pressed && { opacity: 0.8 },
+              ]}
+            >
+              <Ionicons
+                name="add"
+                size={18}
+                color={
+                  activeTab === 'all' || activeTab === 'today' ? T.primary.DEFAULT : T.white
+                }
+                style={{ marginEnd: 6 }}
+              />
+              <AppText
+                style={
+                  activeTab === 'all' || activeTab === 'today'
+                    ? styles.emptyButtonTextSecondary
+                    : styles.emptyButtonText
+                }
+              >
+                {t('productivity.new_task') || 'New Task'}
+              </AppText>
+            </Pressable>
+          )}
+        </View>
+      )}
+    </View>
+  );
 };
 
 export default function ProductivityScreen() {
-  const { t, i18n } = useTranslation();
-  const router = useRouter();
-  const pathname = usePathname();
-  const params = useLocalSearchParams() as Record<string, string | string[] | undefined>;
-  const openCreateTask = params.openCreateTask;
-  const openCreateNote = params.openCreateNote;
-  const [activeTab, setActiveTab] = useState<Tab>('today');
-  const [taskPriority, setTaskPriority] = useState<TaskPriority>('all');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [showCreateNote, setShowCreateNote] = useState(false);
-  const [showCreateTask, setShowCreateTask] = useState(false);
-  const [todayPlan, setTodayPlan] = useState<string | null>(null);
-
   const {
-    notes,
-    tasks,
-    events,
-    fetchNotes,
-    fetchTasks,
-    fetchEvents,
+    t,
+    i18n,
+    activeTab,
+    setActiveTab,
+    taskPriority,
+    setTaskPriority,
+    searchQuery,
+    setSearchQuery,
+    showCreateNote,
+    setShowCreateNote,
+    showCreateTask,
+    setShowCreateTask,
+    todayPlan,
+    setTodayPlan,
+    dataToRender,
     isLoading,
+    handleRefresh,
+    confirmDelete,
     deleteNote,
     deleteTask,
     toggleTask,
-  } = useProductivityStore();
-
-  useEffect(() => {
-    const controller = new AbortController();
-    fetchNotes(controller.signal);
-    fetchTasks(controller.signal);
-    fetchEvents(controller.signal);
-    return () => {
-      controller.abort();
-    };
-  }, [fetchEvents, fetchNotes, fetchTasks]);
-
-  useEffect(() => {
-    if (openCreateTask === '1' || openCreateTask === 'true') {
-      setShowCreateTask(true);
-      const nextParams = Object.fromEntries(
-        Object.entries(params).filter(
-          ([key, value]) => key !== 'openCreateTask' && typeof value === 'string'
-        )
-      );
-      router.replace({ pathname, params: nextParams });
-    }
-  }, [openCreateTask, params, pathname, router]);
-
-  useEffect(() => {
-    if (openCreateNote === '1' || openCreateNote === 'true') {
-      setShowCreateNote(true);
-      const nextParams = Object.fromEntries(
-        Object.entries(params).filter(
-          ([key, value]) => key !== 'openCreateNote' && typeof value === 'string'
-        )
-      );
-      router.replace({ pathname, params: nextParams });
-    }
-  }, [openCreateNote, params, pathname, router]);
-
-  const handleRefresh = useCallback(() => {
-    fetchNotes();
-    fetchTasks();
-    fetchEvents();
-  }, [fetchEvents, fetchNotes, fetchTasks]);
-
-  const confirmDelete = useCallback(
-    (action: () => Promise<void>) =>
-      Alert.alert(
-        t('productivity.delete') || 'Delete',
-        t('productivity.are_you_sure') || 'Are you sure?',
-        [
-          { text: t('settings.actions.cancel') || 'Cancel', style: 'cancel' },
-          {
-            text: t('settings.actions.delete') || 'Delete',
-            style: 'destructive',
-            onPress: () => action(),
-          },
-        ]
-      ),
-    [t]
-  );
-
-  const filteredNotes = useMemo(() => {
-    if (!searchQuery) return notes;
-    const lowerQ = searchQuery.toLowerCase();
-    return notes.filter(
-      (n) => n.title.toLowerCase().includes(lowerQ) || n.content.toLowerCase().includes(lowerQ)
-    );
-  }, [notes, searchQuery]);
-
-  const filteredTasks = useMemo(() => {
-    if (!searchQuery) return tasks;
-    const lowerQ = searchQuery.toLowerCase();
-    return tasks.filter(
-      (task) =>
-        task.title.toLowerCase().includes(lowerQ) ||
-        (task.description?.toLowerCase().includes(lowerQ) ?? false)
-    );
-  }, [searchQuery, tasks]);
-
-  const filteredEvents = useMemo(() => {
-    if (!searchQuery) return events;
-    const lowerQ = searchQuery.toLowerCase();
-    return events.filter(
-      (event) =>
-        event.title.toLowerCase().includes(lowerQ) ||
-        (event.description?.toLowerCase().includes(lowerQ) ?? false) ||
-        (event.location?.toLowerCase().includes(lowerQ) ?? false)
-    );
-  }, [events, searchQuery]);
-
-  const pendingTasksCount = useMemo(
-    () => filteredTasks.filter((task) => !task.completed).length,
-    [filteredTasks]
-  );
-
-  const getTaskPriority = useCallback((task: Task): Exclude<TaskPriority, 'all'> => {
-    if (!task.due_date) return 'no_due';
-    const now = new Date();
-    const due = new Date(task.due_date);
-    if (isNaN(due.getTime())) return 'no_due';
-    const dayStart = new Date(now);
-    dayStart.setHours(0, 0, 0, 0);
-    const tomorrow = new Date(dayStart);
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    if (due < dayStart) return 'overdue';
-    if (due >= dayStart && due < tomorrow) return 'today';
-    return 'upcoming';
-  }, []);
-
-  const taskPriorityCounts = useMemo(() => {
-    const counts: Record<TaskPriority, number> = {
-      all: 0,
-      overdue: 0,
-      today: 0,
-      upcoming: 0,
-      no_due: 0,
-    };
-    filteredTasks
-      .filter((task) => !task.completed)
-      .forEach((task) => {
-        counts.all += 1;
-        counts[getTaskPriority(task)] += 1;
-      });
-    return counts;
-  }, [filteredTasks, getTaskPriority]);
-
-  const prioritizedTasks = useMemo(() => {
-    const tasksToRank = filteredTasks.filter((task) => !task.completed);
-    const pool =
-      taskPriority === 'all'
-        ? tasksToRank
-        : tasksToRank.filter((task) => getTaskPriority(task) === taskPriority);
-    return [...pool].sort((a, b) => {
-      const aDue = a.due_date ? new Date(a.due_date).getTime() : Number.MAX_SAFE_INTEGER;
-      const bDue = b.due_date ? new Date(b.due_date).getTime() : Number.MAX_SAFE_INTEGER;
-      return aDue - bDue;
-    });
-  }, [filteredTasks, getTaskPriority, taskPriority]);
-
-  const mixedData = useMemo(() => {
-    const data: RenderItemData[] = [];
-    filteredNotes.forEach((note) => {
-      data.push({
-        type: 'note',
-        item: note,
-        id: `note-${note.id}`,
-        date: new Date(note.created_at).getTime(),
-      });
-    });
-    filteredTasks.forEach((task) => {
-      data.push({
-        type: 'task',
-        item: task,
-        id: `task-${task.id}`,
-        date: new Date(task.created_at).getTime(),
-      });
-    });
-    return data.sort((a, b) => (b.date || 0) - (a.date || 0));
-  }, [filteredNotes, filteredTasks]);
-
-  const todayData = useMemo(() => {
-    const now = new Date();
-    const start = new Date(now);
-    start.setHours(0, 0, 0, 0);
-    const end = new Date(start);
-    end.setDate(end.getDate() + 1);
-    const weekEnd = new Date(start);
-    weekEnd.setDate(weekEnd.getDate() + 7);
-
-    const overdueTasks = filteredTasks.filter((task) => {
-      if (task.completed || !task.due_date) return false;
-      return new Date(task.due_date) < start;
-    });
-
-    const dueTodayTasks = filteredTasks.filter((task) => {
-      if (task.completed || !task.due_date) return false;
-      const dueDate = new Date(task.due_date);
-      return dueDate >= start && dueDate < end;
-    });
-
-    const upcomingEvents = filteredEvents.filter((event) => {
-      const startTime = new Date(event.start_time);
-      return startTime >= start && startTime < weekEnd;
-    });
-
-    const items: RenderItemData[] = [
-      ...overdueTasks.map((task) => ({
-        type: 'task' as const,
-        item: task,
-        id: `overdue-${task.id}`,
-        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
-      })),
-      ...dueTodayTasks.map((task) => ({
-        type: 'task' as const,
-        item: task,
-        id: `today-${task.id}`,
-        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
-      })),
-      ...upcomingEvents.map((event) => ({
-        type: 'event' as const,
-        item: event,
-        id: `event-${event.id}`,
-        date: new Date(event.start_time).getTime(),
-      })),
-    ];
-
-    return items.sort((a, b) => (a.date || 0) - (b.date || 0));
-  }, [filteredEvents, filteredTasks]);
-
-  const dataToRender: RenderItemData[] =
-    activeTab === 'today'
-      ? todayData.filter((entry) => {
-          if (entry.type !== 'task') return true;
-          if (taskPriority === 'all') return true;
-          return getTaskPriority(entry.item as Task) === taskPriority;
-        })
-      : activeTab === 'all'
-        ? mixedData
-        : activeTab === 'notes'
-          ? filteredNotes.map((note) => ({ type: 'note' as const, item: note, id: note.id }))
-          : prioritizedTasks.map((task) => ({ type: 'task' as const, item: task, id: task.id }));
-
-  const generateTodayPlan = useCallback(() => {
-    const now = new Date();
-    const nextTasks = prioritizedTasks.slice(0, 3);
-    const nextEvents = [...filteredEvents]
-      .filter((event) => new Date(event.end_time) >= now)
-      .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime())
-      .slice(0, 3);
-
-    const lines: string[] = [];
-    if (taskPriorityCounts.overdue > 0) {
-      lines.push(`1) Recover overdue: start with ${taskPriorityCounts.overdue} overdue task(s).`);
-    } else {
-      lines.push('1) No overdue tasks: start with highest-impact open work.');
-    }
-
-    if (nextTasks.length > 0) {
-      lines.push(`2) Focus block: ${nextTasks.map((task) => task.title).join(', ')}.`);
-    } else {
-      lines.push('2) Focus block: no pending tasks, use this for planning or review.');
-    }
-
-    if (nextEvents.length > 0) {
-      const eventLine = nextEvents
-        .map((event) =>
-          new Intl.DateTimeFormat(i18n.language, {
-            hour: '2-digit',
-            minute: '2-digit',
-          }).format(new Date(event.start_time))
-        )
-        .join(', ');
-      lines.push(`3) Calendar checkpoints at ${eventLine}.`);
-    } else {
-      lines.push('3) Calendar is light: reserve time for deep work and wrap-up.');
-    }
-
-    setTodayPlan(lines.join('\n'));
-    setActiveTab('today');
-  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue]);
-
-  const renderItem = useCallback(
-    ({ item }: { item: RenderItemData }) => {
-      if (item.type === 'note') {
-        const note = item.item as Note;
-        return <NoteCard note={note} onDelete={() => confirmDelete(() => deleteNote(note.id))} />;
-      }
-      if (item.type === 'event') {
-        const event = item.item as CalendarEvent;
-        return (
-          <View style={styles.eventCard}>
-            <View style={styles.eventIcon}>
-              <Ionicons name="calendar-outline" size={16} color={T.primary.DEFAULT} />
-            </View>
-            <View style={styles.eventBody}>
-              <AppText style={styles.eventTitle}>{event.title}</AppText>
-              <AppText style={styles.eventMeta}>
-                {new Intl.DateTimeFormat(i18n.language, {
-                  weekday: 'short',
-                  month: 'short',
-                  day: 'numeric',
-                  hour: event.is_all_day ? undefined : '2-digit',
-                  minute: event.is_all_day ? undefined : '2-digit',
-                }).format(new Date(event.start_time))}
-              </AppText>
-            </View>
-          </View>
-        );
-      }
-
-      const task = item.item as Task;
-      return (
-        <TaskCard
-          task={task}
-          onToggle={() => toggleTask(task.id)}
-          onDelete={() => confirmDelete(() => deleteTask(task.id))}
-        />
-      );
-    },
-    [confirmDelete, deleteNote, deleteTask, i18n.language, toggleTask]
-  );
+    pendingTasksCount,
+    taskPriorityCounts,
+    generateTodayPlan,
+    fetchNotes,
+    fetchTasks,
+  } = useProductivityViewModel();
 
   return (
     <SafeAreaView style={styles.container}>
@@ -446,7 +327,7 @@ export default function ProductivityScreen() {
           >
             <AppText style={[styles.tabText, activeTab === tab && styles.tabTextActive]}>
               {tab === 'today'
-                ? t('productivity.today')
+                ? t('productivity.today') || 'Today'
                 : tab === 'all'
                   ? t('productivity.all') || 'All'
                   : tab === 'notes'
@@ -468,28 +349,28 @@ export default function ProductivityScreen() {
         >
           {(
             [
-              { key: 'all', label: t('productivity.priority.all', { count: taskPriorityCounts.all }) },
+              { key: 'all', label: t('productivity.priority.all', { count: taskPriorityCounts.all }) || `All (${taskPriorityCounts.all})` },
               {
                 key: 'overdue',
-                label: t('productivity.priority.overdue', { count: taskPriorityCounts.overdue }),
+                label: t('productivity.priority.overdue', { count: taskPriorityCounts.overdue }) || `Overdue (${taskPriorityCounts.overdue})`,
               },
               {
                 key: 'today',
-                label: t('productivity.priority.today', { count: taskPriorityCounts.today }),
+                label: t('productivity.priority.today', { count: taskPriorityCounts.today }) || `Today (${taskPriorityCounts.today})`,
               },
               {
                 key: 'upcoming',
-                label: t('productivity.priority.upcoming', { count: taskPriorityCounts.upcoming }),
+                label: t('productivity.priority.upcoming', { count: taskPriorityCounts.upcoming }) || `Upcoming (${taskPriorityCounts.upcoming})`,
               },
               {
                 key: 'no_due',
-                label: t('productivity.priority.no_due', { count: taskPriorityCounts.no_due }),
+                label: t('productivity.priority.no_due', { count: taskPriorityCounts.no_due }) || `No Due Date (${taskPriorityCounts.no_due})`,
               },
             ] as const
           ).map((option) => (
             <Pressable
               key={option.key}
-              onPress={() => setTaskPriority(option.key)}
+              onPress={() => setTaskPriority(option.key as TaskPriority)}
               style={({ pressed }) => [
                 {
                   borderRadius: 12,
@@ -531,120 +412,29 @@ export default function ProductivityScreen() {
             tintColor={T.primary.DEFAULT}
           />
         }
-        renderItem={renderItem}
+        renderItem={({ item }) => (
+          <ProductivityListItem
+            itemData={item}
+            confirmDelete={confirmDelete}
+            deleteNote={deleteNote}
+            deleteTask={deleteTask}
+            toggleTask={toggleTask}
+            language={i18n.language}
+          />
+        )}
         ListHeaderComponent={
-          activeTab === 'today' && todayPlan ? (
-            <View
-              style={{
-                borderRadius: R.xl,
-                backgroundColor: T.primary.surfaceLight,
-                borderWidth: 1,
-                borderColor: T.border.light,
-                padding: S.lg,
-                marginBottom: S.md,
-              }}
-            >
-              <View
-                style={{
-                  flexDirection: 'row',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                }}
-              >
-                <AppText style={{ color: T.onSurface.light, fontWeight: '700', fontSize: 15 }}>
-                  Today plan
-                </AppText>
-                <Pressable onPress={() => setTodayPlan(null)}>
-                  <Ionicons name="close" size={16} color={T.onSurface.mutedLight} />
-                </Pressable>
-              </View>
-              <AppText style={{ color: T.onSurface.mutedLight, marginTop: 8, lineHeight: 20 }}>
-                {todayPlan}
-              </AppText>
-            </View>
+          activeTab === 'today' ? (
+            <TodayPlanHeader todayPlan={todayPlan} setTodayPlan={setTodayPlan} />
           ) : null
         }
         ListEmptyComponent={
-          <View style={styles.emptyContainer}>
-            <View style={styles.emptyIconCircle}>
-              <Ionicons
-                name={
-                  activeTab === 'notes'
-                    ? 'document-text'
-                    : activeTab === 'tasks'
-                      ? 'checkbox'
-                      : activeTab === 'today'
-                        ? 'sunny-outline'
-                        : 'planet'
-                }
-                size={42}
-                color={T.primary.DEFAULT}
-              />
-            </View>
-            <AppText variant="h3" style={styles.emptyTitle}>
-              {searchQuery
-                ? t('productivity.no_matches') || 'No matches found'
-                : activeTab === 'notes'
-                  ? t('productivity.no_notes') || 'No Notes'
-                  : activeTab === 'tasks'
-                    ? t('productivity.no_tasks') || 'No Tasks'
-                    : activeTab === 'today'
-                      ? t('productivity.nothing_urgent_today')
-                      : t('productivity.workspace_clear') || 'Your workspace is clear'}
-            </AppText>
-            <AppText style={styles.emptySubtitle}>
-              {searchQuery
-                ? t('productivity.try_adjust_search') || 'Try adjusting your search terms.'
-                : activeTab === 'today'
-                  ? t('productivity.today_empty_detail')
-                  : t('productivity.capture_thoughts') ||
-                    'Capture your thoughts and track what needs to get done.'}
-            </AppText>
-
-            {!searchQuery && (
-              <View style={styles.emptyActions}>
-                {(activeTab === 'all' || activeTab === 'notes') && (
-                  <Pressable
-                    onPress={() => setShowCreateNote(true)}
-                    style={({ pressed }) => [styles.emptyButton, pressed && { opacity: 0.8 }]}
-                  >
-                    <Ionicons name="add" size={18} color={T.white} style={{ marginEnd: 6 }} />
-                    <AppText style={styles.emptyButtonText}>
-                      {t('productivity.newNote') || 'New Note'}
-                    </AppText>
-                  </Pressable>
-                )}
-                {(activeTab === 'all' || activeTab === 'tasks' || activeTab === 'today') && (
-                  <Pressable
-                    onPress={() => setShowCreateTask(true)}
-                    style={({ pressed }) => [
-                      styles.emptyButton,
-                      (activeTab === 'all' || activeTab === 'today') && styles.emptyButtonSecondary,
-                      pressed && { opacity: 0.8 },
-                    ]}
-                  >
-                    <Ionicons
-                      name="add"
-                      size={18}
-                      color={
-                        activeTab === 'all' || activeTab === 'today' ? T.primary.DEFAULT : T.white
-                      }
-                      style={{ marginEnd: 6 }}
-                    />
-                    <AppText
-                      style={
-                        activeTab === 'all' || activeTab === 'today'
-                          ? styles.emptyButtonTextSecondary
-                          : styles.emptyButtonText
-                      }
-                    >
-                      {t('productivity.new_task')}
-                    </AppText>
-                  </Pressable>
-                )}
-              </View>
-            )}
-          </View>
+          <ProductivityEmptyState
+            activeTab={activeTab}
+            searchQuery={searchQuery}
+            setShowCreateNote={setShowCreateNote}
+            setShowCreateTask={setShowCreateTask}
+            t={t}
+          />
         }
       />
 

--- a/frontend/src/hooks/viewmodels/useProductivityViewModel.ts
+++ b/frontend/src/hooks/viewmodels/useProductivityViewModel.ts
@@ -26,6 +26,16 @@ export function useProductivityViewModel() {
   const [activeTab, setActiveTab] = useState<Tab>('today');
   const [taskPriority, setTaskPriority] = useState<TaskPriority>('all');
   const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(searchQuery);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery);
+    }, 300);
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [searchQuery]);
   const [showCreateNote, setShowCreateNote] = useState(false);
   const [showCreateTask, setShowCreateTask] = useState(false);
   const [todayPlan, setTodayPlan] = useState<string | null>(null);
@@ -57,9 +67,7 @@ export function useProductivityViewModel() {
     if (openCreateTask === '1' || openCreateTask === 'true') {
       setShowCreateTask(true);
       const nextParams = Object.fromEntries(
-        Object.entries(params).filter(
-          ([key, value]) => key !== 'openCreateTask' && typeof value === 'string'
-        )
+        Object.entries(params).filter(([key]) => key !== 'openCreateTask')
       );
       router.replace({ pathname, params: nextParams });
     }
@@ -69,9 +77,7 @@ export function useProductivityViewModel() {
     if (openCreateNote === '1' || openCreateNote === 'true') {
       setShowCreateNote(true);
       const nextParams = Object.fromEntries(
-        Object.entries(params).filter(
-          ([key, value]) => key !== 'openCreateNote' && typeof value === 'string'
-        )
+        Object.entries(params).filter(([key]) => key !== 'openCreateNote')
       );
       router.replace({ pathname, params: nextParams });
     }
@@ -101,33 +107,33 @@ export function useProductivityViewModel() {
   );
 
   const filteredNotes = useMemo(() => {
-    if (!searchQuery) return notes;
-    const lowerQ = searchQuery.toLowerCase();
+    if (!debouncedSearchQuery) return notes;
+    const lowerQ = debouncedSearchQuery.toLowerCase();
     return notes.filter(
       (n) => n.title.toLowerCase().includes(lowerQ) || n.content.toLowerCase().includes(lowerQ)
     );
-  }, [notes, searchQuery]);
+  }, [notes, debouncedSearchQuery]);
 
   const filteredTasks = useMemo(() => {
-    if (!searchQuery) return tasks;
-    const lowerQ = searchQuery.toLowerCase();
+    if (!debouncedSearchQuery) return tasks;
+    const lowerQ = debouncedSearchQuery.toLowerCase();
     return tasks.filter(
       (task) =>
         task.title.toLowerCase().includes(lowerQ) ||
         (task.description?.toLowerCase().includes(lowerQ) ?? false)
     );
-  }, [searchQuery, tasks]);
+  }, [debouncedSearchQuery, tasks]);
 
   const filteredEvents = useMemo(() => {
-    if (!searchQuery) return events;
-    const lowerQ = searchQuery.toLowerCase();
+    if (!debouncedSearchQuery) return events;
+    const lowerQ = debouncedSearchQuery.toLowerCase();
     return events.filter(
       (event) =>
         event.title.toLowerCase().includes(lowerQ) ||
         (event.description?.toLowerCase().includes(lowerQ) ?? false) ||
         (event.location?.toLowerCase().includes(lowerQ) ?? false)
     );
-  }, [events, searchQuery]);
+  }, [debouncedSearchQuery, events]);
 
   const pendingTasksCount = useMemo(
     () => filteredTasks.filter((task) => !task.completed).length,
@@ -196,8 +202,16 @@ export function useProductivityViewModel() {
         date: new Date(task.created_at).getTime(),
       });
     });
+    filteredEvents.forEach((event) => {
+      data.push({
+        type: 'event',
+        item: event,
+        id: `event-${event.id}`,
+        date: new Date(event.created_at || event.start_time).getTime(),
+      });
+    });
     return data.sort((a, b) => (b.date || 0) - (a.date || 0));
-  }, [filteredNotes, filteredTasks]);
+  }, [filteredNotes, filteredTasks, filteredEvents]);
 
   const todayData = useMemo(() => {
     const now = new Date();
@@ -271,15 +285,33 @@ export function useProductivityViewModel() {
 
     const lines: string[] = [];
     if (taskPriorityCounts.overdue > 0) {
-      lines.push(`1) Recover overdue: start with ${taskPriorityCounts.overdue} overdue task(s).`);
+      lines.push(
+        t('productivity.plan.recover_overdue', {
+          count: taskPriorityCounts.overdue,
+          defaultValue: `1) Recover overdue: start with ${taskPriorityCounts.overdue} overdue task(s).`,
+        })
+      );
     } else {
-      lines.push('1) No overdue tasks: start with highest-impact open work.');
+      lines.push(
+        t('productivity.plan.no_overdue', {
+          defaultValue: '1) No overdue tasks: start with highest-impact open work.',
+        })
+      );
     }
 
     if (nextTasks.length > 0) {
-      lines.push(`2) Focus block: ${nextTasks.map((task) => task.title).join(', ')}.`);
+      lines.push(
+        t('productivity.plan.focus_block', {
+          tasks: nextTasks.map((task) => task.title).join(', '),
+          defaultValue: `2) Focus block: ${nextTasks.map((task) => task.title).join(', ')}.`,
+        })
+      );
     } else {
-      lines.push('2) Focus block: no pending tasks, use this for planning or review.');
+      lines.push(
+        t('productivity.plan.focus_block_empty', {
+          defaultValue: '2) Focus block: no pending tasks, use this for planning or review.',
+        })
+      );
     }
 
     if (nextEvents.length > 0) {
@@ -291,14 +323,23 @@ export function useProductivityViewModel() {
           }).format(new Date(event.start_time))
         )
         .join(', ');
-      lines.push(`3) Calendar checkpoints at ${eventLine}.`);
+      lines.push(
+        t('productivity.plan.calendar_checkpoints', {
+          times: eventLine,
+          defaultValue: `3) Calendar checkpoints at ${eventLine}.`,
+        })
+      );
     } else {
-      lines.push('3) Calendar is light: reserve time for deep work and wrap-up.');
+      lines.push(
+        t('productivity.plan.calendar_light', {
+          defaultValue: '3) Calendar is light: reserve time for deep work and wrap-up.',
+        })
+      );
     }
 
     setTodayPlan(lines.join('\n'));
     setActiveTab('today');
-  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue]);
+  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue, t]);
 
   return {
     t,

--- a/frontend/src/hooks/viewmodels/useProductivityViewModel.ts
+++ b/frontend/src/hooks/viewmodels/useProductivityViewModel.ts
@@ -1,0 +1,331 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Alert } from 'react-native';
+import { useLocalSearchParams, usePathname, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { CalendarEvent, Note, Task } from '@/core/models';
+import { useProductivityStore } from '@/store/useProductivityStore';
+
+export type Tab = 'today' | 'all' | 'notes' | 'tasks';
+export type TaskPriority = 'all' | 'overdue' | 'today' | 'upcoming' | 'no_due';
+
+export type RenderItemData = {
+  date?: number;
+  type: 'note' | 'task' | 'event';
+  item: Note | Task | CalendarEvent;
+  id: string;
+};
+
+export function useProductivityViewModel() {
+  const { t, i18n } = useTranslation();
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useLocalSearchParams() as Record<string, string | string[] | undefined>;
+  const openCreateTask = params.openCreateTask;
+  const openCreateNote = params.openCreateNote;
+
+  const [activeTab, setActiveTab] = useState<Tab>('today');
+  const [taskPriority, setTaskPriority] = useState<TaskPriority>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showCreateNote, setShowCreateNote] = useState(false);
+  const [showCreateTask, setShowCreateTask] = useState(false);
+  const [todayPlan, setTodayPlan] = useState<string | null>(null);
+
+  const {
+    notes,
+    tasks,
+    events,
+    fetchNotes,
+    fetchTasks,
+    fetchEvents,
+    isLoading,
+    deleteNote,
+    deleteTask,
+    toggleTask,
+  } = useProductivityStore();
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchNotes(controller.signal);
+    fetchTasks(controller.signal);
+    fetchEvents(controller.signal);
+    return () => {
+      controller.abort();
+    };
+  }, [fetchEvents, fetchNotes, fetchTasks]);
+
+  useEffect(() => {
+    if (openCreateTask === '1' || openCreateTask === 'true') {
+      setShowCreateTask(true);
+      const nextParams = Object.fromEntries(
+        Object.entries(params).filter(
+          ([key, value]) => key !== 'openCreateTask' && typeof value === 'string'
+        )
+      );
+      router.replace({ pathname, params: nextParams });
+    }
+  }, [openCreateTask, params, pathname, router]);
+
+  useEffect(() => {
+    if (openCreateNote === '1' || openCreateNote === 'true') {
+      setShowCreateNote(true);
+      const nextParams = Object.fromEntries(
+        Object.entries(params).filter(
+          ([key, value]) => key !== 'openCreateNote' && typeof value === 'string'
+        )
+      );
+      router.replace({ pathname, params: nextParams });
+    }
+  }, [openCreateNote, params, pathname, router]);
+
+  const handleRefresh = useCallback(() => {
+    fetchNotes();
+    fetchTasks();
+    fetchEvents();
+  }, [fetchEvents, fetchNotes, fetchTasks]);
+
+  const confirmDelete = useCallback(
+    (action: () => Promise<void>) =>
+      Alert.alert(
+        t('productivity.delete') || 'Delete',
+        t('productivity.are_you_sure') || 'Are you sure?',
+        [
+          { text: t('settings.actions.cancel') || 'Cancel', style: 'cancel' },
+          {
+            text: t('settings.actions.delete') || 'Delete',
+            style: 'destructive',
+            onPress: () => action(),
+          },
+        ]
+      ),
+    [t]
+  );
+
+  const filteredNotes = useMemo(() => {
+    if (!searchQuery) return notes;
+    const lowerQ = searchQuery.toLowerCase();
+    return notes.filter(
+      (n) => n.title.toLowerCase().includes(lowerQ) || n.content.toLowerCase().includes(lowerQ)
+    );
+  }, [notes, searchQuery]);
+
+  const filteredTasks = useMemo(() => {
+    if (!searchQuery) return tasks;
+    const lowerQ = searchQuery.toLowerCase();
+    return tasks.filter(
+      (task) =>
+        task.title.toLowerCase().includes(lowerQ) ||
+        (task.description?.toLowerCase().includes(lowerQ) ?? false)
+    );
+  }, [searchQuery, tasks]);
+
+  const filteredEvents = useMemo(() => {
+    if (!searchQuery) return events;
+    const lowerQ = searchQuery.toLowerCase();
+    return events.filter(
+      (event) =>
+        event.title.toLowerCase().includes(lowerQ) ||
+        (event.description?.toLowerCase().includes(lowerQ) ?? false) ||
+        (event.location?.toLowerCase().includes(lowerQ) ?? false)
+    );
+  }, [events, searchQuery]);
+
+  const pendingTasksCount = useMemo(
+    () => filteredTasks.filter((task) => !task.completed).length,
+    [filteredTasks]
+  );
+
+  const getTaskPriority = useCallback((task: Task): Exclude<TaskPriority, 'all'> => {
+    if (!task.due_date) return 'no_due';
+    const now = new Date();
+    const due = new Date(task.due_date);
+    if (isNaN(due.getTime())) return 'no_due';
+    const dayStart = new Date(now);
+    dayStart.setHours(0, 0, 0, 0);
+    const tomorrow = new Date(dayStart);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    if (due < dayStart) return 'overdue';
+    if (due >= dayStart && due < tomorrow) return 'today';
+    return 'upcoming';
+  }, []);
+
+  const taskPriorityCounts = useMemo(() => {
+    const counts: Record<TaskPriority, number> = {
+      all: 0,
+      overdue: 0,
+      today: 0,
+      upcoming: 0,
+      no_due: 0,
+    };
+    filteredTasks
+      .filter((task) => !task.completed)
+      .forEach((task) => {
+        counts.all += 1;
+        counts[getTaskPriority(task)] += 1;
+      });
+    return counts;
+  }, [filteredTasks, getTaskPriority]);
+
+  const prioritizedTasks = useMemo(() => {
+    const tasksToRank = filteredTasks.filter((task) => !task.completed);
+    const pool =
+      taskPriority === 'all'
+        ? tasksToRank
+        : tasksToRank.filter((task) => getTaskPriority(task) === taskPriority);
+    return [...pool].sort((a, b) => {
+      const aDue = a.due_date ? new Date(a.due_date).getTime() : Number.MAX_SAFE_INTEGER;
+      const bDue = b.due_date ? new Date(b.due_date).getTime() : Number.MAX_SAFE_INTEGER;
+      return aDue - bDue;
+    });
+  }, [filteredTasks, getTaskPriority, taskPriority]);
+
+  const mixedData = useMemo(() => {
+    const data: RenderItemData[] = [];
+    filteredNotes.forEach((note) => {
+      data.push({
+        type: 'note',
+        item: note,
+        id: `note-${note.id}`,
+        date: new Date(note.created_at).getTime(),
+      });
+    });
+    filteredTasks.forEach((task) => {
+      data.push({
+        type: 'task',
+        item: task,
+        id: `task-${task.id}`,
+        date: new Date(task.created_at).getTime(),
+      });
+    });
+    return data.sort((a, b) => (b.date || 0) - (a.date || 0));
+  }, [filteredNotes, filteredTasks]);
+
+  const todayData = useMemo(() => {
+    const now = new Date();
+    const start = new Date(now);
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(start);
+    end.setDate(end.getDate() + 1);
+    const weekEnd = new Date(start);
+    weekEnd.setDate(weekEnd.getDate() + 7);
+
+    const overdueTasks = filteredTasks.filter((task) => {
+      if (task.completed || !task.due_date) return false;
+      return new Date(task.due_date) < start;
+    });
+
+    const dueTodayTasks = filteredTasks.filter((task) => {
+      if (task.completed || !task.due_date) return false;
+      const dueDate = new Date(task.due_date);
+      return dueDate >= start && dueDate < end;
+    });
+
+    const upcomingEvents = filteredEvents.filter((event) => {
+      const startTime = new Date(event.start_time);
+      return startTime >= start && startTime < weekEnd;
+    });
+
+    const items: RenderItemData[] = [
+      ...overdueTasks.map((task) => ({
+        type: 'task' as const,
+        item: task,
+        id: `overdue-${task.id}`,
+        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
+      })),
+      ...dueTodayTasks.map((task) => ({
+        type: 'task' as const,
+        item: task,
+        id: `today-${task.id}`,
+        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
+      })),
+      ...upcomingEvents.map((event) => ({
+        type: 'event' as const,
+        item: event,
+        id: `event-${event.id}`,
+        date: new Date(event.start_time).getTime(),
+      })),
+    ];
+
+    return items.sort((a, b) => (a.date || 0) - (b.date || 0));
+  }, [filteredEvents, filteredTasks]);
+
+  const dataToRender: RenderItemData[] =
+    activeTab === 'today'
+      ? todayData.filter((entry) => {
+          if (entry.type !== 'task') return true;
+          if (taskPriority === 'all') return true;
+          return getTaskPriority(entry.item as Task) === taskPriority;
+        })
+      : activeTab === 'all'
+        ? mixedData
+        : activeTab === 'notes'
+          ? filteredNotes.map((note) => ({ type: 'note' as const, item: note, id: note.id }))
+          : prioritizedTasks.map((task) => ({ type: 'task' as const, item: task, id: task.id }));
+
+  const generateTodayPlan = useCallback(() => {
+    const now = new Date();
+    const nextTasks = prioritizedTasks.slice(0, 3);
+    const nextEvents = [...filteredEvents]
+      .filter((event) => new Date(event.end_time) >= now)
+      .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime())
+      .slice(0, 3);
+
+    const lines: string[] = [];
+    if (taskPriorityCounts.overdue > 0) {
+      lines.push(`1) Recover overdue: start with ${taskPriorityCounts.overdue} overdue task(s).`);
+    } else {
+      lines.push('1) No overdue tasks: start with highest-impact open work.');
+    }
+
+    if (nextTasks.length > 0) {
+      lines.push(`2) Focus block: ${nextTasks.map((task) => task.title).join(', ')}.`);
+    } else {
+      lines.push('2) Focus block: no pending tasks, use this for planning or review.');
+    }
+
+    if (nextEvents.length > 0) {
+      const eventLine = nextEvents
+        .map((event) =>
+          new Intl.DateTimeFormat(i18n.language, {
+            hour: '2-digit',
+            minute: '2-digit',
+          }).format(new Date(event.start_time))
+        )
+        .join(', ');
+      lines.push(`3) Calendar checkpoints at ${eventLine}.`);
+    } else {
+      lines.push('3) Calendar is light: reserve time for deep work and wrap-up.');
+    }
+
+    setTodayPlan(lines.join('\n'));
+    setActiveTab('today');
+  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue]);
+
+  return {
+    t,
+    i18n,
+    activeTab,
+    setActiveTab,
+    taskPriority,
+    setTaskPriority,
+    searchQuery,
+    setSearchQuery,
+    showCreateNote,
+    setShowCreateNote,
+    showCreateTask,
+    setShowCreateTask,
+    todayPlan,
+    setTodayPlan,
+    dataToRender,
+    isLoading,
+    handleRefresh,
+    confirmDelete,
+    deleteNote,
+    deleteTask,
+    toggleTask,
+    pendingTasksCount,
+    taskPriorityCounts,
+    generateTodayPlan,
+    fetchNotes,
+    fetchTasks,
+  };
+}


### PR DESCRIPTION
Extracted business logic, filtering, and data preparation from `productivity.tsx` into a new `useProductivityViewModel` hook. Decomposed the 850+ line "God Widget" by moving `renderItem`, `ListHeaderComponent`, and `ListEmptyComponent` into private named sub-components. This adheres to Clean Architecture and SRP.

---
*PR created automatically by Jules for task [1305026185137982427](https://jules.google.com/task/1305026185137982427) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dismissible "Today plan" panel showing prioritized tasks and upcoming events
  * Task filtering by priority categories (overdue, today, upcoming, no due date)
  * Deep-link support to open create note/task flows
  * Localized empty state with quick-action buttons and loading indicator

* **Refactor**
  * Productivity screen state and data preparation centralized to improve responsiveness and refresh/delete UX

* **Improvements**
  * Priority labels and "Today" tab use translation fallbacks and count-aware labels

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->