### PR TITLE
chore(security): harden CORS origins and disable cleartext traffic

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -6,6 +6,18 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    """Application configuration loaded from environment variables or .env file.
+
+    Key configuration groups:
+    - API keys: openrouter_api_key
+    - Supabase: supabase_url, supabase_key, supabase_service_role_key (backend-only), supabase_jwt_secret
+    - Database: database_url, database_ssl
+    - Models: embedding_model, default_chat_model
+    - WebAuthn: webauthn_rp_id, webauthn_expected_origin
+    - Networking: cors_allowed_origins
+    - Third-party APIs: tavily_api_key, steam_api_key
+    - Telemetry/Notifications: sentry_dsn, azure_notification_hub_name
+    """
     openrouter_api_key: str
     # Supabase configuration (replaces local PostgreSQL)
     supabase_url: str
@@ -63,4 +75,4 @@ class Settings(BaseSettings):
 
 @lru_cache
 def get_settings() -> Settings:
-    return Settings()  # ty: ignore[missing-argument]  # pydantic-settings loads from env
+    return Settings()  # type: ignore[call-arg]  # pydantic-settings loads from env

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -18,6 +18,7 @@ class Settings(BaseSettings):
     - Third-party APIs: tavily_api_key, steam_api_key
     - Telemetry/Notifications: sentry_dsn, azure_notification_hub_name
     """
+
     openrouter_api_key: str
     # Supabase configuration (replaces local PostgreSQL)
     supabase_url: str

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -37,7 +37,7 @@ class Settings(BaseSettings):
     # e.g. "https://miru.app,https://www.miru.app"
     webauthn_expected_origin: str = "http://localhost"
     # Comma-separated allowed CORS origins — tighten in production
-    cors_allowed_origins: str = "*"
+    cors_allowed_origins: str = "http://localhost"
     # Tavily Search API key for web search capabilities
     tavily_api_key: str | None = None
     # Steam Web API key for Steam games integration

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -16,7 +16,10 @@
       "supportsTablet": true,
       "bundleIdentifier": "com.ykdbonte.miru.dev",
       "infoPlist": {
-        "ITSAppUsesNonExemptEncryption": false
+        "ITSAppUsesNonExemptEncryption": false,
+        "NSAppTransportSecurity": {
+          "NSAllowsArbitraryLoads": false
+        }
       }
     },
     "android": {
@@ -27,7 +30,8 @@
         "monochromeImage": "./assets/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "package": "com.miru.app"
+      "package": "com.miru.app",
+      "usesCleartextTraffic": false
     },
     "web": {
       "favicon": "./assets/favicon.png"


### PR DESCRIPTION
# Security Advisory
- **CORS Misconfiguration**: Backend allowed a wildcard (`*`) for CORS origins while accepting credentials, creating a risk of Cross-Site Request Forgery (CSRF).
- **Insecure Network Traffic**: The frontend lacked explicit constraints disabling cleartext HTTP traffic, potentially allowing interception of sensitive API payloads.

# Hardened Code
- Restricted `cors_allowed_origins` default to `http://localhost`.
- Configured Expo `app.json` to enforce `"usesCleartextTraffic": false` on Android and `"NSAllowsArbitraryLoads": false` on iOS.

# Integrity Note
- The new default for CORS requires developers to explicitly whitelist safe origins via `.env`.
- Frontend apps compiled with these settings will reject insecure connections at the OS level, preventing regression.

---
*PR created automatically by Jules for task [17990238544351389784](https://jules.google.com/task/17990238544351389784) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened backend cross-origin defaults to a more restrictive baseline for improved API security.
  * Strengthened mobile app transport security: disabled arbitrary loads on iOS and cleartext traffic on Android.

* **Documentation**
  * Clarified configuration documentation for backend settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->