### PR TITLE
docs: align documentation with codebase ground truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ The following AI agents actively monitor and modify the Miru codebase. Their act
 **Note on Prompt:** Jules is instructed to strictly follow project architecture and code style: 100-char lines, type hints/explicit types, double quotes for Python, single quotes for TypeScript, specific import orders (`stdlib` → `third-party` → `first-party`), use `str | None` not `Optional[str]`, use `const` for components/internal functions, include `from __future__ import annotations`, log errors with context (`logger.exception()`), and structure domains in `backend/app/domain/<domain>/` and routes in `backend/app/api/v1/`.
 
 ### 2. CodeRabbit
+// DOCS(miru-agent): prompt mismatch
 
 **Mission:** Continuous code review, enforcing style, finding bugs, and suggesting refactors.
 **Trigger Conditions:**
@@ -112,8 +113,9 @@ backend/
         graph_service.py # Graph logic
         document_service.py # Document processing logic
       notifications/
-        api/         # Push notification endpoints
-        services.py  # Token registration service
+        schemas.py   # Pydantic schemas for notifications
+        interfaces/  # Interface boundaries for dependencies
+        use_cases/   # Application logic orchestrating notification domain
       productivity/
         models.py    # Task, Note, CalendarEvent Tortoise ORM models
         schemas.py   # Task, Note, CalendarEvent Pydantic schemas

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -99,6 +99,7 @@ async def _handle_send_message(
 # ---------------------------------------------------------------------------
 # WebSocket endpoint
 # ---------------------------------------------------------------------------
+# DOCS(miru-agent): undocumented endpoint
 @router.websocket("/ws/chat")
 async def websocket_chat_hub(
     websocket: WebSocket,


### PR DESCRIPTION
This PR audits and updates the documentation to align with the actual state of the codebase.

Changes made:
- Added `// DOCS(miru-agent): prompt mismatch` for CodeRabbit in `AGENTS.md` as its trigger conditions documented there did not match `.coderabbit.yaml`.
- Fixed the architecture folder structure for the `notifications` domain in `AGENTS.md` to accurately reflect its contents (`schemas.py`, `interfaces/`, `use_cases/`).
- Added `# DOCS(miru-agent): undocumented endpoint` for the `websocket_chat_hub` endpoint in `backend/app/api/v1/websocket.py` to ensure it is eventually documented in the OpenAPI schema.

---
*PR created automatically by Jules for task [9933892152442385985](https://jules.google.com/task/9933892152442385985) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation structure and internal reference markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->