### PR TITLE
test: add failure tests for memory deletion ownership

### DIFF
--- a/backend/tests/test_memory_routes.py
+++ b/backend/tests/test_memory_routes.py
@@ -381,6 +381,16 @@ def test_delete_memory_endpoint_with_user_id(
 def test_delete_memory_endpoint_with_wrong_user_id(
     client: TestClient, authed_headers: dict, test_user_id: UUID
 ) -> None:
+    """Verify that deleting a memory with a wrong user id returns 404.
+
+    Args:
+        client: TestClient instance for making requests.
+        authed_headers: dict containing authorization headers.
+        test_user_id: UUID of the authenticated user.
+
+    Returns:
+        None
+    """
     memory_id = uuid4()
     with patch(
         "app.domain.memory.service.MemoryService.delete_memory", new_callable=AsyncMock

--- a/backend/tests/test_memory_routes.py
+++ b/backend/tests/test_memory_routes.py
@@ -376,3 +376,17 @@ def test_delete_memory_endpoint_with_user_id(
         response = client.delete(f"/api/v1/memory/{memory_id}", headers=authed_headers)
         assert response.status_code == 200
         mock_delete.assert_awaited_once_with(memory_id, user_id=UUID(str(test_user_id)))
+
+
+def test_delete_memory_endpoint_with_wrong_user_id(
+    client: TestClient, authed_headers: dict, test_user_id: UUID
+) -> None:
+    memory_id = uuid4()
+    with patch(
+        "app.domain.memory.service.MemoryService.delete_memory", new_callable=AsyncMock
+    ) as mock_delete:
+        mock_delete.return_value = False
+        response = client.delete(f"/api/v1/memory/{memory_id}", headers=authed_headers)
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Memory not found"}
+        mock_delete.assert_awaited_once_with(memory_id, user_id=UUID(str(test_user_id)))

--- a/backend/tests/test_repositories.py
+++ b/backend/tests/test_repositories.py
@@ -113,7 +113,17 @@ class TestChatRepository:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_delete_memory_with_user_id(self) -> None:
+    async def test_delete_memory_with_user_id_success(self) -> None:
+        repo = MemoryRepository()
+        user_id = uuid4()
+        memory = Memory(content="To delete with user", user_id=user_id, embedding=[0.0])
+        await repo.insert_memory(memory)
+
+        result_owner = await repo.delete_memory(memory.id, user_id=user_id)
+        assert result_owner is True
+
+    @pytest.mark.asyncio
+    async def test_delete_memory_returns_false_for_wrong_user_id(self) -> None:
         repo = MemoryRepository()
         user_id = uuid4()
         other_user_id = uuid4()
@@ -122,9 +132,6 @@ class TestChatRepository:
 
         result_other = await repo.delete_memory(memory.id, user_id=other_user_id)
         assert result_other is False
-
-        result_owner = await repo.delete_memory(memory.id, user_id=user_id)
-        assert result_owner is True
 
     @pytest.mark.asyncio
     async def test_create_and_delete_room(self) -> None:

--- a/backend/tests/test_repositories.py
+++ b/backend/tests/test_repositories.py
@@ -114,6 +114,14 @@ class TestChatRepository:
 
     @pytest.mark.asyncio
     async def test_delete_memory_with_user_id_success(self) -> None:
+        """Verify successful deletion of a memory when the correct user_id is provided.
+
+        Args:
+            self: The test class instance.
+
+        Returns:
+            None
+        """
         repo = MemoryRepository()
         user_id = uuid4()
         memory = Memory(content="To delete with user", user_id=user_id, embedding=[0.0])
@@ -124,6 +132,14 @@ class TestChatRepository:
 
     @pytest.mark.asyncio
     async def test_delete_memory_returns_false_for_wrong_user_id(self) -> None:
+        """Verify that memory deletion returns False when a wrong user_id is provided.
+
+        Args:
+            self: The test class instance.
+
+        Returns:
+            None
+        """
         repo = MemoryRepository()
         user_id = uuid4()
         other_user_id = uuid4()


### PR DESCRIPTION
The Test Engineer requested that any missing tests, particularly failure scenarios such as an invalid or wrong user ID being used, should be explicitly defined and covered. The `MemoryRepository` and route handlers had partial coverage for the user ID check upon deletion, but lacked explicit validation that another user's ID would fail to delete a memory.

This adds explicit success and failure cases for deleting memories with the appropriate (and inappropriate) user IDs in both the repository and the routing layers.

---
*PR created automatically by Jules for task [6666213828031590334](https://jules.google.com/task/6666213828031590334) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for memory deletion authorization validation when user is not the owner
  * Enhanced test organization with dedicated test methods for success and failure scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YKDBontekoe/miru/pull/720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->