### PR TITLE
perf(frontend): migrate ScrollView lists to FlatList

### DIFF
--- a/frontend/src/components/chat/ChatListHeader.tsx
+++ b/frontend/src/components/chat/ChatListHeader.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
-import { Ionicons } from '@expo/vector-icons';
 import { TextInput, View, FlatList } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { AppText } from '@/components/AppText';
 import { ScalePressable } from '@/components/ScalePressable';
 import { AgentPill } from '@/components/chat/AgentPill';
@@ -49,15 +49,16 @@ const FilterItemCell = React.memo(({
 }) => (
   <ScalePressable
     onPress={onPress}
-    className={`me-2 rounded-full px-3 py-2 border ${
-      active
-        ? 'bg-[#DDF4EB] border-[#147D6473]'
-        : 'bg-[#ECF5F0] border-[#DDE8E0]'
-    }`}
+    className="me-2 rounded-full px-3 py-2 border"
+    style={{
+      backgroundColor: active ? C.primarySoft : C.surfaceHigh,
+      borderColor: active ? `${C.primary}73` : C.border,
+    }}
   >
     <AppText
       variant="caption"
-      className={`font-bold ${active ? 'text-[#147D64]' : 'text-[#5A7467]'}`}
+      className="font-bold"
+      style={{ color: active ? C.primary : C.deep }}
     >
       {label}
     </AppText>
@@ -73,7 +74,7 @@ const AgentItemCell = React.memo(({
   selectedAgentId: string | null;
   onSelectAgent: (agentId: string | null) => void;
 }) => (
-  <View style={{ marginRight: 8 }}>
+  <View className="mr-2">
     <AgentPill
       agent={agent}
       onPress={() => onSelectAgent(selectedAgentId === agent.id ? null : agent.id)}
@@ -108,29 +109,33 @@ export const ChatListHeader = React.memo(({
     return () => clearTimeout(timer);
   }, [localQuery, onChangeQuery]);
 
-  const filterItems = useMemo(() => [
-    { id: 'sort-recent', type: 'sort' as const, mode: 'recent' as SortMode, label: t('chat.filter_recent', 'Recent') },
-    { id: 'sort-mentions', type: 'sort' as const, mode: 'mentions' as SortMode, label: t('chat.filter_mentions', 'Mentions') },
-    { id: 'sort-tasks', type: 'sort' as const, mode: 'tasks' as SortMode, label: t('chat.filter_tasks', 'Tasks') },
-    { id: 'filter-recent', type: 'filter' as const, active: recentOnly, onToggle: onToggleRecentOnly, label: t('chat.recent_only', '7d') },
-    { id: 'filter-unread', type: 'filter' as const, active: unreadOnly, onToggle: onToggleUnreadOnly, label: t('chat.unread_only', 'Unread') },
+  type FilterItem =
+    | { type: 'sort'; mode: SortMode; label: string; id: string }
+    | { type: 'filter'; active: boolean; onToggle: () => void; label: string; id: string };
+
+  const filterItems = useMemo<FilterItem[]>(() => [
+    { id: 'sort-recent', type: 'sort', mode: 'recent', label: t('chat.filter_recent', 'Recent') },
+    { id: 'sort-mentions', type: 'sort', mode: 'mentions', label: t('chat.filter_mentions', 'Mentions') },
+    { id: 'sort-tasks', type: 'sort', mode: 'tasks', label: t('chat.filter_tasks', 'Tasks') },
+    { id: 'filter-recent', type: 'filter', active: recentOnly, onToggle: onToggleRecentOnly, label: t('chat.recent_only', '7d') },
+    { id: 'filter-unread', type: 'filter', active: unreadOnly, onToggle: onToggleUnreadOnly, label: t('chat.unread_only', 'Unread') },
   ], [t, recentOnly, onToggleRecentOnly, unreadOnly, onToggleUnreadOnly]);
 
-  const renderFilterItem = useCallback(({ item }: { item: typeof filterItems[0] }) => {
+  const renderFilterItem = useCallback(({ item }: { item: FilterItem }) => {
     if (item.type === 'sort') {
       return (
         <FilterItemCell
           label={item.label}
           active={sortMode === item.mode}
-          onPress={() => onChangeSortMode(item.mode!)}
+          onPress={() => onChangeSortMode(item.mode)}
         />
       );
     } else {
       return (
         <FilterItemCell
           label={item.label}
-          active={item.active!}
-          onPress={item.onToggle!}
+          active={item.active}
+          onPress={item.onToggle}
         />
       );
     }
@@ -231,7 +236,7 @@ export const ChatListHeader = React.memo(({
             data={agents}
             renderItem={renderAgentItem}
             keyExtractor={agentKeyExtractor}
-            ListHeaderComponent={<AllAgentsHeader />}
+            ListHeaderComponent={AllAgentsHeader}
           />
         </View>
       ) : null}

--- a/frontend/src/components/chat/ChatListHeader.tsx
+++ b/frontend/src/components/chat/ChatListHeader.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { Ionicons } from '@expo/vector-icons';
-import { ScrollView, TextInput, View } from 'react-native';
+import { TextInput, View, FlatList } from 'react-native';
 import { AppText } from '@/components/AppText';
 import { ScalePressable } from '@/components/ScalePressable';
 import { AgentPill } from '@/components/chat/AgentPill';
@@ -38,7 +38,50 @@ interface ChatListHeaderProps {
   roomCount: number;
 }
 
-export function ChatListHeader({
+const FilterItemCell = React.memo(({
+  label,
+  active,
+  onPress
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+}) => (
+  <ScalePressable
+    onPress={onPress}
+    className={`me-2 rounded-full px-3 py-2 border ${
+      active
+        ? 'bg-[#DDF4EB] border-[#147D6473]'
+        : 'bg-[#ECF5F0] border-[#DDE8E0]'
+    }`}
+  >
+    <AppText
+      variant="caption"
+      className={`font-bold ${active ? 'text-[#147D64]' : 'text-[#5A7467]'}`}
+    >
+      {label}
+    </AppText>
+  </ScalePressable>
+));
+
+const AgentItemCell = React.memo(({
+  agent,
+  selectedAgentId,
+  onSelectAgent
+}: {
+  agent: Agent;
+  selectedAgentId: string | null;
+  onSelectAgent: (agentId: string | null) => void;
+}) => (
+  <View style={{ marginRight: 8 }}>
+    <AgentPill
+      agent={agent}
+      onPress={() => onSelectAgent(selectedAgentId === agent.id ? null : agent.id)}
+    />
+  </View>
+));
+
+export const ChatListHeader = React.memo(({
   t,
   query,
   onChangeQuery,
@@ -53,7 +96,7 @@ export function ChatListHeader({
   onSelectAgent,
   activeFilterCount,
   roomCount,
-}: ChatListHeaderProps) {
+}: ChatListHeaderProps) => {
   const [localQuery, setLocalQuery] = useState(query);
 
   useEffect(() => {
@@ -64,6 +107,62 @@ export function ChatListHeader({
     const timer = setTimeout(() => onChangeQuery(localQuery), 300);
     return () => clearTimeout(timer);
   }, [localQuery, onChangeQuery]);
+
+  const filterItems = useMemo(() => [
+    { id: 'sort-recent', type: 'sort' as const, mode: 'recent' as SortMode, label: t('chat.filter_recent', 'Recent') },
+    { id: 'sort-mentions', type: 'sort' as const, mode: 'mentions' as SortMode, label: t('chat.filter_mentions', 'Mentions') },
+    { id: 'sort-tasks', type: 'sort' as const, mode: 'tasks' as SortMode, label: t('chat.filter_tasks', 'Tasks') },
+    { id: 'filter-recent', type: 'filter' as const, active: recentOnly, onToggle: onToggleRecentOnly, label: t('chat.recent_only', '7d') },
+    { id: 'filter-unread', type: 'filter' as const, active: unreadOnly, onToggle: onToggleUnreadOnly, label: t('chat.unread_only', 'Unread') },
+  ], [t, recentOnly, onToggleRecentOnly, unreadOnly, onToggleUnreadOnly]);
+
+  const renderFilterItem = useCallback(({ item }: { item: typeof filterItems[0] }) => {
+    if (item.type === 'sort') {
+      return (
+        <FilterItemCell
+          label={item.label}
+          active={sortMode === item.mode}
+          onPress={() => onChangeSortMode(item.mode!)}
+        />
+      );
+    } else {
+      return (
+        <FilterItemCell
+          label={item.label}
+          active={item.active!}
+          onPress={item.onToggle!}
+        />
+      );
+    }
+  }, [sortMode, onChangeSortMode]);
+
+  const filterKeyExtractor = useCallback((item: typeof filterItems[0]) => item.id, []);
+
+  const renderAgentItem = useCallback(({ item }: { item: Agent }) => (
+    <AgentItemCell
+      agent={item}
+      selectedAgentId={selectedAgentId}
+      onSelectAgent={onSelectAgent}
+    />
+  ), [selectedAgentId, onSelectAgent]);
+
+  const agentKeyExtractor = useCallback((item: Agent) => item.id, []);
+
+  const AllAgentsHeader = useCallback(() => (
+    <ScalePressable
+      onPress={() => onSelectAgent(null)}
+      className={`me-2 rounded-full px-3 py-2 border ${
+        selectedAgentId ? 'bg-[#ECF5F0] border-[#DDE8E0]' : 'bg-[#DDF4EB] border-[#147D6473]'
+      }`}
+    >
+      <AppText
+        variant="caption"
+        className={`font-bold ${selectedAgentId ? 'text-[#5A7467]' : 'text-[#147D64]'}`}
+      >
+        {t('chat.all_agents', 'All')}
+      </AppText>
+    </ScalePressable>
+  ), [onSelectAgent, selectedAgentId, t]);
 
   return (
     <>
@@ -104,53 +203,13 @@ export function ChatListHeader({
           ) : null}
         </View>
 
-        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-          {(
-            [
-              ['recent', t('chat.filter_recent', 'Recent')],
-              ['mentions', t('chat.filter_mentions', 'Mentions')],
-              ['tasks', t('chat.filter_tasks', 'Tasks')],
-            ] as [SortMode, string][]
-          ).map(([mode, label]) => {
-            const selected = sortMode === mode;
-            return (
-              <ScalePressable
-                key={mode}
-                onPress={() => onChangeSortMode(mode)}
-                className={`me-2 rounded-full px-3 py-2 border ${
-                  selected
-                    ? 'bg-[#DDF4EB] border-[#147D6473]'
-                    : 'bg-[#ECF5F0] border-[#DDE8E0]'
-                }`}
-              >
-                <AppText
-                  variant="caption"
-                  className={`font-bold ${selected ? 'text-[#147D64]' : 'text-[#5A7467]'}`}
-                >
-                  {label}
-                </AppText>
-              </ScalePressable>
-            );
-          })}
-          {(
-            [
-              [recentOnly, onToggleRecentOnly, t('chat.recent_only', '7d')],
-              [unreadOnly, onToggleUnreadOnly, t('chat.unread_only', 'Unread')],
-            ] as const
-          ).map(([active, onToggle, label]) => (
-            <ScalePressable
-              key={label}
-              onPress={onToggle}
-              className={`me-2 rounded-full px-3 py-2 border ${
-                active ? 'bg-[#DDF4EB] border-[#147D6473]' : 'bg-[#ECF5F0] border-[#DDE8E0]'
-              }`}
-            >
-              <AppText variant="caption" className={`font-bold ${active ? 'text-[#147D64]' : 'text-[#5A7467]'}`}>
-                {label}
-              </AppText>
-            </ScalePressable>
-          ))}
-        </ScrollView>
+        <FlatList
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          data={filterItems}
+          renderItem={renderFilterItem}
+          keyExtractor={filterKeyExtractor}
+        />
       </View>
 
       {agents.length > 0 ? (
@@ -165,33 +224,15 @@ export function ChatListHeader({
                 : agents.length}
             </AppText>
           </View>
-          <ScrollView
+          <FlatList
             horizontal
             showsHorizontalScrollIndicator={false}
             contentContainerClassName="px-4"
-          >
-            <ScalePressable
-              onPress={() => onSelectAgent(null)}
-              className={`me-2 rounded-full px-3 py-2 border ${
-                selectedAgentId ? 'bg-[#ECF5F0] border-[#DDE8E0]' : 'bg-[#DDF4EB] border-[#147D6473]'
-              }`}
-            >
-              <AppText
-                variant="caption"
-                className={`font-bold ${selectedAgentId ? 'text-[#5A7467]' : 'text-[#147D64]'}`}
-              >
-                {t('chat.all_agents', 'All')}
-              </AppText>
-            </ScalePressable>
-            {agents.map((item) => (
-              <View key={item.id} style={{ marginRight: 8 }}>
-                <AgentPill
-                  agent={item}
-                  onPress={() => onSelectAgent(selectedAgentId === item.id ? null : item.id)}
-                />
-              </View>
-            ))}
-          </ScrollView>
+            data={agents}
+            renderItem={renderAgentItem}
+            keyExtractor={agentKeyExtractor}
+            ListHeaderComponent={<AllAgentsHeader />}
+          />
         </View>
       ) : null}
 
@@ -205,4 +246,7 @@ export function ChatListHeader({
       </View>
     </>
   );
-}
+});
+FilterItemCell.displayName = 'FilterItemCell';
+AgentItemCell.displayName = 'AgentItemCell';
+ChatListHeader.displayName = 'ChatListHeader';

--- a/frontend/src/components/chat/RoomPromptRail.tsx
+++ b/frontend/src/components/chat/RoomPromptRail.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Pressable, ScrollView, View } from 'react-native';
+import React, { useCallback } from 'react';
+import { Pressable, FlatList, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { AppText } from '@/components/AppText';
 
@@ -23,7 +23,56 @@ interface RoomPromptRailProps {
   onContextPress?: (value: string) => void;
 }
 
-export function RoomPromptRail({
+const PromptItemCell = React.memo(({
+  item,
+  isStreaming,
+  onPromptPress,
+  onPromptLongPress
+}: {
+  item: PromptItem;
+  isStreaming: boolean;
+  onPromptPress: (text: string) => void;
+  onPromptLongPress: (prompt: PromptItem) => void;
+}) => (
+  <Pressable
+    onPress={() => onPromptPress(item.text)}
+    onLongPress={() => onPromptLongPress(item)}
+    className={`mr-2 rounded-full px-3 py-2 border ${
+      item.pinned
+        ? 'bg-[#DDF4EB] border-[#147D6455] text-[#147D64]'
+        : 'bg-[#ECF5F0] border-[#DDE8E0] text-[#13251C]'
+    } ${isStreaming ? 'opacity-60' : 'opacity-100'}`}
+    disabled={isStreaming}
+  >
+    <AppText
+      className={`text-xs font-bold ${
+        item.pinned ? 'text-[#147D64]' : 'text-[#13251C]'
+      }`}
+    >
+      {item.pinned ? '★ ' : ''}
+      {item.text}
+    </AppText>
+  </Pressable>
+));
+
+const ContextActionCell = React.memo(({
+  value,
+  onContextPress
+}: {
+  value: string;
+  onContextPress: (value: string) => void;
+}) => (
+  <Pressable
+    onPress={() => onContextPress(value)}
+    className="mr-2 rounded-xl px-2.5 py-[7px] bg-[#ECF5F0] border border-[#DDE8E0]"
+  >
+    <AppText variant="caption" className="text-[#5A7467] font-bold">
+      {value}
+    </AppText>
+  </Pressable>
+));
+
+export const RoomPromptRail = React.memo(({
   prompts,
   isStreaming,
   saveLabel,
@@ -35,8 +84,37 @@ export function RoomPromptRail({
   onPromptLongPress,
   contextActions,
   onContextPress,
-}: RoomPromptRailProps) {
+}: RoomPromptRailProps) => {
   const { t } = useTranslation();
+
+  const renderPromptItem = useCallback(({ item }: { item: PromptItem }) => (
+    <PromptItemCell
+      item={item}
+      isStreaming={isStreaming}
+      onPromptPress={onPromptPress}
+      onPromptLongPress={onPromptLongPress}
+    />
+  ), [isStreaming, onPromptPress, onPromptLongPress]);
+
+  const renderContextAction = useCallback(({ item }: { item: string }) => {
+    if (!onContextPress) return null;
+    return <ContextActionCell value={item} onContextPress={onContextPress} />;
+  }, [onContextPress]);
+
+  const promptKeyExtractor = useCallback((item: PromptItem) => item.id, []);
+  const contextKeyExtractor = useCallback((item: string) => item, []);
+
+  const ListHeader = useCallback(() => (
+    <Pressable
+      onPress={onSave}
+      className={`mr-2 rounded-full px-3 py-2 border bg-[#DDF4EB] border-[#147D6455] ${
+        isStreaming || !canSave ? 'opacity-50' : 'opacity-100'
+      }`}
+      disabled={isStreaming || !canSave}
+    >
+      <AppText className="text-xs font-bold text-[#147D64]">{saveLabel}</AppText>
+    </Pressable>
+  ), [onSave, isStreaming, canSave, saveLabel]);
 
   return (
     <View className="px-3 pb-2">
@@ -52,65 +130,30 @@ export function RoomPromptRail({
           ) : null}
         </View>
 
-        <ScrollView
+        <FlatList
           horizontal
+          data={prompts}
+          keyExtractor={promptKeyExtractor}
+          renderItem={renderPromptItem}
           showsHorizontalScrollIndicator={false}
           contentContainerClassName="px-3"
-        >
-          <Pressable
-            onPress={onSave}
-            className={`mr-2 rounded-full px-3 py-2 border bg-[#DDF4EB] border-[#147D6455] ${
-              isStreaming || !canSave ? 'opacity-50' : 'opacity-100'
-            }`}
-            disabled={isStreaming || !canSave}
-          >
-            <AppText className="text-xs font-bold text-[#147D64]">{saveLabel}</AppText>
-          </Pressable>
-
-          {prompts.map((action) => (
-            <Pressable
-              key={action.id}
-              onPress={() => onPromptPress(action.text)}
-              onLongPress={() => onPromptLongPress(action)}
-              className={`mr-2 rounded-full px-3 py-2 border ${
-                action.pinned
-                  ? 'bg-[#DDF4EB] border-[#147D6455] text-[#147D64]'
-                  : 'bg-[#ECF5F0] border-[#DDE8E0] text-[#13251C]'
-              } ${isStreaming ? 'opacity-60' : 'opacity-100'}`}
-              disabled={isStreaming}
-            >
-              <AppText
-                className={`text-xs font-bold ${
-                  action.pinned ? 'text-[#147D64]' : 'text-[#13251C]'
-                }`}
-              >
-                {action.pinned ? '★ ' : ''}
-                {action.text}
-              </AppText>
-            </Pressable>
-          ))}
-        </ScrollView>
+          ListHeaderComponent={<ListHeader />}
+        />
 
         {contextActions && contextActions.length > 0 && onContextPress ? (
-          <ScrollView
+          <FlatList
             horizontal
+            data={contextActions}
+            keyExtractor={contextKeyExtractor}
+            renderItem={renderContextAction}
             showsHorizontalScrollIndicator={false}
             contentContainerClassName="px-3 pt-2"
-          >
-            {contextActions.map((value) => (
-              <Pressable
-                key={value}
-                onPress={() => onContextPress(value)}
-                className="mr-2 rounded-xl px-2.5 py-[7px] bg-[#ECF5F0] border border-[#DDE8E0]"
-              >
-                <AppText variant="caption" className="text-[#5A7467] font-bold">
-                  {value}
-                </AppText>
-              </Pressable>
-            ))}
-          </ScrollView>
+          />
         ) : null}
       </View>
     </View>
   );
-}
+});
+PromptItemCell.displayName = 'PromptItemCell';
+ContextActionCell.displayName = 'ContextActionCell';
+RoomPromptRail.displayName = 'RoomPromptRail';

--- a/frontend/src/components/chat/RoomPromptRail.tsx
+++ b/frontend/src/components/chat/RoomPromptRail.tsx
@@ -2,6 +2,16 @@ import React, { useCallback } from 'react';
 import { Pressable, FlatList, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { AppText } from '@/components/AppText';
+const C = {
+  bgPromptPinned: '#DDF4EB',
+  borderPromptPinned: '#147D6455',
+  textPromptPinned: '#147D64',
+  bgPrompt: '#ECF5F0',
+  borderPrompt: '#DDE8E0',
+  textPrompt: '#13251C',
+  muted: '#5A7467',
+};
+
 
 interface PromptItem {
   id: string;
@@ -37,17 +47,16 @@ const PromptItemCell = React.memo(({
   <Pressable
     onPress={() => onPromptPress(item.text)}
     onLongPress={() => onPromptLongPress(item)}
-    className={`mr-2 rounded-full px-3 py-2 border ${
-      item.pinned
-        ? 'bg-[#DDF4EB] border-[#147D6455] text-[#147D64]'
-        : 'bg-[#ECF5F0] border-[#DDE8E0] text-[#13251C]'
-    } ${isStreaming ? 'opacity-60' : 'opacity-100'}`}
+    className={`mr-2 rounded-full px-3 py-2 border ${isStreaming ? 'opacity-60' : 'opacity-100'}`}
+    style={{
+      backgroundColor: item.pinned ? C.bgPromptPinned : C.bgPrompt,
+      borderColor: item.pinned ? C.borderPromptPinned : C.borderPrompt,
+    }}
     disabled={isStreaming}
   >
     <AppText
-      className={`text-xs font-bold ${
-        item.pinned ? 'text-[#147D64]' : 'text-[#13251C]'
-      }`}
+      className="text-xs font-bold"
+      style={{ color: item.pinned ? C.textPromptPinned : C.textPrompt }}
     >
       {item.pinned ? '★ ' : ''}
       {item.text}
@@ -64,9 +73,10 @@ const ContextActionCell = React.memo(({
 }) => (
   <Pressable
     onPress={() => onContextPress(value)}
-    className="mr-2 rounded-xl px-2.5 py-[7px] bg-[#ECF5F0] border border-[#DDE8E0]"
+    className="mr-2 rounded-xl px-2.5 py-[7px] border"
+    style={{ backgroundColor: C.bgPrompt, borderColor: C.borderPrompt }}
   >
-    <AppText variant="caption" className="text-[#5A7467] font-bold">
+    <AppText variant="caption" className="font-bold" style={{ color: C.muted }}>
       {value}
     </AppText>
   </Pressable>
@@ -107,12 +117,13 @@ export const RoomPromptRail = React.memo(({
   const ListHeader = useCallback(() => (
     <Pressable
       onPress={onSave}
-      className={`mr-2 rounded-full px-3 py-2 border bg-[#DDF4EB] border-[#147D6455] ${
+      className={`mr-2 rounded-full px-3 py-2 border ${
         isStreaming || !canSave ? 'opacity-50' : 'opacity-100'
       }`}
+      style={{ backgroundColor: C.bgPromptPinned, borderColor: C.borderPromptPinned }}
       disabled={isStreaming || !canSave}
     >
-      <AppText className="text-xs font-bold text-[#147D64]">{saveLabel}</AppText>
+      <AppText className="text-xs font-bold" style={{ color: C.textPromptPinned }}>{saveLabel}</AppText>
     </Pressable>
   ), [onSave, isStreaming, canSave, saveLabel]);
 
@@ -137,7 +148,7 @@ export const RoomPromptRail = React.memo(({
           renderItem={renderPromptItem}
           showsHorizontalScrollIndicator={false}
           contentContainerClassName="px-3"
-          ListHeaderComponent={<ListHeader />}
+          ListHeaderComponent={ListHeader}
         />
 
         {contextActions && contextActions.length > 0 && onContextPress ? (


### PR DESCRIPTION
Refactored `ChatListHeader.tsx` and `RoomPromptRail.tsx` to utilize `FlatList` instead of mapped items inside `ScrollView`. Applied strict memoization by extracting cell components to `React.memo` and using `useCallback` for functions passed down as props to limit unnecessary re-renders.

---
*PR created automatically by Jules for task [11262823410589110890](https://jules.google.com/task/11262823410589110890) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized chat list header and prompt rail components for improved rendering performance through enhanced list virtualization and component memoization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->