### PR TITLE
feat: enforce prompt isolation via XML delimiters

### DIFF
--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -97,11 +97,11 @@ class AgentService:
             ),
         ]
         if description:
-            sections.append(description)
-        sections.append(f"\nPersonality & Behavior:\n{personality}")
+            sections.append(f"<description>\n{description}\n</description>")
+        sections.append(f"\nPersonality & Behavior:\n<personality>\n{personality}\n</personality>")
         if goals:
             goal_list = "\n".join(f"- {g}" for g in goals)
-            sections.append(f"\nYour Goals:\n{goal_list}")
+            sections.append(f"\nYour Goals:\n<goals>\n{goal_list}\n</goals>")
         if capability_ids:
             all_caps = await self.list_capabilities()
             cap_names = [c.name for c in all_caps if c.id in capability_ids]
@@ -170,7 +170,7 @@ class AgentService:
                     "Create a unique, high-quality persona based on the user's keywords."
                 ),
             },
-            {"role": "user", "content": f"Keywords: {keywords}"},
+            {"role": "user", "content": f"Keywords:\n<keywords>\n{keywords}\n</keywords>"},
         ]
 
         return await structured_completion(

--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING
+from xml.sax.saxutils import escape
 
 from app.domain.agents.models import Agent, AgentIntegration, Capability, Integration
 from app.domain.agents.schemas import (
@@ -97,10 +98,12 @@ class AgentService:
             ),
         ]
         if description:
-            sections.append(f"<description>\n{description}\n</description>")
-        sections.append(f"\nPersonality & Behavior:\n<personality>\n{personality}\n</personality>")
+            sections.append(f"<description>\n{escape(description)}\n</description>")
+        sections.append(
+            f"\nPersonality & Behavior:\n<personality>\n{escape(personality)}\n</personality>"
+        )
         if goals:
-            goal_list = "\n".join(f"- {g}" for g in goals)
+            goal_list = "\n".join(f"- {escape(g)}" for g in goals)
             sections.append(f"\nYour Goals:\n<goals>\n{goal_list}\n</goals>")
         if capability_ids:
             all_caps = await self.list_capabilities()
@@ -170,7 +173,7 @@ class AgentService:
                     "Create a unique, high-quality persona based on the user's keywords."
                 ),
             },
-            {"role": "user", "content": f"Keywords:\n<keywords>\n{keywords}\n</keywords>"},
+            {"role": "user", "content": f"Keywords:\n<keywords>\n{escape(keywords)}\n</keywords>"},
         ]
 
         return await structured_completion(

--- a/backend/app/domain/chat/background_service.py
+++ b/backend/app/domain/chat/background_service.py
@@ -152,11 +152,11 @@ class ChatBackgroundService:
                 },
                 {
                     "role": "user",
-                    "content": f"CURRENT SUMMARY:\n{current_summary}",
+                    "content": f"CURRENT SUMMARY:\n<current_summary>\n{current_summary}\n</current_summary>",
                 },
                 {
                     "role": "user",
-                    "content": f"LATEST MESSAGES:\n{transcript}",
+                    "content": f"LATEST MESSAGES:\n<latest_messages>\n{transcript}\n</latest_messages>",
                 },
             ]
 

--- a/backend/app/domain/chat/background_service.py
+++ b/backend/app/domain/chat/background_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import uuid
 from typing import TYPE_CHECKING, Any
+from xml.sax.saxutils import escape
 
 from pydantic import BaseModel
 
@@ -152,11 +153,11 @@ class ChatBackgroundService:
                 },
                 {
                     "role": "user",
-                    "content": f"CURRENT SUMMARY:\n<current_summary>\n{current_summary}\n</current_summary>",
+                    "content": f"CURRENT SUMMARY:\n<current_summary>\n{escape(current_summary)}\n</current_summary>",
                 },
                 {
                     "role": "user",
-                    "content": f"LATEST MESSAGES:\n<latest_messages>\n{transcript}\n</latest_messages>",
+                    "content": f"LATEST MESSAGES:\n<latest_messages>\n{escape(transcript)}\n</latest_messages>",
                 },
             ]
 

--- a/backend/app/domain/chat/prompts.py
+++ b/backend/app/domain/chat/prompts.py
@@ -6,14 +6,19 @@ from __future__ import annotations
 # Prompt templates
 # ---------------------------------------------------------------------------
 
-HISTORY_PREFIX = "Recent conversation history (for context only — do not repeat it):\n<history>\n{history}\n</history>\n\n"
+HISTORY_PREFIX = (
+    "Recent conversation history (for context only — do not repeat it):\n"
+    "<history>\n{history}\n</history>\n\n"
+)
 
 MEMORY_PREFIX = (
     "Relevant memories from past conversations (background context — do not repeat verbatim):\n"
     "<memories>\n{memories}\n</memories>\n\n"
 )
 
-SUMMARY_PREFIX = "Summary of the older parts of this conversation:\n<summary>\n{summary}\n</summary>\n\n"
+SUMMARY_PREFIX = (
+    "Summary of the older parts of this conversation:\n<summary>\n{summary}\n</summary>\n\n"
+)
 
 MULTI_AGENT_PROMPT = (
     "{summary_section}"

--- a/backend/app/domain/chat/prompts.py
+++ b/backend/app/domain/chat/prompts.py
@@ -6,20 +6,20 @@ from __future__ import annotations
 # Prompt templates
 # ---------------------------------------------------------------------------
 
-HISTORY_PREFIX = "Recent conversation history (for context only — do not repeat it):\n{history}\n\n"
+HISTORY_PREFIX = "Recent conversation history (for context only — do not repeat it):\n<history>\n{history}\n</history>\n\n"
 
 MEMORY_PREFIX = (
     "Relevant memories from past conversations (background context — do not repeat verbatim):\n"
-    "{memories}\n\n"
+    "<memories>\n{memories}\n</memories>\n\n"
 )
 
-SUMMARY_PREFIX = "Summary of the older parts of this conversation:\n{summary}\n\n"
+SUMMARY_PREFIX = "Summary of the older parts of this conversation:\n<summary>\n{summary}\n</summary>\n\n"
 
 MULTI_AGENT_PROMPT = (
     "{summary_section}"
     "{memory_section}"
     "{history_section}"
-    "User said: {user_message}. "
+    "User said: <user_message>\n{user_message}\n</user_message>\n"
     "You are managing a group chat with specialized agents. "
     "Delegate ONLY to agents whose expertise is directly relevant to the user's request — "
     "do NOT force every agent to respond. "
@@ -39,7 +39,7 @@ SINGLE_AGENT_PROMPT = (
     "{summary_section}"
     "{memory_section}"
     "{history_section}"
-    "User said: {user_message}. "
+    "User said: <user_message>\n{user_message}\n</user_message>\n"
     "Respond naturally and helpfully as yourself. "
     "When relevant, be proactive about planning and converting intent into tasks/notes/events. "
     "Confirm before write actions unless the user explicitly requested immediate execution. "

--- a/backend/app/domain/memory/graph_service.py
+++ b/backend/app/domain/memory/graph_service.py
@@ -52,7 +52,7 @@ class GraphExtractionService:
                     },
                     {
                         "role": "user",
-                        "content": text,
+                        "content": f"<text>\n{text}\n</text>",
                     },
                 ],
                 response_model=GraphExtractionSchema,

--- a/backend/app/domain/memory/graph_service.py
+++ b/backend/app/domain/memory/graph_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from uuid import UUID
+from xml.sax.saxutils import escape
 
 from pydantic import BaseModel, Field
 
@@ -52,7 +53,7 @@ class GraphExtractionService:
                     },
                     {
                         "role": "user",
-                        "content": f"<text>\n{text}\n</text>",
+                        "content": f"<text>\n{escape(text)}\n</text>",
                     },
                 ],
                 response_model=GraphExtractionSchema,


### PR DESCRIPTION
Harden the LLM integration by enforcing prompt isolation to mitigate prompt injection vulnerabilities. Raw user input and external dynamic values are now safely sandboxed within explicit XML delimiters (e.g., `<user_message>`) before being passed into the system prompts across agent profiles, chat orchestration, and background memory summarization services. This ensures that the AI cleanly separates instructions from data.

---
*PR created automatically by Jules for task [3878732731561993193](https://jules.google.com/task/3878732731561993193) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized tag-based formatting for AI prompts across backend services.

* **Bug Fixes**
  * Improved handling of special characters in messages, summaries, keywords, and extracted text to reduce formatting issues and improve reliability of summaries and agent profiles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->