### PR TITLE
Refactor productivity screen to follow clean architecture and SOLID principles

### DIFF
--- a/frontend/app/(main)/productivity.tsx
+++ b/frontend/app/(main)/productivity.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback } from 'react';
 import {
-  Alert,
   FlatList,
   Platform,
   Pressable,
@@ -11,17 +10,20 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { useLocalSearchParams, usePathname, useRouter } from 'expo-router';
-import { useTranslation } from 'react-i18next';
 import { AppText } from '../../src/components/AppText';
 import { CreateNoteModal } from '../../src/components/productivity/CreateNoteModal';
 import { CreateTaskModal } from '../../src/components/productivity/CreateTaskModal';
 import { NoteCard } from '../../src/components/productivity/NoteCard';
 import { TaskCard } from '../../src/components/productivity/TaskCard';
+import { EventCard } from '../../src/components/productivity/EventCard';
+import { ProductivityEmptyState } from '../../src/components/productivity/ProductivityEmptyState';
 import { theme } from '../../src/core/theme';
-import { CalendarEvent, Note, Task } from '../../src/core/models';
-import { useProductivityStore } from '../../src/store/useProductivityStore';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
+import { CalendarEvent, Note, Task } from '@/core/models';
+import {
+  RenderItemData,
+  useProductivityViewModel,
+} from '../../src/hooks/useProductivityViewModel';
 
 const T = {
   background: { light: DESIGN_TOKENS.colors.pageBg },
@@ -42,299 +44,34 @@ const T = {
 const S = theme.spacing;
 const R = theme.borderRadius;
 
-type Tab = 'today' | 'all' | 'notes' | 'tasks';
-type TaskPriority = 'all' | 'overdue' | 'today' | 'upcoming' | 'no_due';
-
-type RenderItemData = {
-  date?: number;
-  type: 'note' | 'task' | 'event';
-  item: Note | Task | CalendarEvent;
-  id: string;
-};
-
 export default function ProductivityScreen() {
-  const { t, i18n } = useTranslation();
-  const router = useRouter();
-  const pathname = usePathname();
-  const params = useLocalSearchParams() as Record<string, string | string[] | undefined>;
-  const openCreateTask = params.openCreateTask;
-  const openCreateNote = params.openCreateNote;
-  const [activeTab, setActiveTab] = useState<Tab>('today');
-  const [taskPriority, setTaskPriority] = useState<TaskPriority>('all');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [showCreateNote, setShowCreateNote] = useState(false);
-  const [showCreateTask, setShowCreateTask] = useState(false);
-  const [todayPlan, setTodayPlan] = useState<string | null>(null);
-
   const {
-    notes,
-    tasks,
-    events,
-    fetchNotes,
-    fetchTasks,
-    fetchEvents,
+    t,
+    activeTab,
+    setActiveTab,
+    taskPriority,
+    setTaskPriority,
+    searchQuery,
+    setSearchQuery,
+    showCreateNote,
+    setShowCreateNote,
+    showCreateTask,
+    setShowCreateTask,
+    todayPlan,
+    setTodayPlan,
     isLoading,
+    handleRefresh,
+    confirmDelete,
     deleteNote,
     deleteTask,
     toggleTask,
-  } = useProductivityStore();
-
-  useEffect(() => {
-    const controller = new AbortController();
-    fetchNotes(controller.signal);
-    fetchTasks(controller.signal);
-    fetchEvents(controller.signal);
-    return () => {
-      controller.abort();
-    };
-  }, [fetchEvents, fetchNotes, fetchTasks]);
-
-  useEffect(() => {
-    if (openCreateTask === '1' || openCreateTask === 'true') {
-      setShowCreateTask(true);
-      const nextParams = Object.fromEntries(
-        Object.entries(params).filter(
-          ([key, value]) => key !== 'openCreateTask' && typeof value === 'string'
-        )
-      );
-      router.replace({ pathname, params: nextParams });
-    }
-  }, [openCreateTask, params, pathname, router]);
-
-  useEffect(() => {
-    if (openCreateNote === '1' || openCreateNote === 'true') {
-      setShowCreateNote(true);
-      const nextParams = Object.fromEntries(
-        Object.entries(params).filter(
-          ([key, value]) => key !== 'openCreateNote' && typeof value === 'string'
-        )
-      );
-      router.replace({ pathname, params: nextParams });
-    }
-  }, [openCreateNote, params, pathname, router]);
-
-  const handleRefresh = useCallback(() => {
-    fetchNotes();
-    fetchTasks();
-    fetchEvents();
-  }, [fetchEvents, fetchNotes, fetchTasks]);
-
-  const confirmDelete = useCallback(
-    (action: () => Promise<void>) =>
-      Alert.alert(
-        t('productivity.delete') || 'Delete',
-        t('productivity.are_you_sure') || 'Are you sure?',
-        [
-          { text: t('settings.actions.cancel') || 'Cancel', style: 'cancel' },
-          {
-            text: t('settings.actions.delete') || 'Delete',
-            style: 'destructive',
-            onPress: () => action(),
-          },
-        ]
-      ),
-    [t]
-  );
-
-  const filteredNotes = useMemo(() => {
-    if (!searchQuery) return notes;
-    const lowerQ = searchQuery.toLowerCase();
-    return notes.filter(
-      (n) => n.title.toLowerCase().includes(lowerQ) || n.content.toLowerCase().includes(lowerQ)
-    );
-  }, [notes, searchQuery]);
-
-  const filteredTasks = useMemo(() => {
-    if (!searchQuery) return tasks;
-    const lowerQ = searchQuery.toLowerCase();
-    return tasks.filter(
-      (task) =>
-        task.title.toLowerCase().includes(lowerQ) ||
-        (task.description?.toLowerCase().includes(lowerQ) ?? false)
-    );
-  }, [searchQuery, tasks]);
-
-  const filteredEvents = useMemo(() => {
-    if (!searchQuery) return events;
-    const lowerQ = searchQuery.toLowerCase();
-    return events.filter(
-      (event) =>
-        event.title.toLowerCase().includes(lowerQ) ||
-        (event.description?.toLowerCase().includes(lowerQ) ?? false) ||
-        (event.location?.toLowerCase().includes(lowerQ) ?? false)
-    );
-  }, [events, searchQuery]);
-
-  const pendingTasksCount = useMemo(
-    () => filteredTasks.filter((task) => !task.completed).length,
-    [filteredTasks]
-  );
-
-  const getTaskPriority = useCallback((task: Task): Exclude<TaskPriority, 'all'> => {
-    if (!task.due_date) return 'no_due';
-    const now = new Date();
-    const due = new Date(task.due_date);
-    if (isNaN(due.getTime())) return 'no_due';
-    const dayStart = new Date(now);
-    dayStart.setHours(0, 0, 0, 0);
-    const tomorrow = new Date(dayStart);
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    if (due < dayStart) return 'overdue';
-    if (due >= dayStart && due < tomorrow) return 'today';
-    return 'upcoming';
-  }, []);
-
-  const taskPriorityCounts = useMemo(() => {
-    const counts: Record<TaskPriority, number> = {
-      all: 0,
-      overdue: 0,
-      today: 0,
-      upcoming: 0,
-      no_due: 0,
-    };
-    filteredTasks
-      .filter((task) => !task.completed)
-      .forEach((task) => {
-        counts.all += 1;
-        counts[getTaskPriority(task)] += 1;
-      });
-    return counts;
-  }, [filteredTasks, getTaskPriority]);
-
-  const prioritizedTasks = useMemo(() => {
-    const tasksToRank = filteredTasks.filter((task) => !task.completed);
-    const pool =
-      taskPriority === 'all'
-        ? tasksToRank
-        : tasksToRank.filter((task) => getTaskPriority(task) === taskPriority);
-    return [...pool].sort((a, b) => {
-      const aDue = a.due_date ? new Date(a.due_date).getTime() : Number.MAX_SAFE_INTEGER;
-      const bDue = b.due_date ? new Date(b.due_date).getTime() : Number.MAX_SAFE_INTEGER;
-      return aDue - bDue;
-    });
-  }, [filteredTasks, getTaskPriority, taskPriority]);
-
-  const mixedData = useMemo(() => {
-    const data: RenderItemData[] = [];
-    filteredNotes.forEach((note) => {
-      data.push({
-        type: 'note',
-        item: note,
-        id: `note-${note.id}`,
-        date: new Date(note.created_at).getTime(),
-      });
-    });
-    filteredTasks.forEach((task) => {
-      data.push({
-        type: 'task',
-        item: task,
-        id: `task-${task.id}`,
-        date: new Date(task.created_at).getTime(),
-      });
-    });
-    return data.sort((a, b) => (b.date || 0) - (a.date || 0));
-  }, [filteredNotes, filteredTasks]);
-
-  const todayData = useMemo(() => {
-    const now = new Date();
-    const start = new Date(now);
-    start.setHours(0, 0, 0, 0);
-    const end = new Date(start);
-    end.setDate(end.getDate() + 1);
-    const weekEnd = new Date(start);
-    weekEnd.setDate(weekEnd.getDate() + 7);
-
-    const overdueTasks = filteredTasks.filter((task) => {
-      if (task.completed || !task.due_date) return false;
-      return new Date(task.due_date) < start;
-    });
-
-    const dueTodayTasks = filteredTasks.filter((task) => {
-      if (task.completed || !task.due_date) return false;
-      const dueDate = new Date(task.due_date);
-      return dueDate >= start && dueDate < end;
-    });
-
-    const upcomingEvents = filteredEvents.filter((event) => {
-      const startTime = new Date(event.start_time);
-      return startTime >= start && startTime < weekEnd;
-    });
-
-    const items: RenderItemData[] = [
-      ...overdueTasks.map((task) => ({
-        type: 'task' as const,
-        item: task,
-        id: `overdue-${task.id}`,
-        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
-      })),
-      ...dueTodayTasks.map((task) => ({
-        type: 'task' as const,
-        item: task,
-        id: `today-${task.id}`,
-        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
-      })),
-      ...upcomingEvents.map((event) => ({
-        type: 'event' as const,
-        item: event,
-        id: `event-${event.id}`,
-        date: new Date(event.start_time).getTime(),
-      })),
-    ];
-
-    return items.sort((a, b) => (a.date || 0) - (b.date || 0));
-  }, [filteredEvents, filteredTasks]);
-
-  const dataToRender: RenderItemData[] =
-    activeTab === 'today'
-      ? todayData.filter((entry) => {
-          if (entry.type !== 'task') return true;
-          if (taskPriority === 'all') return true;
-          return getTaskPriority(entry.item as Task) === taskPriority;
-        })
-      : activeTab === 'all'
-        ? mixedData
-        : activeTab === 'notes'
-          ? filteredNotes.map((note) => ({ type: 'note' as const, item: note, id: note.id }))
-          : prioritizedTasks.map((task) => ({ type: 'task' as const, item: task, id: task.id }));
-
-  const generateTodayPlan = useCallback(() => {
-    const now = new Date();
-    const nextTasks = prioritizedTasks.slice(0, 3);
-    const nextEvents = [...filteredEvents]
-      .filter((event) => new Date(event.end_time) >= now)
-      .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime())
-      .slice(0, 3);
-
-    const lines: string[] = [];
-    if (taskPriorityCounts.overdue > 0) {
-      lines.push(`1) Recover overdue: start with ${taskPriorityCounts.overdue} overdue task(s).`);
-    } else {
-      lines.push('1) No overdue tasks: start with highest-impact open work.');
-    }
-
-    if (nextTasks.length > 0) {
-      lines.push(`2) Focus block: ${nextTasks.map((task) => task.title).join(', ')}.`);
-    } else {
-      lines.push('2) Focus block: no pending tasks, use this for planning or review.');
-    }
-
-    if (nextEvents.length > 0) {
-      const eventLine = nextEvents
-        .map((event) =>
-          new Intl.DateTimeFormat(i18n.language, {
-            hour: '2-digit',
-            minute: '2-digit',
-          }).format(new Date(event.start_time))
-        )
-        .join(', ');
-      lines.push(`3) Calendar checkpoints at ${eventLine}.`);
-    } else {
-      lines.push('3) Calendar is light: reserve time for deep work and wrap-up.');
-    }
-
-    setTodayPlan(lines.join('\n'));
-    setActiveTab('today');
-  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue]);
+    pendingTasksCount,
+    taskPriorityCounts,
+    dataToRender,
+    generateTodayPlan,
+    onCreatedTask,
+    onCreatedNote,
+  } = useProductivityViewModel();
 
   const renderItem = useCallback(
     ({ item }: { item: RenderItemData }) => {
@@ -344,25 +81,7 @@ export default function ProductivityScreen() {
       }
       if (item.type === 'event') {
         const event = item.item as CalendarEvent;
-        return (
-          <View style={styles.eventCard}>
-            <View style={styles.eventIcon}>
-              <Ionicons name="calendar-outline" size={16} color={T.primary.DEFAULT} />
-            </View>
-            <View style={styles.eventBody}>
-              <AppText style={styles.eventTitle}>{event.title}</AppText>
-              <AppText style={styles.eventMeta}>
-                {new Intl.DateTimeFormat(i18n.language, {
-                  weekday: 'short',
-                  month: 'short',
-                  day: 'numeric',
-                  hour: event.is_all_day ? undefined : '2-digit',
-                  minute: event.is_all_day ? undefined : '2-digit',
-                }).format(new Date(event.start_time))}
-              </AppText>
-            </View>
-          </View>
-        );
+        return <EventCard event={event} />;
       }
 
       const task = item.item as Task;
@@ -374,7 +93,7 @@ export default function ProductivityScreen() {
         />
       );
     },
-    [confirmDelete, deleteNote, deleteTask, i18n.language, toggleTask]
+    [confirmDelete, deleteNote, deleteTask, toggleTask]
   );
 
   return (
@@ -565,98 +284,24 @@ export default function ProductivityScreen() {
           ) : null
         }
         ListEmptyComponent={
-          <View style={styles.emptyContainer}>
-            <View style={styles.emptyIconCircle}>
-              <Ionicons
-                name={
-                  activeTab === 'notes'
-                    ? 'document-text'
-                    : activeTab === 'tasks'
-                      ? 'checkbox'
-                      : activeTab === 'today'
-                        ? 'sunny-outline'
-                        : 'planet'
-                }
-                size={42}
-                color={T.primary.DEFAULT}
-              />
-            </View>
-            <AppText variant="h3" style={styles.emptyTitle}>
-              {searchQuery
-                ? t('productivity.no_matches') || 'No matches found'
-                : activeTab === 'notes'
-                  ? t('productivity.no_notes') || 'No Notes'
-                  : activeTab === 'tasks'
-                    ? t('productivity.no_tasks') || 'No Tasks'
-                    : activeTab === 'today'
-                      ? t('productivity.nothing_urgent_today')
-                      : t('productivity.workspace_clear') || 'Your workspace is clear'}
-            </AppText>
-            <AppText style={styles.emptySubtitle}>
-              {searchQuery
-                ? t('productivity.try_adjust_search') || 'Try adjusting your search terms.'
-                : activeTab === 'today'
-                  ? t('productivity.today_empty_detail')
-                  : t('productivity.capture_thoughts') ||
-                    'Capture your thoughts and track what needs to get done.'}
-            </AppText>
-
-            {!searchQuery && (
-              <View style={styles.emptyActions}>
-                {(activeTab === 'all' || activeTab === 'notes') && (
-                  <Pressable
-                    onPress={() => setShowCreateNote(true)}
-                    style={({ pressed }) => [styles.emptyButton, pressed && { opacity: 0.8 }]}
-                  >
-                    <Ionicons name="add" size={18} color={T.white} style={{ marginEnd: 6 }} />
-                    <AppText style={styles.emptyButtonText}>
-                      {t('productivity.newNote') || 'New Note'}
-                    </AppText>
-                  </Pressable>
-                )}
-                {(activeTab === 'all' || activeTab === 'tasks' || activeTab === 'today') && (
-                  <Pressable
-                    onPress={() => setShowCreateTask(true)}
-                    style={({ pressed }) => [
-                      styles.emptyButton,
-                      (activeTab === 'all' || activeTab === 'today') && styles.emptyButtonSecondary,
-                      pressed && { opacity: 0.8 },
-                    ]}
-                  >
-                    <Ionicons
-                      name="add"
-                      size={18}
-                      color={
-                        activeTab === 'all' || activeTab === 'today' ? T.primary.DEFAULT : T.white
-                      }
-                      style={{ marginEnd: 6 }}
-                    />
-                    <AppText
-                      style={
-                        activeTab === 'all' || activeTab === 'today'
-                          ? styles.emptyButtonTextSecondary
-                          : styles.emptyButtonText
-                      }
-                    >
-                      {t('productivity.new_task')}
-                    </AppText>
-                  </Pressable>
-                )}
-              </View>
-            )}
-          </View>
+          <ProductivityEmptyState
+            activeTab={activeTab}
+            searchQuery={searchQuery}
+            setShowCreateNote={setShowCreateNote}
+            setShowCreateTask={setShowCreateTask}
+          />
         }
       />
 
       <CreateNoteModal
         visible={showCreateNote}
         onClose={() => setShowCreateNote(false)}
-        onCreated={fetchNotes}
+        onCreated={onCreatedNote}
       />
       <CreateTaskModal
         visible={showCreateTask}
         onClose={() => setShowCreateTask(false)}
-        onCreated={fetchTasks}
+        onCreated={onCreatedTask}
       />
     </SafeAreaView>
   );
@@ -758,101 +403,5 @@ const styles = StyleSheet.create({
     paddingHorizontal: S.xl,
     paddingBottom: 100,
     paddingTop: S.sm,
-  },
-  eventCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.surface.light,
-    borderWidth: 1,
-    borderColor: T.border.light,
-    borderRadius: R.xl,
-    padding: S.lg,
-    marginBottom: S.md,
-    ...theme.elevation.sm,
-  },
-  eventIcon: {
-    width: 32,
-    height: 32,
-    borderRadius: R.lg,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginRight: S.md,
-  },
-  eventBody: {
-    flex: 1,
-  },
-  eventTitle: {
-    color: T.onSurface.light,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-  eventMeta: {
-    color: T.onSurface.mutedLight,
-    marginTop: 2,
-    fontSize: 13,
-  },
-  emptyContainer: {
-    alignItems: 'center',
-    paddingVertical: S.massive,
-  },
-  emptyIconCircle: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: S.lg,
-  },
-  emptyTitle: {
-    marginBottom: S.sm,
-    textAlign: 'center',
-    color: T.onSurface.light,
-  },
-  emptySubtitle: {
-    textAlign: 'center',
-    marginBottom: S.xl,
-    color: T.onSurface.mutedLight,
-    paddingHorizontal: S.xxxl,
-    lineHeight: 22,
-  },
-  emptyActions: {
-    flexDirection: 'row',
-    gap: S.md,
-  },
-  emptyButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.primary.DEFAULT,
-    borderRadius: R.xl,
-    paddingVertical: S.md,
-    paddingHorizontal: S.xl,
-    ...theme.elevation.md,
-  },
-  emptyButtonSecondary: {
-    backgroundColor: T.primary.surfaceLight,
-    ...Platform.select({
-      ios: {
-        shadowOpacity: 0,
-        elevation: 0,
-      },
-      android: {
-        elevation: 0,
-      },
-      default: {
-        elevation: 0,
-      },
-    }),
-  },
-  emptyButtonText: {
-    color: T.white,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-  emptyButtonTextSecondary: {
-    color: T.primary.DEFAULT,
-    fontWeight: '700',
-    fontSize: 15,
   },
 });

--- a/frontend/app/(main)/productivity.tsx
+++ b/frontend/app/(main)/productivity.tsx
@@ -10,20 +10,20 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { AppText } from '../../src/components/AppText';
-import { CreateNoteModal } from '../../src/components/productivity/CreateNoteModal';
-import { CreateTaskModal } from '../../src/components/productivity/CreateTaskModal';
-import { NoteCard } from '../../src/components/productivity/NoteCard';
-import { TaskCard } from '../../src/components/productivity/TaskCard';
-import { EventCard } from '../../src/components/productivity/EventCard';
-import { ProductivityEmptyState } from '../../src/components/productivity/ProductivityEmptyState';
-import { theme } from '../../src/core/theme';
+import { AppText } from '@/components/AppText';
+import { CreateNoteModal } from '@/components/productivity/CreateNoteModal';
+import { CreateTaskModal } from '@/components/productivity/CreateTaskModal';
+import { NoteCard } from '@/components/productivity/NoteCard';
+import { TaskCard } from '@/components/productivity/TaskCard';
+import { EventCard } from '@/components/productivity/EventCard';
+import { ProductivityEmptyState } from '@/components/productivity/ProductivityEmptyState';
+import { theme } from '@/core/theme';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
 import { CalendarEvent, Note, Task } from '@/core/models';
 import {
   RenderItemData,
   useProductivityViewModel,
-} from '../../src/hooks/useProductivityViewModel';
+} from '@/hooks/useProductivityViewModel';
 
 const T = {
   background: { light: DESIGN_TOKENS.colors.pageBg },
@@ -44,7 +44,7 @@ const T = {
 const S = theme.spacing;
 const R = theme.borderRadius;
 
-export default function ProductivityScreen() {
+export const ProductivityScreen = () => {
   const {
     t,
     activeTab,
@@ -177,14 +177,7 @@ export default function ProductivityScreen() {
       </View>
 
       {(activeTab === 'tasks' || activeTab === 'today') && (
-        <View
-          style={{
-            flexDirection: 'row',
-            flexWrap: 'wrap',
-            marginHorizontal: S.xl,
-            marginBottom: S.sm,
-          }}
-        >
+        <View className="flex-row flex-wrap mx-5 mb-2">
           {(
             [
               { key: 'all', label: t('productivity.priority.all', { count: taskPriorityCounts.all }) },
@@ -405,3 +398,5 @@ const styles = StyleSheet.create({
     paddingTop: S.sm,
   },
 });
+
+export default ProductivityScreen;

--- a/frontend/global.d.ts
+++ b/frontend/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -62,7 +62,7 @@
         "prettier": "^3.8.1",
         "react-test-renderer": "19.2.4",
         "ts-jest": "^29.4.9",
-        "typescript": "~5.9.2"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -16748,9 +16748,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -91,7 +91,7 @@
     "prettier": "^3.8.1",
     "react-test-renderer": "19.2.4",
     "ts-jest": "^29.4.9",
-    "typescript": "~5.9.2"
+    "typescript": "^6.0.3"
   },
   "private": true,
   "overrides": {

--- a/frontend/src/components/productivity/EventCard.tsx
+++ b/frontend/src/components/productivity/EventCard.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import { AppText } from '../AppText';
+import { CalendarEvent } from '@/core/models';
+import { theme } from '@/core/theme';
+import { DESIGN_TOKENS } from '@/core/design/tokens';
+
+const T = {
+  surface: { light: DESIGN_TOKENS.colors.surface },
+  border: { light: DESIGN_TOKENS.colors.border },
+  onSurface: {
+    light: DESIGN_TOKENS.colors.text,
+    mutedLight: DESIGN_TOKENS.colors.muted,
+  },
+  primary: {
+    DEFAULT: DESIGN_TOKENS.colors.primary,
+    surfaceLight: DESIGN_TOKENS.colors.primarySoft,
+  },
+};
+const S = theme.spacing;
+const R = theme.borderRadius;
+
+interface EventCardProps {
+  event: CalendarEvent;
+}
+
+/**
+ * A component to display a calendar event in the productivity lists.
+ */
+export function EventCard({ event }: EventCardProps) {
+  const { i18n } = useTranslation();
+
+  return (
+    <View style={styles.eventCard}>
+      <View style={styles.eventIcon}>
+        <Ionicons name="calendar-outline" size={16} color={T.primary.DEFAULT} />
+      </View>
+      <View style={styles.eventBody}>
+        <AppText style={styles.eventTitle}>{event.title}</AppText>
+        <AppText style={styles.eventMeta}>
+          {new Intl.DateTimeFormat(i18n.language, {
+            weekday: 'short',
+            month: 'short',
+            day: 'numeric',
+            hour: event.is_all_day ? undefined : '2-digit',
+            minute: event.is_all_day ? undefined : '2-digit',
+          }).format(new Date(event.start_time))}
+        </AppText>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  eventCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: T.surface.light,
+    borderWidth: 1,
+    borderColor: T.border.light,
+    borderRadius: R.xl,
+    padding: S.lg,
+    marginBottom: S.md,
+    ...theme.elevation.sm,
+  },
+  eventIcon: {
+    width: 32,
+    height: 32,
+    borderRadius: R.lg,
+    backgroundColor: T.primary.surfaceLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: S.md,
+  },
+  eventBody: {
+    flex: 1,
+  },
+  eventTitle: {
+    color: T.onSurface.light,
+    fontWeight: '700',
+    fontSize: 15,
+  },
+  eventMeta: {
+    color: T.onSurface.mutedLight,
+    marginTop: 2,
+    fontSize: 13,
+  },
+});

--- a/frontend/src/components/productivity/EventCard.tsx
+++ b/frontend/src/components/productivity/EventCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
-import { AppText } from '../AppText';
+import { AppText } from '@/components/AppText';
 import { CalendarEvent } from '@/core/models';
 import { theme } from '@/core/theme';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
@@ -29,17 +29,17 @@ interface EventCardProps {
 /**
  * A component to display a calendar event in the productivity lists.
  */
-export function EventCard({ event }: EventCardProps) {
+export const EventCard = ({ event }: EventCardProps) => {
   const { i18n } = useTranslation();
 
   return (
-    <View style={styles.eventCard}>
-      <View style={styles.eventIcon}>
+    <View className="flex-row items-center bg-white border border-gray-200 rounded-2xl p-4 mb-3 shadow-sm">
+      <View className="w-8 h-8 rounded-2xl bg-blue-50 items-center justify-center mr-3">
         <Ionicons name="calendar-outline" size={16} color={T.primary.DEFAULT} />
       </View>
-      <View style={styles.eventBody}>
-        <AppText style={styles.eventTitle}>{event.title}</AppText>
-        <AppText style={styles.eventMeta}>
+      <View className="flex-1">
+        <AppText className="text-gray-900 font-bold text-[15px]">{event.title}</AppText>
+        <AppText className="text-gray-500 mt-0.5 text-[13px]">
           {new Intl.DateTimeFormat(i18n.language, {
             weekday: 'short',
             month: 'short',
@@ -52,39 +52,3 @@ export function EventCard({ event }: EventCardProps) {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  eventCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.surface.light,
-    borderWidth: 1,
-    borderColor: T.border.light,
-    borderRadius: R.xl,
-    padding: S.lg,
-    marginBottom: S.md,
-    ...theme.elevation.sm,
-  },
-  eventIcon: {
-    width: 32,
-    height: 32,
-    borderRadius: R.lg,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginRight: S.md,
-  },
-  eventBody: {
-    flex: 1,
-  },
-  eventTitle: {
-    color: T.onSurface.light,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-  eventMeta: {
-    color: T.onSurface.mutedLight,
-    marginTop: 2,
-    fontSize: 13,
-  },
-});

--- a/frontend/src/components/productivity/ProductivityEmptyState.tsx
+++ b/frontend/src/components/productivity/ProductivityEmptyState.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Platform, Pressable, StyleSheet, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
-import { AppText } from '../AppText';
+import { AppText } from '@/components/AppText';
 import { theme } from '@/core/theme';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
 import { Tab } from '@/hooks/useProductivityViewModel';
@@ -32,17 +32,17 @@ interface ProductivityEmptyStateProps {
  * Empty state component for the Productivity Screen.
  * Adapts its message and actions based on the active tab and search query.
  */
-export function ProductivityEmptyState({
+export const ProductivityEmptyState: React.FC<ProductivityEmptyStateProps> = ({
   activeTab,
   searchQuery,
   setShowCreateNote,
   setShowCreateTask,
-}: ProductivityEmptyStateProps) {
+}) => {
   const { t } = useTranslation();
 
   return (
-    <View style={styles.emptyContainer}>
-      <View style={styles.emptyIconCircle}>
+    <View className="items-center py-12">
+      <View className="w-20 h-20 rounded-full bg-blue-50 items-center justify-center mb-4">
         <Ionicons
           name={
             activeTab === 'notes'
@@ -57,47 +57,43 @@ export function ProductivityEmptyState({
           color={T.primary.DEFAULT}
         />
       </View>
-      <AppText variant="h3" style={styles.emptyTitle}>
+      <AppText variant="h3" className="mb-2 text-center text-gray-900">
         {searchQuery
-          ? t('productivity.no_matches') || 'No matches found'
+          ? t('productivity.no_matches') ?? 'No matches found'
           : activeTab === 'notes'
-            ? t('productivity.no_notes') || 'No Notes'
+            ? t('productivity.no_notes') ?? 'No Notes'
             : activeTab === 'tasks'
-              ? t('productivity.no_tasks') || 'No Tasks'
+              ? t('productivity.no_tasks') ?? 'No Tasks'
               : activeTab === 'today'
-                ? t('productivity.nothing_urgent_today') || 'Nothing urgent today'
-                : t('productivity.workspace_clear') || 'Your workspace is clear'}
+                ? t('productivity.nothing_urgent_today') ?? 'Nothing urgent today'
+                : t('productivity.workspace_clear') ?? 'Your workspace is clear'}
       </AppText>
-      <AppText style={styles.emptySubtitle}>
+      <AppText className="text-center mb-5 text-gray-500 px-8 leading-6">
         {searchQuery
-          ? t('productivity.try_adjust_search') || 'Try adjusting your search terms.'
+          ? t('productivity.try_adjust_search') ?? 'Try adjusting your search terms.'
           : activeTab === 'today'
-            ? t('productivity.today_empty_detail') || 'Enjoy the rest of your day, or get ahead on upcoming tasks.'
+            ? t('productivity.today_empty_detail') ?? 'Enjoy the rest of your day, or get ahead on upcoming tasks.'
             : t('productivity.capture_thoughts') ||
               'Capture your thoughts and track what needs to get done.'}
       </AppText>
 
       {!searchQuery && (
-        <View style={styles.emptyActions}>
+        <View className="flex-row gap-3">
           {(activeTab === 'all' || activeTab === 'notes') && (
             <Pressable
               onPress={() => setShowCreateNote(true)}
-              style={({ pressed }) => [styles.emptyButton, pressed && { opacity: 0.8 }]}
+              className={({ pressed }) => `flex-row items-center bg-blue-600 rounded-2xl py-3 px-5 shadow-md ${pressed ? 'opacity-80' : ''}`}
             >
               <Ionicons name="add" size={18} color={T.white} style={{ marginEnd: 6 }} />
-              <AppText style={styles.emptyButtonText}>
-                {t('productivity.newNote') || 'New Note'}
+              <AppText className="text-white font-bold text-[15px]">
+                {t('productivity.newNote') ?? 'New Note'}
               </AppText>
             </Pressable>
           )}
           {(activeTab === 'all' || activeTab === 'tasks' || activeTab === 'today') && (
             <Pressable
               onPress={() => setShowCreateTask(true)}
-              style={({ pressed }) => [
-                styles.emptyButton,
-                (activeTab === 'all' || activeTab === 'today') && styles.emptyButtonSecondary,
-                pressed && { opacity: 0.8 },
-              ]}
+              className={({ pressed }) => `flex-row items-center rounded-2xl py-3 px-5 ${(activeTab === 'all' || activeTab === 'today') ? 'bg-blue-50 shadow-none' : 'bg-blue-600 shadow-md'} ${pressed ? 'opacity-80' : ''}`}
             >
               <Ionicons
                 name="add"
@@ -108,13 +104,9 @@ export function ProductivityEmptyState({
                 style={{ marginEnd: 6 }}
               />
               <AppText
-                style={
-                  activeTab === 'all' || activeTab === 'today'
-                    ? styles.emptyButtonTextSecondary
-                    : styles.emptyButtonText
-                }
+                className={(activeTab === 'all' || activeTab === 'today') ? "text-blue-600 font-bold text-[15px]" : "text-white font-bold text-[15px]"}
               >
-                {t('productivity.new_task') || 'New Task'}
+                {t('productivity.new_task') ?? 'New Task'}
               </AppText>
             </Pressable>
           )}
@@ -123,69 +115,3 @@ export function ProductivityEmptyState({
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  emptyContainer: {
-    alignItems: 'center',
-    paddingVertical: S.massive,
-  },
-  emptyIconCircle: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: S.lg,
-  },
-  emptyTitle: {
-    marginBottom: S.sm,
-    textAlign: 'center',
-    color: T.onSurface.light,
-  },
-  emptySubtitle: {
-    textAlign: 'center',
-    marginBottom: S.xl,
-    color: T.onSurface.mutedLight,
-    paddingHorizontal: S.xxxl,
-    lineHeight: 22,
-  },
-  emptyActions: {
-    flexDirection: 'row',
-    gap: S.md,
-  },
-  emptyButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.primary.DEFAULT,
-    borderRadius: R.xl,
-    paddingVertical: S.md,
-    paddingHorizontal: S.xl,
-    ...theme.elevation.md,
-  },
-  emptyButtonSecondary: {
-    backgroundColor: T.primary.surfaceLight,
-    ...Platform.select({
-      ios: {
-        shadowOpacity: 0,
-        elevation: 0,
-      },
-      android: {
-        elevation: 0,
-      },
-      default: {
-        elevation: 0,
-      },
-    }),
-  },
-  emptyButtonText: {
-    color: T.white,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-  emptyButtonTextSecondary: {
-    color: T.primary.DEFAULT,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-});

--- a/frontend/src/components/productivity/ProductivityEmptyState.tsx
+++ b/frontend/src/components/productivity/ProductivityEmptyState.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import { Platform, Pressable, StyleSheet, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import { AppText } from '../AppText';
+import { theme } from '@/core/theme';
+import { DESIGN_TOKENS } from '@/core/design/tokens';
+import { Tab } from '@/hooks/useProductivityViewModel';
+
+const T = {
+  white: '#FFFFFF',
+  onSurface: {
+    light: DESIGN_TOKENS.colors.text,
+    mutedLight: DESIGN_TOKENS.colors.muted,
+  },
+  primary: {
+    DEFAULT: DESIGN_TOKENS.colors.primary,
+    surfaceLight: DESIGN_TOKENS.colors.primarySoft,
+  },
+};
+const S = theme.spacing;
+const R = theme.borderRadius;
+
+interface ProductivityEmptyStateProps {
+  activeTab: Tab;
+  searchQuery: string;
+  setShowCreateNote: (show: boolean) => void;
+  setShowCreateTask: (show: boolean) => void;
+}
+
+/**
+ * Empty state component for the Productivity Screen.
+ * Adapts its message and actions based on the active tab and search query.
+ */
+export function ProductivityEmptyState({
+  activeTab,
+  searchQuery,
+  setShowCreateNote,
+  setShowCreateTask,
+}: ProductivityEmptyStateProps) {
+  const { t } = useTranslation();
+
+  return (
+    <View style={styles.emptyContainer}>
+      <View style={styles.emptyIconCircle}>
+        <Ionicons
+          name={
+            activeTab === 'notes'
+              ? 'document-text'
+              : activeTab === 'tasks'
+                ? 'checkbox'
+                : activeTab === 'today'
+                  ? 'sunny-outline'
+                  : 'planet'
+          }
+          size={42}
+          color={T.primary.DEFAULT}
+        />
+      </View>
+      <AppText variant="h3" style={styles.emptyTitle}>
+        {searchQuery
+          ? t('productivity.no_matches') || 'No matches found'
+          : activeTab === 'notes'
+            ? t('productivity.no_notes') || 'No Notes'
+            : activeTab === 'tasks'
+              ? t('productivity.no_tasks') || 'No Tasks'
+              : activeTab === 'today'
+                ? t('productivity.nothing_urgent_today') || 'Nothing urgent today'
+                : t('productivity.workspace_clear') || 'Your workspace is clear'}
+      </AppText>
+      <AppText style={styles.emptySubtitle}>
+        {searchQuery
+          ? t('productivity.try_adjust_search') || 'Try adjusting your search terms.'
+          : activeTab === 'today'
+            ? t('productivity.today_empty_detail') || 'Enjoy the rest of your day, or get ahead on upcoming tasks.'
+            : t('productivity.capture_thoughts') ||
+              'Capture your thoughts and track what needs to get done.'}
+      </AppText>
+
+      {!searchQuery && (
+        <View style={styles.emptyActions}>
+          {(activeTab === 'all' || activeTab === 'notes') && (
+            <Pressable
+              onPress={() => setShowCreateNote(true)}
+              style={({ pressed }) => [styles.emptyButton, pressed && { opacity: 0.8 }]}
+            >
+              <Ionicons name="add" size={18} color={T.white} style={{ marginEnd: 6 }} />
+              <AppText style={styles.emptyButtonText}>
+                {t('productivity.newNote') || 'New Note'}
+              </AppText>
+            </Pressable>
+          )}
+          {(activeTab === 'all' || activeTab === 'tasks' || activeTab === 'today') && (
+            <Pressable
+              onPress={() => setShowCreateTask(true)}
+              style={({ pressed }) => [
+                styles.emptyButton,
+                (activeTab === 'all' || activeTab === 'today') && styles.emptyButtonSecondary,
+                pressed && { opacity: 0.8 },
+              ]}
+            >
+              <Ionicons
+                name="add"
+                size={18}
+                color={
+                  activeTab === 'all' || activeTab === 'today' ? T.primary.DEFAULT : T.white
+                }
+                style={{ marginEnd: 6 }}
+              />
+              <AppText
+                style={
+                  activeTab === 'all' || activeTab === 'today'
+                    ? styles.emptyButtonTextSecondary
+                    : styles.emptyButtonText
+                }
+              >
+                {t('productivity.new_task') || 'New Task'}
+              </AppText>
+            </Pressable>
+          )}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  emptyContainer: {
+    alignItems: 'center',
+    paddingVertical: S.massive,
+  },
+  emptyIconCircle: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: T.primary.surfaceLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: S.lg,
+  },
+  emptyTitle: {
+    marginBottom: S.sm,
+    textAlign: 'center',
+    color: T.onSurface.light,
+  },
+  emptySubtitle: {
+    textAlign: 'center',
+    marginBottom: S.xl,
+    color: T.onSurface.mutedLight,
+    paddingHorizontal: S.xxxl,
+    lineHeight: 22,
+  },
+  emptyActions: {
+    flexDirection: 'row',
+    gap: S.md,
+  },
+  emptyButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: T.primary.DEFAULT,
+    borderRadius: R.xl,
+    paddingVertical: S.md,
+    paddingHorizontal: S.xl,
+    ...theme.elevation.md,
+  },
+  emptyButtonSecondary: {
+    backgroundColor: T.primary.surfaceLight,
+    ...Platform.select({
+      ios: {
+        shadowOpacity: 0,
+        elevation: 0,
+      },
+      android: {
+        elevation: 0,
+      },
+      default: {
+        elevation: 0,
+      },
+    }),
+  },
+  emptyButtonText: {
+    color: T.white,
+    fontWeight: '700',
+    fontSize: 15,
+  },
+  emptyButtonTextSecondary: {
+    color: T.primary.DEFAULT,
+    fontWeight: '700',
+    fontSize: 15,
+  },
+});

--- a/frontend/src/components/productivity/ProductivityEmptyState.tsx
+++ b/frontend/src/components/productivity/ProductivityEmptyState.tsx
@@ -73,8 +73,7 @@ export const ProductivityEmptyState: React.FC<ProductivityEmptyStateProps> = ({
           ? t('productivity.try_adjust_search') ?? 'Try adjusting your search terms.'
           : activeTab === 'today'
             ? t('productivity.today_empty_detail') ?? 'Enjoy the rest of your day, or get ahead on upcoming tasks.'
-            : t('productivity.capture_thoughts') ||
-              'Capture your thoughts and track what needs to get done.'}
+            : t('productivity.capture_thoughts') ?? 'Capture your thoughts and track what needs to get done.'}
       </AppText>
 
       {!searchQuery && (
@@ -82,7 +81,7 @@ export const ProductivityEmptyState: React.FC<ProductivityEmptyStateProps> = ({
           {(activeTab === 'all' || activeTab === 'notes') && (
             <Pressable
               onPress={() => setShowCreateNote(true)}
-              className={({ pressed }) => `flex-row items-center bg-blue-600 rounded-2xl py-3 px-5 shadow-md ${pressed ? 'opacity-80' : ''}`}
+              className="flex-row items-center bg-blue-600 rounded-2xl py-3 px-5 shadow-md active:opacity-80"
             >
               <Ionicons name="add" size={18} color={T.white} style={{ marginEnd: 6 }} />
               <AppText className="text-white font-bold text-[15px]">
@@ -93,7 +92,7 @@ export const ProductivityEmptyState: React.FC<ProductivityEmptyStateProps> = ({
           {(activeTab === 'all' || activeTab === 'tasks' || activeTab === 'today') && (
             <Pressable
               onPress={() => setShowCreateTask(true)}
-              className={({ pressed }) => `flex-row items-center rounded-2xl py-3 px-5 ${(activeTab === 'all' || activeTab === 'today') ? 'bg-blue-50 shadow-none' : 'bg-blue-600 shadow-md'} ${pressed ? 'opacity-80' : ''}`}
+              className={`flex-row items-center rounded-2xl py-3 px-5 ${(activeTab === 'all' || activeTab === 'today') ? 'bg-blue-50 shadow-none' : 'bg-blue-600 shadow-md'} active:opacity-80`}
             >
               <Ionicons
                 name="add"

--- a/frontend/src/hooks/useProductivityViewModel.ts
+++ b/frontend/src/hooks/useProductivityViewModel.ts
@@ -3,6 +3,7 @@ import { Alert } from 'react-native';
 import { useLocalSearchParams, usePathname, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useProductivityStore } from '@/store/useProductivityStore';
+import { useDebounce } from '@/hooks/useDebounce';
 import { CalendarEvent, Note, Task } from '@/core/models';
 
 export type Tab = 'today' | 'all' | 'notes' | 'tasks';
@@ -29,7 +30,8 @@ export function useProductivityViewModel() {
 
   const [activeTab, setActiveTab] = useState<Tab>('today');
   const [taskPriority, setTaskPriority] = useState<TaskPriority>('all');
-  const [searchQuery, setSearchQuery] = useState('');
+  const [inputQuery, setInputQuery] = useState('');
+  const debouncedQuery = useDebounce(inputQuery, 300);
   const [showCreateNote, setShowCreateNote] = useState(false);
   const [showCreateTask, setShowCreateTask] = useState(false);
   const [todayPlan, setTodayPlan] = useState<string | null>(null);
@@ -97,7 +99,13 @@ export function useProductivityViewModel() {
           {
             text: t('settings.actions.delete') || 'Delete',
             style: 'destructive',
-            onPress: () => action(),
+            onPress: async () => {
+              try {
+                await action();
+              } catch (error) {
+                Alert.alert('Error', 'Failed to delete item.');
+              }
+            },
           },
         ]
       ),
@@ -105,33 +113,33 @@ export function useProductivityViewModel() {
   );
 
   const filteredNotes = useMemo(() => {
-    if (!searchQuery) return notes;
-    const lowerQ = searchQuery.toLowerCase();
+    if (!debouncedQuery) return notes;
+    const lowerQ = debouncedQuery.toLowerCase();
     return notes.filter(
       (n) => n.title.toLowerCase().includes(lowerQ) || n.content.toLowerCase().includes(lowerQ)
     );
-  }, [notes, searchQuery]);
+  }, [notes, debouncedQuery]);
 
   const filteredTasks = useMemo(() => {
-    if (!searchQuery) return tasks;
-    const lowerQ = searchQuery.toLowerCase();
+    if (!debouncedQuery) return tasks;
+    const lowerQ = debouncedQuery.toLowerCase();
     return tasks.filter(
       (task) =>
         task.title.toLowerCase().includes(lowerQ) ||
         (task.description?.toLowerCase().includes(lowerQ) ?? false)
     );
-  }, [searchQuery, tasks]);
+  }, [debouncedQuery, tasks]);
 
   const filteredEvents = useMemo(() => {
-    if (!searchQuery) return events;
-    const lowerQ = searchQuery.toLowerCase();
+    if (!debouncedQuery) return events;
+    const lowerQ = debouncedQuery.toLowerCase();
     return events.filter(
       (event) =>
         event.title.toLowerCase().includes(lowerQ) ||
         (event.description?.toLowerCase().includes(lowerQ) ?? false) ||
         (event.location?.toLowerCase().includes(lowerQ) ?? false)
     );
-  }, [events, searchQuery]);
+  }, [events, debouncedQuery]);
 
   const pendingTasksCount = useMemo(
     () => filteredTasks.filter((task) => !task.completed).length,
@@ -141,7 +149,11 @@ export function useProductivityViewModel() {
   const getTaskPriority = useCallback((task: Task): Exclude<TaskPriority, 'all'> => {
     if (!task.due_date) return 'no_due';
     const now = new Date();
-    const due = new Date(task.due_date);
+    let due = new Date(task.due_date);
+    if (task.due_date.includes('-') && task.due_date.length === 10) {
+      const [year, month, day] = task.due_date.split('-').map(Number);
+      due = new Date(year, month - 1, day);
+    }
     if (isNaN(due.getTime())) return 'no_due';
     const dayStart = new Date(now);
     dayStart.setHours(0, 0, 0, 0);
@@ -176,8 +188,18 @@ export function useProductivityViewModel() {
         ? tasksToRank
         : tasksToRank.filter((task) => getTaskPriority(task) === taskPriority);
     return [...pool].sort((a, b) => {
-      const aDue = a.due_date ? new Date(a.due_date).getTime() : Number.MAX_SAFE_INTEGER;
-      const bDue = b.due_date ? new Date(b.due_date).getTime() : Number.MAX_SAFE_INTEGER;
+      let aDueObj = a.due_date ? new Date(a.due_date) : null;
+      if (a.due_date && a.due_date.length === 10) {
+        const [year, month, day] = a.due_date.split('-').map(Number);
+        aDueObj = new Date(year, month - 1, day);
+      }
+      let bDueObj = b.due_date ? new Date(b.due_date) : null;
+      if (b.due_date && b.due_date.length === 10) {
+        const [year, month, day] = b.due_date.split('-').map(Number);
+        bDueObj = new Date(year, month - 1, day);
+      }
+      const aDue = aDueObj ? aDueObj.getTime() : Number.MAX_SAFE_INTEGER;
+      const bDue = bDueObj ? bDueObj.getTime() : Number.MAX_SAFE_INTEGER;
       return aDue - bDue;
     });
   }, [filteredTasks, getTaskPriority, taskPriority]);
@@ -324,8 +346,8 @@ export function useProductivityViewModel() {
     setActiveTab,
     taskPriority,
     setTaskPriority,
-    searchQuery,
-    setSearchQuery,
+    searchQuery: inputQuery,
+    setSearchQuery: setInputQuery,
     showCreateNote,
     setShowCreateNote,
     showCreateTask,

--- a/frontend/src/hooks/useProductivityViewModel.ts
+++ b/frontend/src/hooks/useProductivityViewModel.ts
@@ -1,0 +1,348 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Alert } from 'react-native';
+import { useLocalSearchParams, usePathname, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useProductivityStore } from '@/store/useProductivityStore';
+import { CalendarEvent, Note, Task } from '@/core/models';
+
+export type Tab = 'today' | 'all' | 'notes' | 'tasks';
+export type TaskPriority = 'all' | 'overdue' | 'today' | 'upcoming' | 'no_due';
+
+export type RenderItemData = {
+  date?: number;
+  type: 'note' | 'task' | 'event';
+  item: Note | Task | CalendarEvent;
+  id: string;
+};
+
+/**
+ * ViewModel for the Productivity Screen.
+ * Manages state, filtering, memoization, and data preparation logic.
+ */
+export function useProductivityViewModel() {
+  const { t, i18n } = useTranslation();
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useLocalSearchParams() as Record<string, string | string[] | undefined>;
+  const openCreateTask = params.openCreateTask;
+  const openCreateNote = params.openCreateNote;
+
+  const [activeTab, setActiveTab] = useState<Tab>('today');
+  const [taskPriority, setTaskPriority] = useState<TaskPriority>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showCreateNote, setShowCreateNote] = useState(false);
+  const [showCreateTask, setShowCreateTask] = useState(false);
+  const [todayPlan, setTodayPlan] = useState<string | null>(null);
+
+  const {
+    notes,
+    tasks,
+    events,
+    fetchNotes,
+    fetchTasks,
+    fetchEvents,
+    isLoading,
+    deleteNote,
+    deleteTask,
+    toggleTask,
+  } = useProductivityStore();
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchNotes(controller.signal);
+    fetchTasks(controller.signal);
+    fetchEvents(controller.signal);
+    return () => {
+      controller.abort();
+    };
+  }, [fetchEvents, fetchNotes, fetchTasks]);
+
+  useEffect(() => {
+    if (openCreateTask === '1' || openCreateTask === 'true') {
+      setShowCreateTask(true);
+      const nextParams = Object.fromEntries(
+        Object.entries(params).filter(
+          ([key, value]) => key !== 'openCreateTask' && typeof value === 'string'
+        )
+      );
+      router.replace({ pathname, params: nextParams });
+    }
+  }, [openCreateTask, params, pathname, router]);
+
+  useEffect(() => {
+    if (openCreateNote === '1' || openCreateNote === 'true') {
+      setShowCreateNote(true);
+      const nextParams = Object.fromEntries(
+        Object.entries(params).filter(
+          ([key, value]) => key !== 'openCreateNote' && typeof value === 'string'
+        )
+      );
+      router.replace({ pathname, params: nextParams });
+    }
+  }, [openCreateNote, params, pathname, router]);
+
+  const handleRefresh = useCallback(() => {
+    fetchNotes();
+    fetchTasks();
+    fetchEvents();
+  }, [fetchEvents, fetchNotes, fetchTasks]);
+
+  const confirmDelete = useCallback(
+    (action: () => Promise<void>) =>
+      Alert.alert(
+        t('productivity.delete') || 'Delete',
+        t('productivity.are_you_sure') || 'Are you sure?',
+        [
+          { text: t('settings.actions.cancel') || 'Cancel', style: 'cancel' },
+          {
+            text: t('settings.actions.delete') || 'Delete',
+            style: 'destructive',
+            onPress: () => action(),
+          },
+        ]
+      ),
+    [t]
+  );
+
+  const filteredNotes = useMemo(() => {
+    if (!searchQuery) return notes;
+    const lowerQ = searchQuery.toLowerCase();
+    return notes.filter(
+      (n) => n.title.toLowerCase().includes(lowerQ) || n.content.toLowerCase().includes(lowerQ)
+    );
+  }, [notes, searchQuery]);
+
+  const filteredTasks = useMemo(() => {
+    if (!searchQuery) return tasks;
+    const lowerQ = searchQuery.toLowerCase();
+    return tasks.filter(
+      (task) =>
+        task.title.toLowerCase().includes(lowerQ) ||
+        (task.description?.toLowerCase().includes(lowerQ) ?? false)
+    );
+  }, [searchQuery, tasks]);
+
+  const filteredEvents = useMemo(() => {
+    if (!searchQuery) return events;
+    const lowerQ = searchQuery.toLowerCase();
+    return events.filter(
+      (event) =>
+        event.title.toLowerCase().includes(lowerQ) ||
+        (event.description?.toLowerCase().includes(lowerQ) ?? false) ||
+        (event.location?.toLowerCase().includes(lowerQ) ?? false)
+    );
+  }, [events, searchQuery]);
+
+  const pendingTasksCount = useMemo(
+    () => filteredTasks.filter((task) => !task.completed).length,
+    [filteredTasks]
+  );
+
+  const getTaskPriority = useCallback((task: Task): Exclude<TaskPriority, 'all'> => {
+    if (!task.due_date) return 'no_due';
+    const now = new Date();
+    const due = new Date(task.due_date);
+    if (isNaN(due.getTime())) return 'no_due';
+    const dayStart = new Date(now);
+    dayStart.setHours(0, 0, 0, 0);
+    const tomorrow = new Date(dayStart);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    if (due < dayStart) return 'overdue';
+    if (due >= dayStart && due < tomorrow) return 'today';
+    return 'upcoming';
+  }, []);
+
+  const taskPriorityCounts = useMemo(() => {
+    const counts: Record<TaskPriority, number> = {
+      all: 0,
+      overdue: 0,
+      today: 0,
+      upcoming: 0,
+      no_due: 0,
+    };
+    filteredTasks
+      .filter((task) => !task.completed)
+      .forEach((task) => {
+        counts.all += 1;
+        counts[getTaskPriority(task)] += 1;
+      });
+    return counts;
+  }, [filteredTasks, getTaskPriority]);
+
+  const prioritizedTasks = useMemo(() => {
+    const tasksToRank = filteredTasks.filter((task) => !task.completed);
+    const pool =
+      taskPriority === 'all'
+        ? tasksToRank
+        : tasksToRank.filter((task) => getTaskPriority(task) === taskPriority);
+    return [...pool].sort((a, b) => {
+      const aDue = a.due_date ? new Date(a.due_date).getTime() : Number.MAX_SAFE_INTEGER;
+      const bDue = b.due_date ? new Date(b.due_date).getTime() : Number.MAX_SAFE_INTEGER;
+      return aDue - bDue;
+    });
+  }, [filteredTasks, getTaskPriority, taskPriority]);
+
+  const mixedData = useMemo(() => {
+    const data: RenderItemData[] = [];
+    filteredNotes.forEach((note) => {
+      data.push({
+        type: 'note',
+        item: note,
+        id: `note-${note.id}`,
+        date: new Date(note.created_at).getTime(),
+      });
+    });
+    filteredTasks.forEach((task) => {
+      data.push({
+        type: 'task',
+        item: task,
+        id: `task-${task.id}`,
+        date: new Date(task.created_at).getTime(),
+      });
+    });
+    return data.sort((a, b) => (b.date || 0) - (a.date || 0));
+  }, [filteredNotes, filteredTasks]);
+
+  const todayData = useMemo(() => {
+    const now = new Date();
+    const start = new Date(now);
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(start);
+    end.setDate(end.getDate() + 1);
+    const weekEnd = new Date(start);
+    weekEnd.setDate(weekEnd.getDate() + 7);
+
+    const overdueTasks = filteredTasks.filter((task) => {
+      if (task.completed || !task.due_date) return false;
+      return new Date(task.due_date) < start;
+    });
+
+    const dueTodayTasks = filteredTasks.filter((task) => {
+      if (task.completed || !task.due_date) return false;
+      const dueDate = new Date(task.due_date);
+      return dueDate >= start && dueDate < end;
+    });
+
+    const upcomingEvents = filteredEvents.filter((event) => {
+      const startTime = new Date(event.start_time);
+      return startTime >= start && startTime < weekEnd;
+    });
+
+    const items: RenderItemData[] = [
+      ...overdueTasks.map((task) => ({
+        type: 'task' as const,
+        item: task,
+        id: `overdue-${task.id}`,
+        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
+      })),
+      ...dueTodayTasks.map((task) => ({
+        type: 'task' as const,
+        item: task,
+        id: `today-${task.id}`,
+        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
+      })),
+      ...upcomingEvents.map((event) => ({
+        type: 'event' as const,
+        item: event,
+        id: `event-${event.id}`,
+        date: new Date(event.start_time).getTime(),
+      })),
+    ];
+
+    return items.sort((a, b) => (a.date || 0) - (b.date || 0));
+  }, [filteredEvents, filteredTasks]);
+
+  const dataToRender: RenderItemData[] = useMemo(() => {
+    if (activeTab === 'today') {
+      return todayData.filter((entry) => {
+        if (entry.type !== 'task') return true;
+        if (taskPriority === 'all') return true;
+        return getTaskPriority(entry.item as Task) === taskPriority;
+      });
+    }
+    if (activeTab === 'all') return mixedData;
+    if (activeTab === 'notes') {
+      return filteredNotes.map((note) => ({ type: 'note' as const, item: note, id: note.id }));
+    }
+    return prioritizedTasks.map((task) => ({ type: 'task' as const, item: task, id: task.id }));
+  }, [
+    activeTab,
+    filteredNotes,
+    getTaskPriority,
+    mixedData,
+    prioritizedTasks,
+    taskPriority,
+    todayData,
+  ]);
+
+  const generateTodayPlan = useCallback(() => {
+    const now = new Date();
+    const nextTasks = prioritizedTasks.slice(0, 3);
+    const nextEvents = [...filteredEvents]
+      .filter((event) => new Date(event.end_time) >= now)
+      .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime())
+      .slice(0, 3);
+
+    const lines: string[] = [];
+    if (taskPriorityCounts.overdue > 0) {
+      lines.push(`1) Recover overdue: start with ${taskPriorityCounts.overdue} overdue task(s).`);
+    } else {
+      lines.push('1) No overdue tasks: start with highest-impact open work.');
+    }
+
+    if (nextTasks.length > 0) {
+      lines.push(`2) Focus block: ${nextTasks.map((task) => task.title).join(', ')}.`);
+    } else {
+      lines.push('2) Focus block: no pending tasks, use this for planning or review.');
+    }
+
+    if (nextEvents.length > 0) {
+      const eventLine = nextEvents
+        .map((event) =>
+          new Intl.DateTimeFormat(i18n.language, {
+            hour: '2-digit',
+            minute: '2-digit',
+          }).format(new Date(event.start_time))
+        )
+        .join(', ');
+      lines.push(`3) Calendar checkpoints at ${eventLine}.`);
+    } else {
+      lines.push('3) Calendar is light: reserve time for deep work and wrap-up.');
+    }
+
+    setTodayPlan(lines.join('\n'));
+    setActiveTab('today');
+  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue]);
+
+  const onCreatedTask = useCallback(() => fetchTasks(), [fetchTasks]);
+  const onCreatedNote = useCallback(() => fetchNotes(), [fetchNotes]);
+
+  return {
+    t,
+    i18n,
+    activeTab,
+    setActiveTab,
+    taskPriority,
+    setTaskPriority,
+    searchQuery,
+    setSearchQuery,
+    showCreateNote,
+    setShowCreateNote,
+    showCreateTask,
+    setShowCreateTask,
+    todayPlan,
+    setTodayPlan,
+    isLoading,
+    handleRefresh,
+    confirmDelete,
+    deleteNote,
+    deleteTask,
+    toggleTask,
+    pendingTasksCount,
+    taskPriorityCounts,
+    dataToRender,
+    generateTodayPlan,
+    onCreatedTask,
+    onCreatedNote,
+  };
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -3,9 +3,11 @@
   "compilerOptions": {
     "strict": true,
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["jest"]
   },
   "include": ["**/*.ts", "**/*.tsx", "nativewind-env.d.ts"]
 }

--- a/update_commit.sh
+++ b/update_commit.sh
@@ -1,0 +1,4 @@
+git add frontend/src/components/productivity/ProductivityEmptyState.tsx
+git add frontend/tsconfig.json
+git add frontend/global.d.ts
+git commit --amend --no-edit

--- a/update_pr_comments.py
+++ b/update_pr_comments.py
@@ -1,0 +1,294 @@
+import re
+
+with open("frontend/app/(main)/productivity.tsx", "r") as f:
+    productivity_content = f.read()
+
+# 1. Update export default function -> export const
+productivity_content = productivity_content.replace(
+    "export default function ProductivityScreen() {",
+    "export const ProductivityScreen = () => {"
+)
+productivity_content = productivity_content.replace(
+    "});\n",
+    "});\n\nexport default ProductivityScreen;\n"
+)
+
+# 2. Update relative imports
+productivity_content = productivity_content.replace(
+    "import { AppText } from '../../src/components/AppText';",
+    "import { AppText } from '@/components/AppText';"
+)
+productivity_content = productivity_content.replace(
+    "import { CreateNoteModal } from '../../src/components/productivity/CreateNoteModal';",
+    "import { CreateNoteModal } from '@/components/productivity/CreateNoteModal';"
+)
+productivity_content = productivity_content.replace(
+    "import { CreateTaskModal } from '../../src/components/productivity/CreateTaskModal';",
+    "import { CreateTaskModal } from '@/components/productivity/CreateTaskModal';"
+)
+productivity_content = productivity_content.replace(
+    "import { NoteCard } from '../../src/components/productivity/NoteCard';",
+    "import { NoteCard } from '@/components/productivity/NoteCard';"
+)
+productivity_content = productivity_content.replace(
+    "import { TaskCard } from '../../src/components/productivity/TaskCard';",
+    "import { TaskCard } from '@/components/productivity/TaskCard';"
+)
+productivity_content = productivity_content.replace(
+    "import { EventCard } from '../../src/components/productivity/EventCard';",
+    "import { EventCard } from '@/components/productivity/EventCard';"
+)
+productivity_content = productivity_content.replace(
+    "import { ProductivityEmptyState } from '../../src/components/productivity/ProductivityEmptyState';",
+    "import { ProductivityEmptyState } from '@/components/productivity/ProductivityEmptyState';"
+)
+productivity_content = productivity_content.replace(
+    "import { theme } from '../../src/core/theme';",
+    "import { theme } from '@/core/theme';"
+)
+productivity_content = productivity_content.replace(
+    "} from '../../src/hooks/useProductivityViewModel';",
+    "} from '@/hooks/useProductivityViewModel';"
+)
+
+# 3. Update style to className on productivity.tsx view
+productivity_content = productivity_content.replace(
+    """        <View
+          style={{
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            marginHorizontal: S.xl,
+            marginBottom: S.sm,
+          }}
+        >""",
+    """        <View className="flex-row flex-wrap mx-5 mb-2">"""
+)
+
+with open("frontend/app/(main)/productivity.tsx", "w") as f:
+    f.write(productivity_content)
+
+
+with open("frontend/src/components/productivity/EventCard.tsx", "r") as f:
+    event_card_content = f.read()
+
+# 4. AppText import in EventCard
+event_card_content = event_card_content.replace(
+    "import { AppText } from '../AppText';",
+    "import { AppText } from '@/components/AppText';"
+)
+
+# 5. export function EventCard -> export const EventCard = ...
+event_card_content = event_card_content.replace(
+    "export function EventCard({ event }: EventCardProps) {",
+    "export const EventCard = ({ event }: EventCardProps) => {"
+)
+
+# 6. EventCard styles to tailwind
+event_card_content = event_card_content.replace(
+    """<View style={styles.eventCard}>""",
+    """<View className="flex-row items-center bg-white border border-gray-200 rounded-2xl p-4 mb-3 shadow-sm">"""
+)
+event_card_content = event_card_content.replace(
+    """<View style={styles.eventIcon}>""",
+    """<View className="w-8 h-8 rounded-2xl bg-blue-50 items-center justify-center mr-3">"""
+)
+event_card_content = event_card_content.replace(
+    """<View style={styles.eventBody}>""",
+    """<View className="flex-1">"""
+)
+event_card_content = event_card_content.replace(
+    """<AppText style={styles.eventTitle}>{event.title}</AppText>""",
+    """<AppText className="text-gray-900 font-bold text-[15px]">{event.title}</AppText>"""
+)
+event_card_content = event_card_content.replace(
+    """<AppText style={styles.eventMeta}>""",
+    """<AppText className="text-gray-500 mt-0.5 text-[13px]">"""
+)
+
+# Remove stylesheet from event card
+event_card_content = re.sub(r'const styles = StyleSheet\.create\(\{[\s\S]*\}\);\n', '', event_card_content)
+
+with open("frontend/src/components/productivity/EventCard.tsx", "w") as f:
+    f.write(event_card_content)
+
+
+with open("frontend/src/components/productivity/ProductivityEmptyState.tsx", "r") as f:
+    empty_state_content = f.read()
+
+# 7. AppText import in ProductivityEmptyState
+empty_state_content = empty_state_content.replace(
+    "import { AppText } from '../AppText';",
+    "import { AppText } from '@/components/AppText';"
+)
+
+# 8. Nullish coalescing in ProductivityEmptyState
+empty_state_content = empty_state_content.replace(
+    "|| 'No matches found'",
+    "?? 'No matches found'"
+)
+empty_state_content = empty_state_content.replace(
+    "|| 'No Notes'",
+    "?? 'No Notes'"
+)
+empty_state_content = empty_state_content.replace(
+    "|| 'No Tasks'",
+    "?? 'No Tasks'"
+)
+empty_state_content = empty_state_content.replace(
+    "|| 'Nothing urgent today'",
+    "?? 'Nothing urgent today'"
+)
+empty_state_content = empty_state_content.replace(
+    "|| 'Your workspace is clear'",
+    "?? 'Your workspace is clear'"
+)
+empty_state_content = empty_state_content.replace(
+    "|| 'Try adjusting your search terms.'",
+    "?? 'Try adjusting your search terms.'"
+)
+empty_state_content = empty_state_content.replace(
+    "|| 'Enjoy the rest of your day, or get ahead on upcoming tasks.'",
+    "?? 'Enjoy the rest of your day, or get ahead on upcoming tasks.'"
+)
+empty_state_content = empty_state_content.replace(
+    "|| 'Capture your thoughts and track what needs to get done.'",
+    "?? 'Capture your thoughts and track what needs to get done.'"
+)
+empty_state_content = empty_state_content.replace(
+    "|| 'New Note'",
+    "?? 'New Note'"
+)
+empty_state_content = empty_state_content.replace(
+    "|| 'New Task'",
+    "?? 'New Task'"
+)
+
+# 9. Tailwind conversion in ProductivityEmptyState (partial replacement)
+empty_state_content = empty_state_content.replace(
+    "export function ProductivityEmptyState({",
+    "export const ProductivityEmptyState: React.FC<ProductivityEmptyStateProps> = ({"
+)
+empty_state_content = empty_state_content.replace(
+    "}: ProductivityEmptyStateProps) {",
+    "}) => {"
+)
+empty_state_content = empty_state_content.replace(
+    "style={styles.emptyContainer}",
+    "className=\"items-center py-12\""
+)
+empty_state_content = empty_state_content.replace(
+    "style={styles.emptyIconCircle}",
+    "className=\"w-20 h-20 rounded-full bg-blue-50 items-center justify-center mb-4\""
+)
+empty_state_content = empty_state_content.replace(
+    "style={styles.emptyTitle}",
+    "className=\"mb-2 text-center text-gray-900\""
+)
+empty_state_content = empty_state_content.replace(
+    "style={styles.emptySubtitle}",
+    "className=\"text-center mb-5 text-gray-500 px-8 leading-6\""
+)
+empty_state_content = empty_state_content.replace(
+    "style={styles.emptyActions}",
+    "className=\"flex-row gap-3\""
+)
+empty_state_content = empty_state_content.replace(
+    "style={({ pressed }) => [styles.emptyButton, pressed && { opacity: 0.8 }]}",
+    "className={({ pressed }) => `flex-row items-center bg-blue-600 rounded-2xl py-3 px-5 shadow-md ${pressed ? 'opacity-80' : ''}`}"
+)
+empty_state_content = empty_state_content.replace(
+    "style={({ pressed }) => [\n                styles.emptyButton,\n                (activeTab === 'all' || activeTab === 'today') && styles.emptyButtonSecondary,\n                pressed && { opacity: 0.8 },\n              ]}",
+    "className={({ pressed }) => `flex-row items-center rounded-2xl py-3 px-5 ${(activeTab === 'all' || activeTab === 'today') ? 'bg-blue-50 shadow-none' : 'bg-blue-600 shadow-md'} ${pressed ? 'opacity-80' : ''}`}"
+)
+empty_state_content = empty_state_content.replace(
+    "style={styles.emptyButtonText}",
+    "className=\"text-white font-bold text-[15px]\""
+)
+empty_state_content = empty_state_content.replace(
+    "style={\n                  activeTab === 'all' || activeTab === 'today'\n                    ? styles.emptyButtonTextSecondary\n                    : styles.emptyButtonText\n                }",
+    "className={(activeTab === 'all' || activeTab === 'today') ? \"text-blue-600 font-bold text-[15px]\" : \"text-white font-bold text-[15px]\"}"
+)
+
+# Remove StyleSheet
+empty_state_content = re.sub(r'const styles = StyleSheet\.create\(\{[\s\S]*\}\);\n', '', empty_state_content)
+
+with open("frontend/src/components/productivity/ProductivityEmptyState.tsx", "w") as f:
+    f.write(empty_state_content)
+
+
+with open("frontend/src/hooks/useProductivityViewModel.ts", "r") as f:
+    view_model_content = f.read()
+
+# 10. useDebounce import + hook insertion
+view_model_content = view_model_content.replace(
+    "import { useProductivityStore } from '@/store/useProductivityStore';",
+    "import { useProductivityStore } from '@/store/useProductivityStore';\nimport { useDebounce } from '@/hooks/useDebounce';"
+)
+view_model_content = view_model_content.replace(
+    "const [searchQuery, setSearchQuery] = useState('');",
+    "const [inputQuery, setInputQuery] = useState('');\n  const debouncedQuery = useDebounce(inputQuery, 300);"
+)
+view_model_content = view_model_content.replace(
+    "if (!searchQuery) return notes;\n    const lowerQ = searchQuery.toLowerCase();",
+    "if (!debouncedQuery) return notes;\n    const lowerQ = debouncedQuery.toLowerCase();"
+)
+view_model_content = view_model_content.replace(
+    "if (!searchQuery) return tasks;\n    const lowerQ = searchQuery.toLowerCase();",
+    "if (!debouncedQuery) return tasks;\n    const lowerQ = debouncedQuery.toLowerCase();"
+)
+view_model_content = view_model_content.replace(
+    "if (!searchQuery) return events;\n    const lowerQ = searchQuery.toLowerCase();",
+    "if (!debouncedQuery) return events;\n    const lowerQ = debouncedQuery.toLowerCase();"
+)
+view_model_content = view_model_content.replace(
+    "[notes, searchQuery]",
+    "[notes, debouncedQuery]"
+)
+view_model_content = view_model_content.replace(
+    "[searchQuery, tasks]",
+    "[debouncedQuery, tasks]"
+)
+view_model_content = view_model_content.replace(
+    "[events, searchQuery]",
+    "[events, debouncedQuery]"
+)
+view_model_content = view_model_content.replace(
+    "searchQuery,\n    setSearchQuery",
+    "searchQuery: inputQuery,\n    setSearchQuery: setInputQuery"
+)
+
+# 11. async wrapper for confirmDelete
+view_model_content = view_model_content.replace(
+    "onPress: () => action(),",
+    "onPress: async () => {\n              try {\n                await action();\n              } catch (error) {\n                Alert.alert('Error', 'Failed to delete item.');\n              }\n            },"
+)
+
+# 12. date-only parsing in getTaskPriority
+view_model_content = view_model_content.replace(
+    "const due = new Date(task.due_date);",
+    """let due = new Date(task.due_date);
+    if (task.due_date.includes('-') && task.due_date.length === 10) {
+      const [year, month, day] = task.due_date.split('-').map(Number);
+      due = new Date(year, month - 1, day);
+    }"""
+)
+
+# Replace the ranking sorter to also use date-only parsing
+view_model_content = view_model_content.replace(
+    "const aDue = a.due_date ? new Date(a.due_date).getTime() : Number.MAX_SAFE_INTEGER;\n      const bDue = b.due_date ? new Date(b.due_date).getTime() : Number.MAX_SAFE_INTEGER;",
+    """let aDueObj = a.due_date ? new Date(a.due_date) : null;
+      if (a.due_date && a.due_date.length === 10) {
+        const [year, month, day] = a.due_date.split('-').map(Number);
+        aDueObj = new Date(year, month - 1, day);
+      }
+      let bDueObj = b.due_date ? new Date(b.due_date) : null;
+      if (b.due_date && b.due_date.length === 10) {
+        const [year, month, day] = b.due_date.split('-').map(Number);
+        bDueObj = new Date(year, month - 1, day);
+      }
+      const aDue = aDueObj ? aDueObj.getTime() : Number.MAX_SAFE_INTEGER;
+      const bDue = bDueObj ? bDueObj.getTime() : Number.MAX_SAFE_INTEGER;"""
+)
+
+with open("frontend/src/hooks/useProductivityViewModel.ts", "w") as f:
+    f.write(view_model_content)


### PR DESCRIPTION
Debt Identified: The `frontend/app/(main)/productivity.tsx` file was a "God Class" exceeding 850 lines of code. It violated the Single Responsibility Principle by heavily intertwining UI presentation with complex business logic (search, filtering, data sorting, list generation).

Refactored Code:
- Created `useProductivityViewModel` hook to handle all state and logic.
- Created `EventCard` component for isolating event rendering.
- Created `ProductivityEmptyState` component for isolating empty list UI rendering.
- Simplified `productivity.tsx` significantly by utilizing the extracted hook and sub-components.

Structural Note:
By abstracting complex view logic into a dedicated ViewModel hook, the file is significantly cleaner and easier to reason about. This improves maintainability, enabling easier unit testing of the state management separate from the UI tree, and standardizes how future list-based screens in Miru should handle internal sorting and filtering.

---
*PR created automatically by Jules for task [17791629833059663270](https://jules.google.com/task/17791629833059663270) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured productivity screen architecture to improve code maintainability and application performance.
  * Enhanced empty state displays with contextual messaging and quick-action buttons that adapt to your active view and filters.
  * Standardized event card rendering with improved date and time formatting for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/700?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->