### PR TITLE
Refactor AgentService to enforce Clean Architecture boundaries

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -11,6 +11,7 @@ from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
 from app.domain.memory.service import MemoryService
 from app.infrastructure.database.supabase import SupabaseClient
+from app.infrastructure.external.openrouter import OpenRouterLLMAdapter
 from app.infrastructure.repositories.agent_repo import AgentRepository
 from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
@@ -44,7 +45,8 @@ def get_auth_repo(db: SupabaseClient) -> AuthRepository:
 
 
 def get_agent_service(repo: Annotated[AgentRepository, Depends(get_agent_repo)]) -> AgentService:
-    return AgentService(repo)
+    llm_client = OpenRouterLLMAdapter()
+    return AgentService(repo, llm_client)
 
 
 def get_chat_service(

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -123,12 +123,14 @@ async def websocket_chat_hub(
         await chat_hub.connect(websocket, user_id)
         await chat_hub.send_to_user(user_id, {"type": "connected", "user_id": str(user_id)})
 
+        from app.infrastructure.external.openrouter import OpenRouterLLMAdapter
+
         agent_repo = AgentRepository()
         service = ChatService(
             chat_repo=ChatRepository(),
             agent_repo=agent_repo,
             memory_repo=MemoryRepository(),
-            agent_service=AgentService(repo=agent_repo),
+            agent_service=AgentService(repo=agent_repo, llm_client=OpenRouterLLMAdapter()),
         )
 
         while True:

--- a/backend/app/api/v1/websocket.py.patch
+++ b/backend/app/api/v1/websocket.py.patch
@@ -1,0 +1,18 @@
+--- backend/app/api/v1/websocket.py
++++ backend/app/api/v1/websocket.py
+@@ -123,13 +123,13 @@
+         await chat_hub.connect(websocket, user_id)
+         await chat_hub.send_to_user(user_id, {"type": "connected", "user_id": str(user_id)})
+
+-            from app.infrastructure.external.openrouter import OpenRouterLLMAdapter
++        from app.infrastructure.external.openrouter import OpenRouterLLMAdapter
+         agent_repo = AgentRepository()
+         service = ChatService(
+             chat_repo=ChatRepository(),
+             agent_repo=agent_repo,
+             memory_repo=MemoryRepository(),
+-                agent_service=AgentService(repo=agent_repo, llm_client=OpenRouterLLMAdapter()),
++            agent_service=AgentService(repo=agent_repo, llm_client=OpenRouterLLMAdapter()),
+         )
+
+         while True:

--- a/backend/app/domain/agents/llm_interface.py
+++ b/backend/app/domain/agents/llm_interface.py
@@ -1,0 +1,22 @@
+"""LLM Interface for the Agent Domain."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, TypeVar
+
+if TYPE_CHECKING:
+    from openai.types.chat import ChatCompletionMessageParam
+
+T = TypeVar("T")
+
+
+class LLMInterface(Protocol):
+    """Protocol for structured language model completions."""
+
+    async def structured_completion(
+        self,
+        messages: list[ChatCompletionMessageParam],
+        response_model: type[T],
+    ) -> T:
+        """Generate a structured completion from a language model."""
+        ...

--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from app.domain.agents.models import Agent, AgentIntegration, Capability, Integration
 from app.domain.agents.schemas import (
     AgentCreate,
     AgentGenerationResponse,
@@ -14,25 +13,33 @@ from app.domain.agents.schemas import (
     AgentUpdate,
     MoodResponse,
 )
-from app.infrastructure.external.openrouter import structured_completion
 
 if TYPE_CHECKING:
     from uuid import UUID
 
     from openai.types.chat import ChatCompletionMessageParam
 
+    from app.domain.agents.llm_interface import LLMInterface
+    from app.domain.agents.models import Agent, Capability, Integration
     from app.infrastructure.repositories.agent_repo import AgentRepository
 
 logger = logging.getLogger(__name__)
 
 
-def _build_agent_response(agent: Agent) -> AgentResponse:
+def _build_agent_response(
+    agent: Agent,
+    effective_cap_ids: list[str] | None = None,
+) -> AgentResponse:
     """Construct an AgentResponse from a prefetched Agent ORM instance.
 
     Assumes ``capabilities`` and ``agent_integrations__integration`` have been
     prefetched on the agent before calling this function.
     """
-    cap_ids: list[str] = [cap.pk for cap in agent.capabilities.related_objects]
+    if effective_cap_ids is not None:
+        cap_ids = effective_cap_ids
+    else:
+        cap_ids = [cap.pk for cap in agent.capabilities.related_objects]
+
     integration_ids: list[str] = [
         ai.integration_id for ai in agent.agent_integrations if ai.enabled
     ]
@@ -58,8 +65,9 @@ def _build_agent_response(agent: Agent) -> AgentResponse:
 
 
 class AgentService:
-    def __init__(self, repo: AgentRepository):
+    def __init__(self, repo: AgentRepository, llm_client: LLMInterface):
         self.repo = repo
+        self.llm_client = llm_client
         self._cached_capabilities: list[Capability] | None = None
         self._cached_integrations: list[Integration] | None = None
 
@@ -123,37 +131,18 @@ class AgentService:
             capability_ids=agent_data.capabilities,
         )
 
-        agent = await Agent.create(
+        agent = await self.repo.create_agent_with_relations(
             user_id=user_id,
             name=agent_data.name,
             personality=agent_data.personality,
+            system_prompt=system_prompt,
             description=agent_data.description,
             goals=agent_data.goals,
-            system_prompt=system_prompt,
+            capability_ids=agent_data.capabilities,
+            integration_ids=agent_data.integrations,
+            integration_configs=agent_data.integration_configs,
         )
-
-        if agent_data.capabilities:
-            caps = await Capability.filter(id__in=agent_data.capabilities)
-            await agent.capabilities.add(*caps)
-
-        if agent_data.integrations:
-            integrations = await Integration.filter(id__in=agent_data.integrations)
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=agent_data.integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
-
-        # Refetch with relations so the response is fully populated.
-        refetched = await self.repo.get_by_id(agent.pk)
-        assert refetched is not None
-        return _build_agent_response(refetched)
+        return _build_agent_response(agent)
 
     async def list_agents(self, user_id: UUID) -> list[AgentResponse]:
         """List all agents for a user."""
@@ -173,7 +162,7 @@ class AgentService:
             {"role": "user", "content": f"Keywords: {keywords}"},
         ]
 
-        return await structured_completion(
+        return await self.llm_client.structured_completion(
             messages=messages,
             response_model=AgentGenerationResponse,
         )
@@ -191,37 +180,14 @@ class AgentService:
             return None
 
         fields = data.model_dump(exclude_none=True)
+        capabilities = fields.pop("capabilities", None)
+        integrations = fields.pop("integrations", None)
+        integration_configs = fields.pop("integration_configs", None)
 
-        # --- capabilities ---
-        new_capability_ids: list[str] | None = fields.pop("capabilities", None)
-        if new_capability_ids is not None:
-            caps = await Capability.filter(id__in=new_capability_ids)
-            await agent.capabilities.clear()
-            if caps:
-                await agent.capabilities.add(*caps)
-            effective_cap_ids = new_capability_ids
+        if capabilities is not None:
+            effective_cap_ids = capabilities
         else:
-            effective_cap_ids = [
-                str(c_id) for c_id in await agent.capabilities.all().values_list("id", flat=True)
-            ]
-
-        # --- integrations ---
-        new_integration_ids: list[str] | None = fields.pop("integrations", None)
-        new_integration_configs: dict = fields.pop("integration_configs", None) or {}
-        if new_integration_ids is not None:
-            await AgentIntegration.filter(agent=agent).delete()
-            integrations = await Integration.filter(id__in=new_integration_ids)
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=new_integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
+            effective_cap_ids = [str(cap.pk) for cap in agent.capabilities.related_objects]
 
         # Merge profile fields with current values so build_system_prompt has full context
         name = fields.get("name", agent.name)
@@ -238,10 +204,19 @@ class AgentService:
         )
         fields["system_prompt"] = updated_prompt
 
-        updated = await self.repo.update_agent(agent_id, user_id, **fields)
+        updated, effective_cap_ids = await self.repo.update_agent(
+            agent_id,
+            user_id,
+            capabilities=capabilities,
+            integrations=integrations,
+            integration_configs=integration_configs,
+            **fields,
+        )
+
         if not updated:
             return None
-        return _build_agent_response(updated)
+
+        return _build_agent_response(updated, effective_cap_ids)
 
     async def delete_agent(self, agent_id: UUID | str, user_id: UUID) -> bool:
         """Soft-delete an agent owned by user_id."""
@@ -271,7 +246,7 @@ class AgentService:
             return
         mood_list = ", ".join(self._VALID_MOODS)
         try:
-            response = await structured_completion(
+            response = await self.llm_client.structured_completion(
                 messages=[
                     {
                         "role": "system",

--- a/backend/app/infrastructure/external/openrouter.py
+++ b/backend/app/infrastructure/external/openrouter.py
@@ -190,3 +190,14 @@ async def structured_completion(
 async def embed(text: str) -> list[float]:
     client = get_openrouter_client()
     return await client.embed(text, get_settings().embedding_model)
+
+
+class OpenRouterLLMAdapter:
+    """Adapter to provide the OpenRouterClient functionality through the LLMInterface."""
+
+    async def structured_completion(
+        self,
+        messages: list[ChatCompletionMessageParam],
+        response_model: type[T],
+    ) -> T:
+        return await structured_completion(messages=messages, response_model=response_model)

--- a/backend/app/infrastructure/repositories/agent_repo.py
+++ b/backend/app/infrastructure/repositories/agent_repo.py
@@ -10,6 +10,7 @@ from tortoise.transactions import in_transaction
 
 from app.domain.agents.models import (
     Agent,
+    AgentIntegration,
     AgentTemplate,
     Capability,
     Integration,
@@ -57,6 +58,49 @@ class AgentRepository:
         await agent.save()
         return agent
 
+    async def create_agent_with_relations(
+        self,
+        user_id: UUID | str,
+        name: str,
+        personality: str,
+        system_prompt: str,
+        description: str | None = None,
+        goals: list[str] | None = None,
+        capability_ids: list[str] | None = None,
+        integration_ids: list[str] | None = None,
+        integration_configs: dict | None = None,
+    ) -> Agent:
+        """Create an agent along with its capabilities and integrations."""
+        agent = await Agent.create(
+            user_id=user_id,
+            name=name,
+            personality=personality,
+            description=description,
+            goals=goals or [],
+            system_prompt=system_prompt,
+        )
+
+        if capability_ids:
+            caps = await Capability.filter(id__in=capability_ids)
+            await agent.capabilities.add(*caps)
+
+        if integration_ids:
+            integrations = await Integration.filter(id__in=integration_ids)
+            configs = integration_configs or {}
+            agent_integrations = [
+                AgentIntegration(
+                    agent=agent,
+                    integration=integration,
+                    config=configs.get(str(integration.id), {}),
+                    enabled=True,
+                )
+                for integration in integrations
+            ]
+            if agent_integrations:
+                await AgentIntegration.bulk_create(agent_integrations)
+
+        return await self.get_by_id(agent.pk)
+
     async def update_mood(self, agent_id: UUID | str, mood: str) -> None:
         """Update an agent's mood."""
         agent = await self.get_by_id(agent_id)
@@ -69,9 +113,16 @@ class AgentRepository:
     )
 
     async def update_agent(
-        self, agent_id: UUID | str, user_id: UUID | str, **fields: object
-    ) -> Agent | None:
-        """Update an agent's fields. Only updates the owner's agent."""
+        self,
+        agent_id: UUID | str,
+        user_id: UUID | str,
+        capabilities: list[str] | None = None,
+        integrations: list[str] | None = None,
+        integration_configs: dict | None = None,
+        **fields: object,
+    ) -> tuple[Agent | None, list[str]]:
+        """Update an agent's fields and relations. Only updates the owner's agent.
+        Returns the updated agent and its effective capability IDs."""
         unknown = set(fields) - self._ALLOWED_AGENT_FIELDS
         if unknown:
             raise ValueError(f"update_agent received unknown fields: {unknown}")
@@ -79,15 +130,51 @@ class AgentRepository:
             agent_id = UUID(agent_id)
         if isinstance(user_id, str):
             user_id = UUID(user_id)
+
         agent = await Agent.get_or_none(id=agent_id, user_id=user_id).prefetch_related(
             "capabilities", "agent_integrations__integration"
         )
-        if agent:
+
+        if not agent:
+            return None, []
+
+        async with in_transaction():
+            if capabilities is not None:
+                caps = await Capability.filter(id__in=capabilities)
+                await agent.capabilities.clear()
+                if caps:
+                    await agent.capabilities.add(*caps)
+                effective_cap_ids = capabilities
+            else:
+                effective_cap_ids = [
+                    str(c_id)
+                    for c_id in await agent.capabilities.all().values_list("id", flat=True)
+                ]
+
+            if integrations is not None:
+                await AgentIntegration.filter(agent=agent).delete()
+                integration_records = await Integration.filter(id__in=integrations)
+                configs = integration_configs or {}
+                agent_integrations = [
+                    AgentIntegration(
+                        agent=agent,
+                        integration=integration,
+                        config=configs.get(str(integration.id), {}),
+                        enabled=True,
+                    )
+                    for integration in integration_records
+                ]
+                if agent_integrations:
+                    await AgentIntegration.bulk_create(agent_integrations)
+
             for key, value in fields.items():
                 if value is not None:
                     setattr(agent, key, value)
+
             await agent.save()
-        return agent
+
+        refetched_agent = await self.get_by_id(agent_id)
+        return refetched_agent, effective_cap_ids
 
     async def delete_agent(self, agent_id: UUID | str, user_id: UUID | str) -> bool:
         """Soft-delete an agent by setting deleted_at. Only deletes the owner's agent."""

--- a/backend/app/infrastructure/repositories/agent_repo.py
+++ b/backend/app/infrastructure/repositories/agent_repo.py
@@ -99,7 +99,8 @@ class AgentRepository:
             if agent_integrations:
                 await AgentIntegration.bulk_create(agent_integrations)
 
-        return await self.get_by_id(agent.pk)
+        refetched = await self.get_by_id(agent.pk)
+        return refetched if refetched is not None else agent
 
     async def update_mood(self, agent_id: UUID | str, mood: str) -> None:
         """Update an agent's mood."""

--- a/backend/app/infrastructure/repositories/agent_repo.py
+++ b/backend/app/infrastructure/repositories/agent_repo.py
@@ -122,8 +122,23 @@ class AgentRepository:
         integration_configs: dict | None = None,
         **fields: object,
     ) -> tuple[Agent | None, list[str]]:
-        """Update an agent's fields and relations. Only updates the owner's agent.
-        Returns the updated agent and its effective capability IDs."""
+        """Update an agent's fields and relations.
+
+        Only updates the owner's agent. Handles replacing capability
+        and integration many-to-many relationships safely.
+
+        Args:
+            agent_id: The ID of the agent to update.
+            user_id: The ID of the user that owns the agent.
+            capabilities: The list of capability IDs to replace existing ones.
+            integrations: The list of integration IDs to replace existing ones.
+            integration_configs: Configuration dicts mapped by integration ID.
+            **fields: Arbitrary model fields allowed for updating.
+
+        Returns:
+            tuple[Agent | None, list[str]]: A tuple containing the updated Agent
+                instance (or None if not found), and the list of effective capability IDs.
+        """
         unknown = set(fields) - self._ALLOWED_AGENT_FIELDS
         if unknown:
             raise ValueError(f"update_agent received unknown fields: {unknown}")
@@ -145,7 +160,7 @@ class AgentRepository:
                 await agent.capabilities.clear()
                 if caps:
                     await agent.capabilities.add(*caps)
-                effective_cap_ids = capabilities
+                effective_cap_ids = [str(c.id) for c in caps]
             else:
                 effective_cap_ids = [
                     str(c_id)

--- a/backend/app/infrastructure/repositories/agent_repo.py.patch
+++ b/backend/app/infrastructure/repositories/agent_repo.py.patch
@@ -1,0 +1,12 @@
+--- backend/app/infrastructure/repositories/agent_repo.py
++++ backend/app/infrastructure/repositories/agent_repo.py
+@@ -99,7 +99,8 @@
+             if agent_integrations:
+                 await AgentIntegration.bulk_create(agent_integrations)
+
+-        return await self.get_by_id(agent.pk)
++        refetched = await self.get_by_id(agent.pk)
++        return refetched if refetched is not None else agent
+
+     async def update_mood(self, agent_id: UUID | str, mood: str) -> None:
+         """Update an agent's mood."""

--- a/backend/app/infrastructure/repositories/agent_repo.py.patch
+++ b/backend/app/infrastructure/repositories/agent_repo.py.patch
@@ -1,12 +1,37 @@
 --- backend/app/infrastructure/repositories/agent_repo.py
 +++ backend/app/infrastructure/repositories/agent_repo.py
-@@ -99,7 +99,8 @@
-             if agent_integrations:
-                 await AgentIntegration.bulk_create(agent_integrations)
-
--        return await self.get_by_id(agent.pk)
-+        refetched = await self.get_by_id(agent.pk)
-+        return refetched if refetched is not None else agent
-
-     async def update_mood(self, agent_id: UUID | str, mood: str) -> None:
-         """Update an agent's mood."""
+@@ -122,8 +122,23 @@
+         integration_configs: dict | None = None,
+         **fields: object,
+     ) -> tuple[Agent | None, list[str]]:
+-        """Update an agent's fields and relations. Only updates the owner's agent.
+-        Returns the updated agent and its effective capability IDs."""
++        """Update an agent's fields and relations.
++
++        Only updates the owner's agent. Handles replacing capability
++        and integration many-to-many relationships safely.
++
++        Args:
++            agent_id: The ID of the agent to update.
++            user_id: The ID of the user that owns the agent.
++            capabilities: The list of capability IDs to replace existing ones.
++            integrations: The list of integration IDs to replace existing ones.
++            integration_configs: Configuration dicts mapped by integration ID.
++            **fields: Arbitrary model fields allowed for updating.
++
++        Returns:
++            tuple[Agent | None, list[str]]: A tuple containing the updated Agent
++                instance (or None if not found), and the list of effective capability IDs.
++        """
+         unknown = set(fields) - self._ALLOWED_AGENT_FIELDS
+         if unknown:
+             raise ValueError(f"update_agent received unknown fields: {unknown}")
+@@ -147,7 +162,7 @@
+                 await agent.capabilities.clear()
+                 if caps:
+                     await agent.capabilities.add(*caps)
+-                effective_cap_ids = capabilities
++                effective_cap_ids = [str(c.id) for c in caps]
+             else:
+                 effective_cap_ids = [
+                     str(c_id) for c_id in await agent.capabilities.all().values_list("id", flat=True)

--- a/backend/tests/agents/test_agent_generation.py
+++ b/backend/tests/agents/test_agent_generation.py
@@ -33,9 +33,9 @@ async def test_update_mood_success():
     llm_mock = AsyncMock()
     service = AgentService(repo, llm_mock)
     mock_completion = llm_mock.structured_completion
-        mock_completion.return_value = MoodResponse(mood="Happy")
-        await service.update_mood(agent_id, "User said something nice")
-        repo.update_mood.assert_called_once_with(agent_id, "Happy")
+    mock_completion.return_value = MoodResponse(mood="Happy")
+    await service.update_mood(agent_id, "User said something nice")
+    repo.update_mood.assert_called_once_with(agent_id, "Happy")
 
 
 @pytest.mark.asyncio
@@ -46,9 +46,9 @@ async def test_update_mood_invalid_mood():
     llm_mock = AsyncMock()
     service = AgentService(repo, llm_mock)
     mock_completion = llm_mock.structured_completion
-        mock_completion.return_value = MoodResponse(mood="UnknownMood")
-        await service.update_mood(agent_id, "User said something weird")
-        repo.update_mood.assert_called_once_with(agent_id, "Neutral")
+    mock_completion.return_value = MoodResponse(mood="UnknownMood")
+    await service.update_mood(agent_id, "User said something weird")
+    repo.update_mood.assert_called_once_with(agent_id, "Neutral")
 
 
 @pytest.mark.asyncio
@@ -59,9 +59,9 @@ async def test_update_mood_exception():
     llm_mock = AsyncMock()
     service = AgentService(repo, llm_mock)
     mock_completion = llm_mock.structured_completion
-        mock_completion.side_effect = Exception("API Error")
-        await service.update_mood(agent_id, "User said something")
-        repo.update_mood.assert_not_called()
+    mock_completion.side_effect = Exception("API Error")
+    await service.update_mood(agent_id, "User said something")
+    repo.update_mood.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -79,9 +79,9 @@ async def test_generate_agent_profile():
     llm_mock = AsyncMock()
     service = AgentService(repo, llm_mock)
     mock_completion = llm_mock.structured_completion
-        mock_completion.return_value = mock_response
-        response = await service.generate_agent_profile("creative artist")
-        assert response.name == "Generated Agent"
+    mock_completion.return_value = mock_response
+    response = await service.generate_agent_profile("creative artist")
+    assert response.name == "Generated Agent"
 
 
 @pytest.mark.asyncio
@@ -111,6 +111,6 @@ async def test_generate_agent_profile_chaos_timeout():
     llm_mock = AsyncMock()
     service = AgentService(repo, llm_mock)
     mock_completion = llm_mock.structured_completion
-        mock_completion.side_effect = TimeoutError("LLM API Timeout")
-        with pytest.raises(TimeoutError):
-            await service.generate_agent_profile("impossible keywords")
+    mock_completion.side_effect = TimeoutError("LLM API Timeout")
+    with pytest.raises(TimeoutError):
+        await service.generate_agent_profile("impossible keywords")

--- a/backend/tests/agents/test_agent_generation.py
+++ b/backend/tests/agents/test_agent_generation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -20,7 +20,7 @@ def get_deterministic_uuid() -> uuid.UUID:
 @pytest.mark.asyncio
 async def test_update_mood_empty_history():
     repo = AsyncMock()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     await service.update_mood(str(get_deterministic_uuid()), "")
     repo.update_mood.assert_not_called()
 
@@ -28,11 +28,11 @@ async def test_update_mood_empty_history():
 @pytest.mark.asyncio
 async def test_update_mood_success():
     repo = AsyncMock()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     agent_id = str(get_deterministic_uuid())
-    with patch(
-        "app.domain.agents.service.structured_completion", new_callable=AsyncMock
-    ) as mock_completion:
+    llm_mock = AsyncMock()
+    service = AgentService(repo, llm_mock)
+    mock_completion = llm_mock.structured_completion
         mock_completion.return_value = MoodResponse(mood="Happy")
         await service.update_mood(agent_id, "User said something nice")
         repo.update_mood.assert_called_once_with(agent_id, "Happy")
@@ -41,11 +41,11 @@ async def test_update_mood_success():
 @pytest.mark.asyncio
 async def test_update_mood_invalid_mood():
     repo = AsyncMock()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     agent_id = str(get_deterministic_uuid())
-    with patch(
-        "app.domain.agents.service.structured_completion", new_callable=AsyncMock
-    ) as mock_completion:
+    llm_mock = AsyncMock()
+    service = AgentService(repo, llm_mock)
+    mock_completion = llm_mock.structured_completion
         mock_completion.return_value = MoodResponse(mood="UnknownMood")
         await service.update_mood(agent_id, "User said something weird")
         repo.update_mood.assert_called_once_with(agent_id, "Neutral")
@@ -54,11 +54,11 @@ async def test_update_mood_invalid_mood():
 @pytest.mark.asyncio
 async def test_update_mood_exception():
     repo = AsyncMock()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     agent_id = str(get_deterministic_uuid())
-    with patch(
-        "app.domain.agents.service.structured_completion", new_callable=AsyncMock
-    ) as mock_completion:
+    llm_mock = AsyncMock()
+    service = AgentService(repo, llm_mock)
+    mock_completion = llm_mock.structured_completion
         mock_completion.side_effect = Exception("API Error")
         await service.update_mood(agent_id, "User said something")
         repo.update_mood.assert_not_called()
@@ -67,7 +67,7 @@ async def test_update_mood_exception():
 @pytest.mark.asyncio
 async def test_generate_agent_profile():
     repo = AsyncMock()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     mock_response = AgentGenerationResponse(
         name="Generated Agent",
         personality="Creative",
@@ -76,9 +76,9 @@ async def test_generate_agent_profile():
         suggested_integrations=["discord"],
         goals=["Create art"],
     )
-    with patch(
-        "app.domain.agents.service.structured_completion", new_callable=AsyncMock
-    ) as mock_completion:
+    llm_mock = AsyncMock()
+    service = AgentService(repo, llm_mock)
+    mock_completion = llm_mock.structured_completion
         mock_completion.return_value = mock_response
         response = await service.generate_agent_profile("creative artist")
         assert response.name == "Generated Agent"
@@ -87,7 +87,7 @@ async def test_generate_agent_profile():
 @pytest.mark.asyncio
 async def test_build_system_prompt_with_goals():
     repo = AsyncMock()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     prompt = await service.build_system_prompt(
         name="Bot", personality="Friendly", goals=["Help users", "Be nice"]
     )
@@ -97,7 +97,7 @@ async def test_build_system_prompt_with_goals():
 @pytest.mark.asyncio
 async def test_build_system_prompt_with_description():
     repo = AsyncMock()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     prompt = await service.build_system_prompt(
         name="Bot", personality="Friendly", description="A super cool bot"
     )
@@ -107,10 +107,10 @@ async def test_build_system_prompt_with_description():
 @pytest.mark.asyncio
 async def test_generate_agent_profile_chaos_timeout():
     repo = AsyncMock()
-    service = AgentService(repo)
-    with patch(
-        "app.domain.agents.service.structured_completion", new_callable=AsyncMock
-    ) as mock_completion:
+    service = AgentService(repo, AsyncMock())
+    llm_mock = AsyncMock()
+    service = AgentService(repo, llm_mock)
+    mock_completion = llm_mock.structured_completion
         mock_completion.side_effect = TimeoutError("LLM API Timeout")
         with pytest.raises(TimeoutError):
             await service.generate_agent_profile("impossible keywords")

--- a/backend/tests/agents/test_agent_lifecycle.py
+++ b/backend/tests/agents/test_agent_lifecycle.py
@@ -22,7 +22,7 @@ def get_deterministic_uuid() -> uuid.UUID:
 @pytest.mark.asyncio
 async def test_create_agent_with_relations():
     repo = AgentRepository()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     user_id = get_deterministic_uuid()
     await Capability.create(id="web_search", name="Web Search", description="desc", icon="icon")
     await Integration.create(
@@ -43,7 +43,7 @@ async def test_create_agent_with_relations():
 @pytest.mark.asyncio
 async def test_update_agent_success():
     repo = AgentRepository()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     user_id = get_deterministic_uuid()
     await Capability.create(id="web_search2", name="Web Search", description="desc", icon="icon")
     await Capability.create(id="memory", name="Memory", description="desc", icon="icon")
@@ -76,7 +76,7 @@ async def test_update_agent_success():
 @pytest.mark.asyncio
 async def test_update_agent_not_found():
     repo = AgentRepository()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     user_id = get_deterministic_uuid()
     update_data = AgentUpdate(name="Non-existent")
     response = await service.update_agent(str(get_deterministic_uuid()), user_id, update_data)
@@ -86,7 +86,7 @@ async def test_update_agent_not_found():
 @pytest.mark.asyncio
 async def test_update_agent_wrong_user():
     repo = AgentRepository()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     user_id = get_deterministic_uuid()
     wrong_user_id = get_deterministic_uuid()
     agent_data = AgentCreate(name="Test Agent", personality="Helpful")
@@ -99,7 +99,7 @@ async def test_update_agent_wrong_user():
 @pytest.mark.asyncio
 async def test_delete_agent():
     repo = AgentRepository()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     user_id = get_deterministic_uuid()
     agent_data = AgentCreate(name="Agent To Delete", personality="Helpful")
     initial_agent = await service.create_agent(agent_data, user_id)
@@ -110,7 +110,7 @@ async def test_delete_agent():
 @pytest.mark.asyncio
 async def test_delete_agent_not_found():
     repo = AgentRepository()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     user_id = get_deterministic_uuid()
     result = await service.delete_agent(str(get_deterministic_uuid()), user_id)
     assert result is False
@@ -119,7 +119,7 @@ async def test_delete_agent_not_found():
 @pytest.mark.asyncio
 async def test_delete_agent_wrong_user():
     repo = AgentRepository()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     user_id = get_deterministic_uuid()
     wrong_user_id = get_deterministic_uuid()
     agent_data = AgentCreate(name="Agent To Delete", personality="Helpful")
@@ -131,7 +131,7 @@ async def test_delete_agent_wrong_user():
 @pytest.mark.asyncio
 async def test_list_templates():
     repo = AgentRepository()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     await AgentTemplate.create(
         id=get_deterministic_uuid(),
         name="Template 1",
@@ -146,7 +146,7 @@ async def test_list_templates():
 @pytest.mark.asyncio
 async def test_update_agent_no_capabilities_update():
     repo = AgentRepository()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     user_id = get_deterministic_uuid()
     await Capability.create(id="web_search3", name="Web Search", description="desc", icon="icon")
     agent_data = AgentCreate(name="Test Agent", personality="Helpful", capabilities=["web_search3"])
@@ -160,12 +160,12 @@ async def test_update_agent_no_capabilities_update():
 @pytest.mark.asyncio
 async def test_update_agent_repo_returns_none():
     repo = AgentRepository()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     user_id = get_deterministic_uuid()
     agent_data = AgentCreate(name="Test Agent", personality="Helpful")
     initial_agent = await service.create_agent(agent_data, user_id)
     with patch.object(repo, "update_agent", new_callable=AsyncMock) as mock_update:
-        mock_update.return_value = None
+        mock_update.return_value = (None, [])
         update_data = AgentUpdate(name="Updated Agent")
         response = await service.update_agent(str(initial_agent.id), user_id, update_data)
         assert response is None
@@ -174,7 +174,7 @@ async def test_update_agent_repo_returns_none():
 @pytest.mark.asyncio
 async def test_list_agents():
     repo = AgentRepository()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     user_id = get_deterministic_uuid()
     await service.create_agent(AgentCreate(name="Agent 1", personality="P1"), user_id)
     await service.create_agent(AgentCreate(name="Agent 2", personality="P2"), user_id)
@@ -185,7 +185,7 @@ async def test_list_agents():
 @pytest.mark.asyncio
 async def test_create_agent_chaos_db_error():
     repo = AgentRepository()
-    service = AgentService(repo)
+    service = AgentService(repo, AsyncMock())
     user_id = get_deterministic_uuid()
     agent_data = AgentCreate(name="DB Error Agent", personality="Helpful")
     with patch("app.domain.agents.models.Agent.create", new_callable=AsyncMock) as mock_create:

--- a/backend/tests/test_agents_routes.py
+++ b/backend/tests/test_agents_routes.py
@@ -124,7 +124,7 @@ async def test_agent_service_caching() -> None:
     mock_repo.list_capabilities = AsyncMock(return_value=[Capability(id="cap1", name="Cap 1")])
     mock_repo.list_integrations = AsyncMock(return_value=[Integration(id="int1", type="Int 1")])
 
-    service = AgentService(repo=mock_repo)
+    service = AgentService(repo=mock_repo, llm_client=AsyncMock())
 
     # First call: hits repo
     caps1 = await service.list_capabilities()


### PR DESCRIPTION
Extracted data persistence logic and external API integrations out of `AgentService` and into `AgentRepository` and `LLMInterface` implementing true Clean Architecture boundaries.

---
*PR created automatically by Jules for task [17805685792721564739](https://jules.google.com/task/17805685792721564739) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated external LLM adapter and a standardized LLM protocol.

* **Improvements**
  * Agent create/update flows now support explicit capabilities and integrations with persisted configs.
  * Profile generation and mood inference run via the injected LLM client.
  * Service/repository flows return consistent agent data including effective capability IDs.

* **Tests**
  * Tests updated to construct services with a mocked async LLM client.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->