### PR TITLE
perf: optimize React Native component renders using FlatList

### DIFF
--- a/frontend/src/components/chat/ChatListHeader.tsx
+++ b/frontend/src/components/chat/ChatListHeader.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { Ionicons } from '@expo/vector-icons';
-import { ScrollView, TextInput, View } from 'react-native';
+import { ScrollView, TextInput, View, FlatList } from 'react-native';
 import { AppText } from '@/components/AppText';
 import { ScalePressable } from '@/components/ScalePressable';
 import { AgentPill } from '@/components/chat/AgentPill';
@@ -38,7 +38,51 @@ interface ChatListHeaderProps {
   roomCount: number;
 }
 
-export function ChatListHeader({
+type AgentItemType = { id: 'all'; isAllItem: true } | Agent;
+
+const keyExtractorAgent = (item: AgentItemType) => item.id;
+
+const RenderAgentItem = React.memo(({
+  item,
+  selectedAgentId,
+  onSelectAgent,
+  t
+}: {
+  item: AgentItemType;
+  selectedAgentId: string | null;
+  onSelectAgent: (agentId: string | null) => void;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
+}) => {
+  if ('isAllItem' in item && item.isAllItem) {
+    return (
+      <ScalePressable
+        onPress={() => onSelectAgent(null)}
+        className={`me-2 rounded-full px-3 py-2 border ${
+          selectedAgentId ? 'bg-[#ECF5F0] border-[#DDE8E0]' : 'bg-[#DDF4EB] border-[#147D6473]'
+        }`}
+      >
+        <AppText
+          variant="caption"
+          className={`font-bold ${selectedAgentId ? 'text-[#5A7467]' : 'text-[#147D64]'}`}
+        >
+          {t('chat.all_agents', 'All')}
+        </AppText>
+      </ScalePressable>
+    );
+  }
+
+  return (
+    <View style={{ marginRight: 8 }}>
+      <AgentPill
+        agent={item as Agent}
+        onPress={() => onSelectAgent(selectedAgentId === item.id ? null : item.id)}
+      />
+    </View>
+  );
+});
+RenderAgentItem.displayName = 'RenderAgentItem';
+
+export const ChatListHeader = React.memo(function ChatListHeader({
   t,
   query,
   onChangeQuery,
@@ -64,6 +108,19 @@ export function ChatListHeader({
     const timer = setTimeout(() => onChangeQuery(localQuery), 300);
     return () => clearTimeout(timer);
   }, [localQuery, onChangeQuery]);
+
+  const agentsListData = useMemo<AgentItemType[]>(() => {
+    return [{ id: 'all', isAllItem: true } as const, ...agents];
+  }, [agents]);
+
+  const renderAgentItem = useCallback(({ item }: { item: AgentItemType }) => (
+    <RenderAgentItem
+      item={item}
+      selectedAgentId={selectedAgentId}
+      onSelectAgent={onSelectAgent}
+      t={t}
+    />
+  ), [selectedAgentId, onSelectAgent, t]);
 
   return (
     <>
@@ -165,33 +222,14 @@ export function ChatListHeader({
                 : agents.length}
             </AppText>
           </View>
-          <ScrollView
+          <FlatList
             horizontal
             showsHorizontalScrollIndicator={false}
             contentContainerClassName="px-4"
-          >
-            <ScalePressable
-              onPress={() => onSelectAgent(null)}
-              className={`me-2 rounded-full px-3 py-2 border ${
-                selectedAgentId ? 'bg-[#ECF5F0] border-[#DDE8E0]' : 'bg-[#DDF4EB] border-[#147D6473]'
-              }`}
-            >
-              <AppText
-                variant="caption"
-                className={`font-bold ${selectedAgentId ? 'text-[#5A7467]' : 'text-[#147D64]'}`}
-              >
-                {t('chat.all_agents', 'All')}
-              </AppText>
-            </ScalePressable>
-            {agents.map((item) => (
-              <View key={item.id} style={{ marginRight: 8 }}>
-                <AgentPill
-                  agent={item}
-                  onPress={() => onSelectAgent(selectedAgentId === item.id ? null : item.id)}
-                />
-              </View>
-            ))}
-          </ScrollView>
+            data={agentsListData}
+            keyExtractor={keyExtractorAgent}
+            renderItem={renderAgentItem}
+          />
         </View>
       ) : null}
 
@@ -205,4 +243,5 @@ export function ChatListHeader({
       </View>
     </>
   );
-}
+});
+ChatListHeader.displayName = 'ChatListHeader';

--- a/frontend/src/components/chat/RoomPromptRail.tsx
+++ b/frontend/src/components/chat/RoomPromptRail.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Pressable, ScrollView, View } from 'react-native';
+import React, { useCallback, useMemo } from 'react';
+import { Pressable, FlatList, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { AppText } from '@/components/AppText';
 
@@ -8,6 +8,83 @@ interface PromptItem {
   text: string;
   pinned: boolean;
 }
+
+const keyExtractorPrompt = (item: PromptItem) => item.id;
+const keyExtractorContextAction = (item: string) => item;
+
+const RenderPromptItem = React.memo(({
+  item,
+  isStreaming,
+  onPromptPress,
+  onPromptLongPress
+}: {
+  item: PromptItem;
+  isStreaming: boolean;
+  onPromptPress: (text: string) => void;
+  onPromptLongPress: (prompt: PromptItem) => void;
+}) => (
+  <Pressable
+    onPress={() => onPromptPress(item.text)}
+    onLongPress={() => onPromptLongPress(item)}
+    className={`mr-2 rounded-full px-3 py-2 border ${
+      item.pinned
+        ? 'bg-[#DDF4EB] border-[#147D6455] text-[#147D64]'
+        : 'bg-[#ECF5F0] border-[#DDE8E0] text-[#13251C]'
+    } ${isStreaming ? 'opacity-60' : 'opacity-100'}`}
+    disabled={isStreaming}
+  >
+    <AppText
+      className={`text-xs font-bold ${
+        item.pinned ? 'text-[#147D64]' : 'text-[#13251C]'
+      }`}
+    >
+      {item.pinned ? '★ ' : ''}
+      {item.text}
+    </AppText>
+  </Pressable>
+));
+RenderPromptItem.displayName = 'RenderPromptItem';
+
+const RenderContextActionItem = React.memo(({
+  item,
+  onContextPress
+}: {
+  item: string;
+  onContextPress: (value: string) => void;
+}) => (
+  <Pressable
+    onPress={() => onContextPress(item)}
+    className="mr-2 rounded-xl px-2.5 py-[7px] bg-[#ECF5F0] border border-[#DDE8E0]"
+  >
+    <AppText variant="caption" className="text-[#5A7467] font-bold">
+      {item}
+    </AppText>
+  </Pressable>
+));
+RenderContextActionItem.displayName = 'RenderContextActionItem';
+
+const ListHeaderSaveButton = React.memo(({
+  onSave,
+  isStreaming,
+  canSave,
+  saveLabel,
+}: {
+  onSave: () => void;
+  isStreaming: boolean;
+  canSave: boolean;
+  saveLabel: string;
+}) => (
+  <Pressable
+    onPress={onSave}
+    className={`mr-2 rounded-full px-3 py-2 border bg-[#DDF4EB] border-[#147D6455] ${
+      isStreaming || !canSave ? 'opacity-50' : 'opacity-100'
+    }`}
+    disabled={isStreaming || !canSave}
+  >
+    <AppText className="text-xs font-bold text-[#147D64]">{saveLabel}</AppText>
+  </Pressable>
+));
+ListHeaderSaveButton.displayName = 'ListHeaderSaveButton';
 
 interface RoomPromptRailProps {
   prompts: PromptItem[];
@@ -23,7 +100,7 @@ interface RoomPromptRailProps {
   onContextPress?: (value: string) => void;
 }
 
-export function RoomPromptRail({
+export const RoomPromptRail = React.memo(function RoomPromptRail({
   prompts,
   isStreaming,
   saveLabel,
@@ -37,6 +114,29 @@ export function RoomPromptRail({
   onContextPress,
 }: RoomPromptRailProps) {
   const { t } = useTranslation();
+
+  const renderPromptItem = useCallback(({ item }: { item: PromptItem }) => (
+    <RenderPromptItem
+      item={item}
+      isStreaming={isStreaming}
+      onPromptPress={onPromptPress}
+      onPromptLongPress={onPromptLongPress}
+    />
+  ), [isStreaming, onPromptPress, onPromptLongPress]);
+
+  const renderContextActionItem = useCallback(({ item }: { item: string }) => {
+    if (!onContextPress) return null;
+    return <RenderContextActionItem item={item} onContextPress={onContextPress} />;
+  }, [onContextPress]);
+
+  const listHeaderSaveButton = useMemo(() => (
+    <ListHeaderSaveButton
+      onSave={onSave}
+      isStreaming={isStreaming}
+      canSave={canSave}
+      saveLabel={saveLabel}
+    />
+  ), [onSave, isStreaming, canSave, saveLabel]);
 
   return (
     <View className="px-3 pb-2">
@@ -52,65 +152,30 @@ export function RoomPromptRail({
           ) : null}
         </View>
 
-        <ScrollView
+        <FlatList
           horizontal
           showsHorizontalScrollIndicator={false}
           contentContainerClassName="px-3"
-        >
-          <Pressable
-            onPress={onSave}
-            className={`mr-2 rounded-full px-3 py-2 border bg-[#DDF4EB] border-[#147D6455] ${
-              isStreaming || !canSave ? 'opacity-50' : 'opacity-100'
-            }`}
-            disabled={isStreaming || !canSave}
-          >
-            <AppText className="text-xs font-bold text-[#147D64]">{saveLabel}</AppText>
-          </Pressable>
-
-          {prompts.map((action) => (
-            <Pressable
-              key={action.id}
-              onPress={() => onPromptPress(action.text)}
-              onLongPress={() => onPromptLongPress(action)}
-              className={`mr-2 rounded-full px-3 py-2 border ${
-                action.pinned
-                  ? 'bg-[#DDF4EB] border-[#147D6455] text-[#147D64]'
-                  : 'bg-[#ECF5F0] border-[#DDE8E0] text-[#13251C]'
-              } ${isStreaming ? 'opacity-60' : 'opacity-100'}`}
-              disabled={isStreaming}
-            >
-              <AppText
-                className={`text-xs font-bold ${
-                  action.pinned ? 'text-[#147D64]' : 'text-[#13251C]'
-                }`}
-              >
-                {action.pinned ? '★ ' : ''}
-                {action.text}
-              </AppText>
-            </Pressable>
-          ))}
-        </ScrollView>
+          data={prompts}
+          keyExtractor={keyExtractorPrompt}
+          renderItem={renderPromptItem}
+          ListHeaderComponent={listHeaderSaveButton}
+        />
 
         {contextActions && contextActions.length > 0 && onContextPress ? (
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerClassName="px-3 pt-2"
-          >
-            {contextActions.map((value) => (
-              <Pressable
-                key={value}
-                onPress={() => onContextPress(value)}
-                className="mr-2 rounded-xl px-2.5 py-[7px] bg-[#ECF5F0] border border-[#DDE8E0]"
-              >
-                <AppText variant="caption" className="text-[#5A7467] font-bold">
-                  {value}
-                </AppText>
-              </Pressable>
-            ))}
-          </ScrollView>
+          <View className="pt-2">
+            <FlatList
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerClassName="px-3"
+              data={contextActions}
+              keyExtractor={keyExtractorContextAction}
+              renderItem={renderContextActionItem}
+            />
+          </View>
         ) : null}
       </View>
     </View>
   );
-}
+});
+RoomPromptRail.displayName = 'RoomPromptRail';


### PR DESCRIPTION
**Performance Log**:
- `frontend/src/components/chat/RoomPromptRail.tsx`: Used `ScrollView` to map multiple lists directly inline (`prompts` and `contextActions`).
- `frontend/src/components/chat/ChatListHeader.tsx`: Used `ScrollView` to map arrays of components inline (`agents`). Re-rendering logic scaled linearly with list growth.

**Complexity Delta**: 
- Migrated standard `ScrollView` instances mapping dynamic variables linearly (O(n) node creations on render) to `FlatList`, which virtualizes items. Render performance shifts to O(viewport), vastly saving memory allocation per view update. 

All unit tests and strict TypeScript type-checks remain passing.

---
*PR created automatically by Jules for task [9680138148557815783](https://jules.google.com/task/9680138148557815783) started by @YKDBontekoe*