### PR TITLE
feat(ai): enforce prompt isolation and XML sanitization

### DIFF
--- a/backend/app/domain/chat/crew_orchestrator.py
+++ b/backend/app/domain/chat/crew_orchestrator.py
@@ -184,7 +184,9 @@ class CrewOrchestrator:
             if not content:
                 continue
             content = xml.sax.saxutils.escape(content)
-            prefix = "User" if role == "user" else entry.get("name", "Agent")
+            raw_name = entry.get("name", "Agent")
+            safe_name = xml.sax.saxutils.escape(raw_name)
+            prefix = "User" if role == "user" else safe_name
             lines.append(f"{prefix}: {content}")
         return "\n".join(lines)
 

--- a/backend/app/domain/chat/crew_orchestrator.py
+++ b/backend/app/domain/chat/crew_orchestrator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import xml.sax.saxutils
 from typing import TYPE_CHECKING, Any, cast
 
 import crewai
@@ -182,6 +183,7 @@ class CrewOrchestrator:
             content = entry.get("content", "").strip()
             if not content:
                 continue
+            content = xml.sax.saxutils.escape(content)
             prefix = "User" if role == "user" else entry.get("name", "Agent")
             lines.append(f"{prefix}: {content}")
         return "\n".join(lines)
@@ -230,8 +232,18 @@ class CrewOrchestrator:
 
         history_text = CrewOrchestrator.format_history(conversation_history)
         history_section = HISTORY_PREFIX.format(history=history_text) if history_text else ""
-        memory_section = MEMORY_PREFIX.format(memories=memory_context) if memory_context else ""
-        summary_section = SUMMARY_PREFIX.format(summary=room_summary) if room_summary else ""
+
+        safe_memory_context = xml.sax.saxutils.escape(memory_context) if memory_context else ""
+        memory_section = (
+            MEMORY_PREFIX.format(memories=safe_memory_context) if safe_memory_context else ""
+        )
+
+        safe_room_summary = xml.sax.saxutils.escape(room_summary) if room_summary else ""
+        summary_section = (
+            SUMMARY_PREFIX.format(summary=safe_room_summary) if safe_room_summary else ""
+        )
+
+        safe_user_message = xml.sax.saxutils.escape(user_message)
 
         kwargs = {}
         if step_callback:
@@ -244,7 +256,7 @@ class CrewOrchestrator:
                     summary_section=summary_section,
                     memory_section=memory_section,
                     history_section=history_section,
-                    user_message=user_message,
+                    user_message=safe_user_message,
                     locale_instruction=locale_instruction,
                 ),
                 expected_output=MULTI_AGENT_EXPECTED_OUTPUT,
@@ -262,7 +274,7 @@ class CrewOrchestrator:
                     summary_section=summary_section,
                     memory_section=memory_section,
                     history_section=history_section,
-                    user_message=user_message,
+                    user_message=safe_user_message,
                     locale_instruction=locale_instruction,
                 ),
                 expected_output=SINGLE_AGENT_EXPECTED_OUTPUT,

--- a/backend/app/domain/chat/prompts.py
+++ b/backend/app/domain/chat/prompts.py
@@ -6,20 +6,25 @@ from __future__ import annotations
 # Prompt templates
 # ---------------------------------------------------------------------------
 
-HISTORY_PREFIX = "Recent conversation history (for context only — do not repeat it):\n{history}\n\n"
+HISTORY_PREFIX = (
+    "Recent conversation history (for context only — do not repeat it):\n"
+    "<history>{history}</history>\n\n"
+)
 
 MEMORY_PREFIX = (
     "Relevant memories from past conversations (background context — do not repeat verbatim):\n"
-    "{memories}\n\n"
+    "<memories>{memories}</memories>\n\n"
 )
 
-SUMMARY_PREFIX = "Summary of the older parts of this conversation:\n{summary}\n\n"
+SUMMARY_PREFIX = (
+    "Summary of the older parts of this conversation:\n<summary>{summary}</summary>\n\n"
+)
 
 MULTI_AGENT_PROMPT = (
     "{summary_section}"
     "{memory_section}"
     "{history_section}"
-    "User said: {user_message}. "
+    "User said: <user_input>{user_message}</user_input>. "
     "You are managing a group chat with specialized agents. "
     "Delegate ONLY to agents whose expertise is directly relevant to the user's request — "
     "do NOT force every agent to respond. "
@@ -39,7 +44,7 @@ SINGLE_AGENT_PROMPT = (
     "{summary_section}"
     "{memory_section}"
     "{history_section}"
-    "User said: {user_message}. "
+    "User said: <user_input>{user_message}</user_input>. "
     "Respond naturally and helpfully as yourself. "
     "When relevant, be proactive about planning and converting intent into tasks/notes/events. "
     "Confirm before write actions unless the user explicitly requested immediate execution. "

--- a/backend/tests/chat/test_chat_crew.py
+++ b/backend/tests/chat/test_chat_crew.py
@@ -10,6 +10,17 @@ from app.domain.chat.crew_orchestrator import CrewOrchestrator
 from app.domain.chat.service import ChatService
 
 
+def test_format_history_sanitizes_xml() -> None:
+    history = [
+        {"role": "user", "name": "User", "content": "<script>alert(1)</script>"},
+        {"role": "agent", "name": "Agent <Malicious>", "content": "Normal text"},
+        {"role": "user", "name": "User", "content": ""},
+        {"role": "agent", "name": "Agent", "content": "   "},
+    ]
+    result = CrewOrchestrator.format_history(history)
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in result
+    assert "Agent &lt;Malicious&gt;" in result
+
 def test_get_agent_tools() -> None:
     agent1 = MagicMock()
     agent1.id = uuid4()

--- a/backend/tests/chat/test_chat_crew.py
+++ b/backend/tests/chat/test_chat_crew.py
@@ -21,6 +21,7 @@ def test_format_history_sanitizes_xml() -> None:
     assert "&lt;script&gt;alert(1)&lt;/script&gt;" in result
     assert "Agent &lt;Malicious&gt;" in result
 
+
 def test_get_agent_tools() -> None:
     agent1 = MagicMock()
     agent1.id = uuid4()


### PR DESCRIPTION
This PR resolves the requirement for prompt isolation set forth by the AI Integration Engineer standard. 

### Changes:
- **XML Tagging:** Restructured prompt templates to encase dynamic variables within XML boundary markers to explicitly define intent-vs-input context for the LLM.
- **Input Sanitization:** Modified `backend/app/domain/chat/crew_orchestrator.py` to sanitize incoming dynamic values with `xml.sax.saxutils.escape`. This neutralizes existing tags in the raw payload, preventing attackers from conducting XML-breakout prompt injection.
- **Verification:** Ran full backend pytest suite (328 tests) successfully to assert behavioral integrity alongside code reviews.

---
*PR created automatically by Jules for task [2483682862939350030](https://jules.google.com/task/2483682862939350030) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced chat security by escaping user input and context to prevent potential injection attacks

* **Refactor**
  * Restructured prompt templates with XML-style tags for better information organization and improved AI model understanding

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->