### PR TITLE
feat(llm): implement prompt isolation, xml templates, and batch embeddings

### DIFF
--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -88,8 +88,13 @@ class AgentService:
         capability_ids: list[str] | None = None,
     ) -> str:
         """Build a rich system prompt from agent profile fields."""
+        from xml.sax.saxutils import escape
+
+        safe_name = escape(name)
+        safe_personality = escape(personality)
+
         sections = [
-            f"You are {name}.",
+            f"You are <agent_name>{safe_name}</agent_name>.",
             (
                 "Respond naturally and concisely like a real person in a chat. "
                 "Never introduce yourself, announce your capabilities, or explain what you can do "
@@ -97,11 +102,13 @@ class AgentService:
             ),
         ]
         if description:
-            sections.append(description)
-        sections.append(f"\nPersonality & Behavior:\n{personality}")
+            safe_description = escape(description)
+            sections.append(f"<description>{safe_description}</description>")
+        sections.append(f"\nPersonality & Behavior:\n<personality>{safe_personality}</personality>")
         if goals:
-            goal_list = "\n".join(f"- {g}" for g in goals)
-            sections.append(f"\nYour Goals:\n{goal_list}")
+            safe_goals = [escape(g) for g in goals]
+            goal_list = "\n".join(f"- {g}" for g in safe_goals)
+            sections.append(f"\nYour Goals:\n<goals>\n{goal_list}\n</goals>")
         if capability_ids:
             all_caps = await self.list_capabilities()
             cap_names = [c.name for c in all_caps if c.id in capability_ids]

--- a/backend/app/domain/chat/crew_orchestrator.py
+++ b/backend/app/domain/chat/crew_orchestrator.py
@@ -228,10 +228,19 @@ class CrewOrchestrator:
             else ""
         )
 
+        from xml.sax.saxutils import escape
+
+        safe_user_message = escape(user_message)
+
         history_text = CrewOrchestrator.format_history(conversation_history)
-        history_section = HISTORY_PREFIX.format(history=history_text) if history_text else ""
-        memory_section = MEMORY_PREFIX.format(memories=memory_context) if memory_context else ""
-        summary_section = SUMMARY_PREFIX.format(summary=room_summary) if room_summary else ""
+        safe_history = escape(history_text) if history_text else ""
+        history_section = HISTORY_PREFIX.format(history=safe_history) if safe_history else ""
+
+        safe_memory = escape(memory_context) if memory_context else ""
+        memory_section = MEMORY_PREFIX.format(memories=safe_memory) if safe_memory else ""
+
+        safe_summary = escape(room_summary) if room_summary else ""
+        summary_section = SUMMARY_PREFIX.format(summary=safe_summary) if safe_summary else ""
 
         kwargs = {}
         if step_callback:
@@ -244,7 +253,7 @@ class CrewOrchestrator:
                     summary_section=summary_section,
                     memory_section=memory_section,
                     history_section=history_section,
-                    user_message=user_message,
+                    user_message=safe_user_message,
                     locale_instruction=locale_instruction,
                 ),
                 expected_output=MULTI_AGENT_EXPECTED_OUTPUT,
@@ -262,7 +271,7 @@ class CrewOrchestrator:
                     summary_section=summary_section,
                     memory_section=memory_section,
                     history_section=history_section,
-                    user_message=user_message,
+                    user_message=safe_user_message,
                     locale_instruction=locale_instruction,
                 ),
                 expected_output=SINGLE_AGENT_EXPECTED_OUTPUT,

--- a/backend/app/domain/chat/prompts.py
+++ b/backend/app/domain/chat/prompts.py
@@ -6,20 +6,22 @@ from __future__ import annotations
 # Prompt templates
 # ---------------------------------------------------------------------------
 
-HISTORY_PREFIX = "Recent conversation history (for context only — do not repeat it):\n{history}\n\n"
+HISTORY_PREFIX = "Recent conversation history (for context only — do not repeat it):\n<history>\n{history}\n</history>\n\n"
 
 MEMORY_PREFIX = (
     "Relevant memories from past conversations (background context — do not repeat verbatim):\n"
-    "{memories}\n\n"
+    "<memories>\n{memories}\n</memories>\n\n"
 )
 
-SUMMARY_PREFIX = "Summary of the older parts of this conversation:\n{summary}\n\n"
+SUMMARY_PREFIX = (
+    "Summary of the older parts of this conversation:\n<summary>\n{summary}\n</summary>\n\n"
+)
 
 MULTI_AGENT_PROMPT = (
     "{summary_section}"
     "{memory_section}"
     "{history_section}"
-    "User said: {user_message}. "
+    "User said: <user_message>{user_message}</user_message>. "
     "You are managing a group chat with specialized agents. "
     "Delegate ONLY to agents whose expertise is directly relevant to the user's request — "
     "do NOT force every agent to respond. "
@@ -39,7 +41,7 @@ SINGLE_AGENT_PROMPT = (
     "{summary_section}"
     "{memory_section}"
     "{history_section}"
-    "User said: {user_message}. "
+    "User said: <user_message>{user_message}</user_message>. "
     "Respond naturally and helpfully as yourself. "
     "When relevant, be proactive about planning and converting intent into tasks/notes/events. "
     "Confirm before write actions unless the user explicitly requested immediate execution. "

--- a/backend/app/domain/chat/prompts.py
+++ b/backend/app/domain/chat/prompts.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 # Prompt templates
 # ---------------------------------------------------------------------------
 
-HISTORY_PREFIX = "Recent conversation history (for context only — do not repeat it):\n<history>\n{history}\n</history>\n\n"
+HISTORY_PREFIX = (
+    "Recent conversation history (for context only — do not repeat it):\n"
+    "<history>\n{history}\n</history>\n\n"
+)
 
 MEMORY_PREFIX = (
     "Relevant memories from past conversations (background context — do not repeat verbatim):\n"

--- a/backend/app/infrastructure/external/openrouter.py
+++ b/backend/app/infrastructure/external/openrouter.py
@@ -51,6 +51,12 @@ class OpenRouterClient:
         structured_resp = await self.structured_completion(messages, model, ChatResponse)
         return structured_resp.message
 
+    @typing.overload
+    async def embed(self, text: str, model: str) -> list[float]: ...
+
+    @typing.overload
+    async def embed(self, text: list[str], model: str) -> list[list[float]]: ...
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=10),
@@ -64,13 +70,15 @@ class OpenRouterClient:
         ),
         reraise=True,
     )
-    async def embed(self, text: str, model: str) -> list[float]:
+    async def embed(self, text: str | list[str], model: str) -> list[float] | list[list[float]]:
         response = await self.openai_client.embeddings.create(
             model=model,
             input=text,
             encoding_format="float",
         )
-        return response.data[0].embedding
+        if isinstance(text, str):
+            return response.data[0].embedding
+        return [d.embedding for d in response.data]
 
     @retry(
         stop=stop_after_attempt(3),
@@ -187,6 +195,14 @@ async def structured_completion(
         raise
 
 
-async def embed(text: str) -> list[float]:
+@typing.overload
+async def embed(text: str) -> list[float]: ...
+
+
+@typing.overload
+async def embed(text: list[str]) -> list[list[float]]: ...
+
+
+async def embed(text: str | list[str]) -> list[float] | list[list[float]]:
     client = get_openrouter_client()
     return await client.embed(text, get_settings().embedding_model)

--- a/backend/app/infrastructure/external/openrouter.py
+++ b/backend/app/infrastructure/external/openrouter.py
@@ -71,6 +71,28 @@ class OpenRouterClient:
         reraise=True,
     )
     async def embed(self, text: str | list[str], model: str) -> list[float] | list[list[float]]:
+        """Generate embeddings for the given text.
+
+        Args:
+            text: A single string or a list of strings to embed.
+            model: The ID of the embedding model to use.
+
+        Returns:
+            If `text` is a string, returns a single list[float] representing the embedding.
+            If `text` is a list[str], returns a list[list[float]] representing batch embeddings.
+
+        Raises:
+            openai.APIConnectionError: If connection fails.
+            openai.RateLimitError: If rate limited.
+            openai.InternalServerError: On server-side errors.
+            openai.APITimeoutError: If the request times out.
+
+        Examples:
+            >>> await client.embed("hello", "model-id")
+            [0.1, 0.2, 0.3]
+            >>> await client.embed(["hello", "world"], "model-id")
+            [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        """
         response = await self.openai_client.embeddings.create(
             model=model,
             input=text,
@@ -204,5 +226,25 @@ async def embed(text: list[str]) -> list[list[float]]: ...
 
 
 async def embed(text: str | list[str]) -> list[float] | list[list[float]]:
+    """Generate embeddings using the default client and default model settings.
+
+    Args:
+        text: A single string or a list of strings to embed.
+
+    Returns:
+        A list[float] if a single string is passed, or a list[list[float]] for batch inputs.
+
+    Raises:
+        openai.APIConnectionError: If connection fails.
+        openai.RateLimitError: If rate limited.
+        openai.InternalServerError: On server-side errors.
+        openai.APITimeoutError: If the request times out.
+
+    Examples:
+        >>> await embed("test string")
+        [0.1, 0.2, ...]
+        >>> await embed(["test string 1", "test string 2"])
+        [[0.1, ...], [0.4, ...]]
+    """
     client = get_openrouter_client()
     return await client.embed(text, get_settings().embedding_model)

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,11 @@
+1. **Fix `HISTORY_PREFIX` in `backend/app/domain/chat/prompts.py`**
+   - The comment states that `HISTORY_PREFIX` exceeds 100 characters. It should be broken into a multi-line implicit concatenated string.
+
+2. **Add Docstrings in `backend/app/infrastructure/external/openrouter.py`**
+   - `OpenRouterClient.embed`: Add a Google-style docstring explaining `text`, `model`, single vs batch behavior, returns, and raises.
+   - `embed` module-level function: Add a similar Google-style docstring explaining `text`, overload behavior, and returns.
+
+3. **Verify**
+   - Run formatting (`uv run ruff format .`) and checks (`uv run ruff check .`) to verify that the line limits are respected.
+   - Reply to the comments confirming the implementation.
+   - Commit and submit on the *exact same branch* (`fix/llm-prompt-isolation-and-efficiency`).


### PR DESCRIPTION
Harden the bridge between the codebase and the LLM by implementing strict prompt isolation and sanitization to prevent prompt injection, alongside improved token efficiency.

Changes:
1. **Batch Embedding**: Enhanced `OpenRouterClient.embed` and the top-level `embed` function with `typing.overload`s to natively accept `list[str]` inputs and return `list[list[float]]`, saving API calls for bulk processing tasks.
2. **Prompt Injection Defense**: Employed `xml.sax.saxutils.escape` to sanitize all variables dynamically injected into system prompts (user messages, conversation history, memories, room summary, agent profile fields).
3. **Structured Context Blocks**: Rewrote internal prompt templates in `prompts.py` and construction logic in `service.py`/`crew_orchestrator.py` to firmly enclose all dynamic variables within explicit XML delimiters (e.g., `<user_message>...</user_message>`, `<agent_name>...</agent_name>`).

All backend integration tests pass.

---
*PR created automatically by Jules for task [4362686022622970643](https://jules.google.com/task/4362686022622970643) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved character escaping and safe handling of special characters in agent names, descriptions, goals, and user messages to enhance prompt robustness across multi-agent systems.

* **New Features**
  * Embedding API now supports flexible input handling, accepting both single texts and lists of texts for efficient batch processing operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/708?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->