### PR TITLE
docs: Document websocket chat hub endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ All routes are under `/api/v1` and require a Supabase JWT Bearer token (except h
 | Prefix | Description |
 |--------|-------------|
 | `GET /health` | Health check |
-| `WS /api/v1/ws/chat` | WebSocket chat hub (requires `token` query param) |
+| `WS /api/v1/ws/chat` | WebSocket chat hub (requires `token`, optional `lang` query params) |
 | `/api/v1/agents` | Agent CRUD |
 | `/api/v1/agents/capabilities` | List available capabilities |
 | `/api/v1/agents/integrations` | List available integrations |

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ All routes are under `/api/v1` and require a Supabase JWT Bearer token (except h
 | Prefix | Description |
 |--------|-------------|
 | `GET /health` | Health check |
+| `WS /api/v1/ws/chat` | WebSocket chat hub (requires `token` query param) |
 | `/api/v1/agents` | Agent CRUD |
 | `/api/v1/agents/capabilities` | List available capabilities |
 | `/api/v1/agents/integrations` | List available integrations |

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -99,7 +99,6 @@ async def _handle_send_message(
 # ---------------------------------------------------------------------------
 # WebSocket endpoint
 # ---------------------------------------------------------------------------
-# DOCS(miru-agent): undocumented endpoint
 @router.websocket("/ws/chat")
 async def websocket_chat_hub(
     websocket: WebSocket,

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -99,6 +99,7 @@ async def _handle_send_message(
 # ---------------------------------------------------------------------------
 # WebSocket endpoint
 # ---------------------------------------------------------------------------
+# DOCS(miru-agent): undocumented endpoint
 @router.websocket("/ws/chat")
 async def websocket_chat_hub(
     websocket: WebSocket,


### PR DESCRIPTION
This PR adds documentation for the undocumented WebSocket chat hub endpoint (`/api/v1/ws/chat`), updating the API section in the `README.md` and adding the required `# DOCS` flag above the endpoint route.

---
*PR created automatically by Jules for task [4257892925249296383](https://jules.google.com/task/4257892925249296383) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented WebSocket chat endpoint (`WS /api/v1/ws/chat`) with token authentication requirement in API documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->