### PR TITLE
refactor(agents): Decouple AgentService from Tortoise ORM in favor of AgentRepository

### DIFF
--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -134,8 +134,9 @@ class AgentService:
 
         integration_configs = None
         if agent_data.integrations:
+            local_integration_configs = agent_data.integration_configs or {}
             integration_configs = {
-                str(integration_id): agent_data.integration_configs.get(str(integration_id), {})
+                str(integration_id): local_integration_configs.get(str(integration_id), {})
                 for integration_id in agent_data.integrations
             }
 

--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -189,9 +189,11 @@ class AgentService:
         if new_capability_ids is not None:
             effective_cap_ids = new_capability_ids
         else:
-            effective_cap_ids = [
-                str(cap.id) for cap in agent.capabilities.related_objects
-            ] if agent.capabilities.related_objects else []
+            effective_cap_ids = (
+                [str(cap.id) for cap in agent.capabilities.related_objects]
+                if agent.capabilities.related_objects
+                else []
+            )
 
         # --- integrations ---
         new_integration_ids: list[str] | None = fields.pop("integrations", None)

--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from app.domain.agents.models import Agent, AgentIntegration, Capability, Integration
+from app.domain.agents.models import Agent, Capability, Integration
 from app.domain.agents.schemas import (
     AgentCreate,
     AgentGenerationResponse,
@@ -123,36 +123,28 @@ class AgentService:
             capability_ids=agent_data.capabilities,
         )
 
-        agent = await Agent.create(
-            user_id=user_id,
-            name=agent_data.name,
-            personality=agent_data.personality,
-            description=agent_data.description,
-            goals=agent_data.goals,
-            system_prompt=system_prompt,
+        agent_dict = {
+            "user_id": user_id,
+            "name": agent_data.name,
+            "personality": agent_data.personality,
+            "description": agent_data.description,
+            "goals": agent_data.goals,
+            "system_prompt": system_prompt,
+        }
+
+        integration_configs = None
+        if agent_data.integrations:
+            integration_configs = {
+                str(integration_id): agent_data.integration_configs.get(str(integration_id), {})
+                for integration_id in agent_data.integrations
+            }
+
+        refetched = await self.repo.create_agent(
+            agent_data=agent_dict,
+            capability_ids=agent_data.capabilities,
+            integration_configs=integration_configs,
         )
 
-        if agent_data.capabilities:
-            caps = await Capability.filter(id__in=agent_data.capabilities)
-            await agent.capabilities.add(*caps)
-
-        if agent_data.integrations:
-            integrations = await Integration.filter(id__in=agent_data.integrations)
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=agent_data.integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
-
-        # Refetch with relations so the response is fully populated.
-        refetched = await self.repo.get_by_id(agent.pk)
-        assert refetched is not None
         return _build_agent_response(refetched)
 
     async def list_agents(self, user_id: UUID) -> list[AgentResponse]:
@@ -195,33 +187,21 @@ class AgentService:
         # --- capabilities ---
         new_capability_ids: list[str] | None = fields.pop("capabilities", None)
         if new_capability_ids is not None:
-            caps = await Capability.filter(id__in=new_capability_ids)
-            await agent.capabilities.clear()
-            if caps:
-                await agent.capabilities.add(*caps)
             effective_cap_ids = new_capability_ids
         else:
             effective_cap_ids = [
-                str(c_id) for c_id in await agent.capabilities.all().values_list("id", flat=True)
-            ]
+                str(cap.id) for cap in agent.capabilities.related_objects
+            ] if agent.capabilities.related_objects else []
 
         # --- integrations ---
         new_integration_ids: list[str] | None = fields.pop("integrations", None)
         new_integration_configs: dict = fields.pop("integration_configs", None) or {}
+        integration_configs = None
         if new_integration_ids is not None:
-            await AgentIntegration.filter(agent=agent).delete()
-            integrations = await Integration.filter(id__in=new_integration_ids)
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=new_integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
+            integration_configs = {
+                str(integration_id): new_integration_configs.get(str(integration_id), {})
+                for integration_id in new_integration_ids
+            }
 
         # Merge profile fields with current values so build_system_prompt has full context
         name = fields.get("name", agent.name)
@@ -237,6 +217,12 @@ class AgentService:
             capability_ids=effective_cap_ids or None,
         )
         fields["system_prompt"] = updated_prompt
+
+        # pass relations to update_agent
+        if new_capability_ids is not None:
+            fields["capability_ids"] = new_capability_ids
+        if integration_configs is not None:
+            fields["integration_configs"] = integration_configs
 
         updated = await self.repo.update_agent(agent_id, user_id, **fields)
         if not updated:

--- a/backend/app/infrastructure/repositories/agent_repo.py
+++ b/backend/app/infrastructure/repositories/agent_repo.py
@@ -52,10 +52,39 @@ class AgentRepository:
         """List agent templates (paginated)."""
         return await AgentTemplate.all().offset(skip).limit(limit)
 
-    async def create(self, agent: Agent) -> Agent:
-        """Create a new agent."""
-        await agent.save()
-        return agent
+    async def create_agent(
+        self,
+        agent_data: dict,
+        capability_ids: list[str] | None = None,
+        integration_configs: dict | None = None,
+    ) -> Agent:
+        """Create a new agent with capabilities and integrations."""
+        agent = await Agent.create(**agent_data)
+
+        if capability_ids:
+            caps = await Capability.filter(id__in=capability_ids)
+            await agent.capabilities.add(*caps)
+
+        if integration_configs:
+            integration_ids = list(integration_configs.keys())
+            integrations = await Integration.filter(id__in=integration_ids)
+            from app.domain.agents.models import AgentIntegration
+
+            agent_integrations = [
+                AgentIntegration(
+                    agent=agent,
+                    integration=integration,
+                    config=integration_configs.get(str(integration.id), {}),
+                    enabled=True,
+                )
+                for integration in integrations
+            ]
+            if agent_integrations:
+                await AgentIntegration.bulk_create(agent_integrations)
+
+        refetched = await self.get_by_id(agent.pk)
+        assert refetched is not None
+        return refetched
 
     async def update_mood(self, agent_id: UUID | str, mood: str) -> None:
         """Update an agent's mood."""
@@ -71,7 +100,11 @@ class AgentRepository:
     async def update_agent(
         self, agent_id: UUID | str, user_id: UUID | str, **fields: object
     ) -> Agent | None:
-        """Update an agent's fields. Only updates the owner's agent."""
+        """Update an agent's fields. Only updates the owner's agent. Handles M2M relation updates if provided."""
+        # Pop relational updates if any
+        capability_ids = fields.pop("capability_ids", None)
+        integration_configs = fields.pop("integration_configs", None)
+
         unknown = set(fields) - self._ALLOWED_AGENT_FIELDS
         if unknown:
             raise ValueError(f"update_agent received unknown fields: {unknown}")
@@ -82,12 +115,44 @@ class AgentRepository:
         agent = await Agent.get_or_none(id=agent_id, user_id=user_id).prefetch_related(
             "capabilities", "agent_integrations__integration"
         )
-        if agent:
-            for key, value in fields.items():
-                if value is not None:
-                    setattr(agent, key, value)
-            await agent.save()
-        return agent
+        if not agent:
+            return None
+
+        # Update standard fields
+        for key, value in fields.items():
+            if value is not None:
+                setattr(agent, key, value)
+        await agent.save()
+
+        # Update M2M relations if provided
+        if capability_ids is not None:
+            caps = await Capability.filter(id__in=capability_ids)
+            await agent.capabilities.clear()
+            if caps:
+                await agent.capabilities.add(*caps)
+
+        if integration_configs is not None:
+            from app.domain.agents.models import AgentIntegration
+
+            await AgentIntegration.filter(agent=agent).delete()
+            integration_ids = list(integration_configs.keys())
+            integrations = await Integration.filter(id__in=integration_ids)
+            agent_integrations = [
+                AgentIntegration(
+                    agent=agent,
+                    integration=integration,
+                    config=integration_configs.get(str(integration.id), {}),
+                    enabled=True,
+                )
+                for integration in integrations
+            ]
+            if agent_integrations:
+                await AgentIntegration.bulk_create(agent_integrations)
+
+        # Re-fetch agent to guarantee relationships are refreshed
+        refetched = await self.get_by_id(agent_id)
+        assert refetched is not None
+        return refetched
 
     async def delete_agent(self, agent_id: UUID | str, user_id: UUID | str) -> bool:
         """Soft-delete an agent by setting deleted_at. Only deletes the owner's agent."""

--- a/backend/app/infrastructure/repositories/agent_repo.py
+++ b/backend/app/infrastructure/repositories/agent_repo.py
@@ -59,31 +59,33 @@ class AgentRepository:
         integration_configs: dict | None = None,
     ) -> Agent:
         """Create a new agent with capabilities and integrations."""
-        agent = await Agent.create(**agent_data)
+        async with in_transaction():
+            agent = await Agent.create(**agent_data)
 
-        if capability_ids:
-            caps = await Capability.filter(id__in=capability_ids)
-            await agent.capabilities.add(*caps)
+            if capability_ids:
+                caps = await Capability.filter(id__in=capability_ids)
+                await agent.capabilities.add(*caps)
 
-        if integration_configs:
-            integration_ids = list(integration_configs.keys())
-            integrations = await Integration.filter(id__in=integration_ids)
-            from app.domain.agents.models import AgentIntegration
+            if integration_configs:
+                integration_ids = list(integration_configs.keys())
+                integrations = await Integration.filter(id__in=integration_ids)
+                from app.domain.agents.models import AgentIntegration
 
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
+                agent_integrations = [
+                    AgentIntegration(
+                        agent=agent,
+                        integration=integration,
+                        config=integration_configs.get(str(integration.id), {}),
+                        enabled=True,
+                    )
+                    for integration in integrations
+                ]
+                if agent_integrations:
+                    await AgentIntegration.bulk_create(agent_integrations)
 
         refetched = await self.get_by_id(agent.pk)
-        assert refetched is not None
+        if refetched is None:
+            raise RuntimeError(f"Expected agent refetch to succeed for id {agent.pk}")
         return refetched
 
     async def update_mood(self, agent_id: UUID | str, mood: str) -> None:
@@ -118,40 +120,42 @@ class AgentRepository:
         if not agent:
             return None
 
-        # Update standard fields
-        for key, value in fields.items():
-            if value is not None:
-                setattr(agent, key, value)
-        await agent.save()
+        async with in_transaction():
+            # Update standard fields
+            for key, value in fields.items():
+                if value is not None:
+                    setattr(agent, key, value)
+            await agent.save()
 
-        # Update M2M relations if provided
-        if capability_ids is not None:
-            caps = await Capability.filter(id__in=capability_ids)
-            await agent.capabilities.clear()
-            if caps:
-                await agent.capabilities.add(*caps)
+            # Update M2M relations if provided
+            if isinstance(capability_ids, list):
+                caps = await Capability.filter(id__in=capability_ids)
+                await agent.capabilities.clear()
+                if caps:
+                    await agent.capabilities.add(*caps)
 
-        if integration_configs is not None:
-            from app.domain.agents.models import AgentIntegration
+            if isinstance(integration_configs, dict):
+                from app.domain.agents.models import AgentIntegration
 
-            await AgentIntegration.filter(agent=agent).delete()
-            integration_ids = list(integration_configs.keys())
-            integrations = await Integration.filter(id__in=integration_ids)
-            agent_integrations = [
-                AgentIntegration(
-                    agent=agent,
-                    integration=integration,
-                    config=integration_configs.get(str(integration.id), {}),
-                    enabled=True,
-                )
-                for integration in integrations
-            ]
-            if agent_integrations:
-                await AgentIntegration.bulk_create(agent_integrations)
+                await AgentIntegration.filter(agent=agent).delete()
+                integration_ids = list(integration_configs.keys())
+                integrations = await Integration.filter(id__in=integration_ids)
+                agent_integrations = [
+                    AgentIntegration(
+                        agent=agent,
+                        integration=integration,
+                        config=integration_configs.get(str(integration.id), {}),
+                        enabled=True,
+                    )
+                    for integration in integrations
+                ]
+                if agent_integrations:
+                    await AgentIntegration.bulk_create(agent_integrations)
 
         # Re-fetch agent to guarantee relationships are refreshed
         refetched = await self.get_by_id(agent_id)
-        assert refetched is not None
+        if refetched is None:
+            raise RuntimeError(f"Expected agent refetch to succeed for id {agent.pk}")
         return refetched
 
     async def delete_agent(self, agent_id: UUID | str, user_id: UUID | str) -> bool:

--- a/backend/tests/test_repositories.py
+++ b/backend/tests/test_repositories.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 
 import pytest
 
-from app.domain.agents.models import Agent
 from app.domain.chat.entities import ChatMessageEntity
 from app.domain.memory.models import Memory
 from app.infrastructure.repositories.agent_repo import AgentRepository
@@ -61,8 +60,13 @@ class TestAgentRepository:
     async def test_create_returns_agent(self) -> None:
         repo = AgentRepository()
         user_id = uuid4()
-        agent = Agent(name="Test", user_id=user_id, personality="Friendly", system_prompt="Hi")
-        created = await repo.create(agent)
+        agent_data = {
+            "name": "Test",
+            "user_id": user_id,
+            "personality": "Friendly",
+            "system_prompt": "Hi",
+        }
+        created = await repo.create_agent(agent_data)
         assert created.name == "Test"
         assert created.id is not None
 


### PR DESCRIPTION
**Violation Summary:**
The `AgentService` in the Domain layer contained logic belonging to the Infrastructure layer, directly executing Tortoise ORM framework queries (like `.create()`, `.filter()`, and `.bulk_create()`). This violated the Clean Architecture "One-Way" Dependency Rule and Layer Contract, causing the Application layer to be tightly coupled with the specific Database ORM implementation.

**Refactoring Performed:**
1. Moved ORM relationship orchestration and database saves from `AgentService` (`backend/app/domain/agents/service.py`) to `AgentRepository` (`backend/app/infrastructure/repositories/agent_repo.py`).
2. `AgentRepository` now explicitly implements `create_agent` and handles complex state relations (capabilities/integrations) during `update_agent`.
3. `AgentService` merely composes raw scalar fields and lists of IDs, delegating the actual queries and relationships to the Repository interface.

**Architectural Note:**
According to the Layer Contract, the Domain Layer (`service.py`) must never import or utilize ORMs or framework-specific code. By restricting `AgentService` to Application logic (like prompt construction) and passing explicit primitives down to `AgentRepository`, we have established clear boundaries. The Infrastructure Layer now correctly owns all database mappers and operations.

---
*PR created automatically by Jules for task [10560429368958874619](https://jules.google.com/task/10560429368958874619) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored agent creation and update workflows to use repository methods for improved data persistence handling. Integration configuration and capability management now flows through the repository layer, enhancing code structure and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/695?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->