### PR TITLE
perf: optimize list rendering in chat components using FlatList

### DIFF
--- a/frontend/src/components/chat/ChatListHeader.tsx
+++ b/frontend/src/components/chat/ChatListHeader.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { Ionicons } from '@expo/vector-icons';
-import { ScrollView, TextInput, View } from 'react-native';
+import { TextInput, View, FlatList } from 'react-native';
 import { AppText } from '@/components/AppText';
 import { ScalePressable } from '@/components/ScalePressable';
 import { AgentPill } from '@/components/chat/AgentPill';
@@ -38,7 +38,7 @@ interface ChatListHeaderProps {
   roomCount: number;
 }
 
-export function ChatListHeader({
+export const ChatListHeader = React.memo(function ChatListHeader({
   t,
   query,
   onChangeQuery,
@@ -55,6 +55,77 @@ export function ChatListHeader({
   roomCount,
 }: ChatListHeaderProps) {
   const [localQuery, setLocalQuery] = useState(query);
+  const agentsData = useMemo(() => [{ id: 'all', isAllItem: true } as const, ...agents], [agents]);
+  const filterData = useMemo(() => [
+    { type: 'sort', mode: 'recent', label: t('chat.filter_recent', 'Recent') },
+    { type: 'sort', mode: 'mentions', label: t('chat.filter_mentions', 'Mentions') },
+    { type: 'sort', mode: 'tasks', label: t('chat.filter_tasks', 'Tasks') },
+    { type: 'filter', active: recentOnly, onToggle: onToggleRecentOnly, label: t('chat.recent_only', '7d') },
+    { type: 'filter', active: unreadOnly, onToggle: onToggleUnreadOnly, label: t('chat.unread_only', 'Unread') },
+  ] as const, [t, recentOnly, onToggleRecentOnly, unreadOnly, onToggleUnreadOnly]);
+
+  const renderFilterItem = useCallback(({ item }: any) => {
+    if (item.type === 'sort') {
+      const selected = sortMode === item.mode;
+      return (
+        <ScalePressable
+          onPress={() => onChangeSortMode(item.mode as SortMode)}
+          className={`me-2 rounded-full px-3 py-2 border ${
+            selected
+              ? 'bg-[#DDF4EB] border-[#147D6473]'
+              : 'bg-[#ECF5F0] border-[#DDE8E0]'
+          }`}
+        >
+          <AppText
+            variant="caption"
+            className={`font-bold ${selected ? 'text-[#147D64]' : 'text-[#5A7467]'}`}
+          >
+            {item.label}
+          </AppText>
+        </ScalePressable>
+      );
+    }
+    return (
+      <ScalePressable
+        onPress={item.onToggle}
+        className={`me-2 rounded-full px-3 py-2 border ${
+          item.active ? 'bg-[#DDF4EB] border-[#147D6473]' : 'bg-[#ECF5F0] border-[#DDE8E0]'
+        }`}
+      >
+        <AppText variant="caption" className={`font-bold ${item.active ? 'text-[#147D64]' : 'text-[#5A7467]'}`}>
+          {item.label}
+        </AppText>
+      </ScalePressable>
+    );
+  }, [sortMode, onChangeSortMode]);
+
+  const renderAgentItem = useCallback(({ item }: any) => {
+    if ('isAllItem' in item && item.isAllItem) {
+      return (
+        <ScalePressable
+          onPress={() => onSelectAgent(null)}
+          className={`me-2 rounded-full px-3 py-2 border ${
+            selectedAgentId ? 'bg-[#ECF5F0] border-[#DDE8E0]' : 'bg-[#DDF4EB] border-[#147D6473]'
+          }`}
+        >
+          <AppText
+            variant="caption"
+            className={`font-bold ${selectedAgentId ? 'text-[#5A7467]' : 'text-[#147D64]'}`}
+          >
+            {t('chat.all_agents', 'All')}
+          </AppText>
+        </ScalePressable>
+      );
+    }
+    return (
+      <View style={{ marginRight: 8 }}>
+        <AgentPill
+          agent={item as Agent}
+          onPress={() => onSelectAgent(selectedAgentId === item.id ? null : item.id)}
+        />
+      </View>
+    );
+  }, [onSelectAgent, selectedAgentId, t]);
 
   useEffect(() => {
     setLocalQuery(query);
@@ -104,53 +175,14 @@ export function ChatListHeader({
           ) : null}
         </View>
 
-        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-          {(
-            [
-              ['recent', t('chat.filter_recent', 'Recent')],
-              ['mentions', t('chat.filter_mentions', 'Mentions')],
-              ['tasks', t('chat.filter_tasks', 'Tasks')],
-            ] as [SortMode, string][]
-          ).map(([mode, label]) => {
-            const selected = sortMode === mode;
-            return (
-              <ScalePressable
-                key={mode}
-                onPress={() => onChangeSortMode(mode)}
-                className={`me-2 rounded-full px-3 py-2 border ${
-                  selected
-                    ? 'bg-[#DDF4EB] border-[#147D6473]'
-                    : 'bg-[#ECF5F0] border-[#DDE8E0]'
-                }`}
-              >
-                <AppText
-                  variant="caption"
-                  className={`font-bold ${selected ? 'text-[#147D64]' : 'text-[#5A7467]'}`}
-                >
-                  {label}
-                </AppText>
-              </ScalePressable>
-            );
-          })}
-          {(
-            [
-              [recentOnly, onToggleRecentOnly, t('chat.recent_only', '7d')],
-              [unreadOnly, onToggleUnreadOnly, t('chat.unread_only', 'Unread')],
-            ] as const
-          ).map(([active, onToggle, label]) => (
-            <ScalePressable
-              key={label}
-              onPress={onToggle}
-              className={`me-2 rounded-full px-3 py-2 border ${
-                active ? 'bg-[#DDF4EB] border-[#147D6473]' : 'bg-[#ECF5F0] border-[#DDE8E0]'
-              }`}
-            >
-              <AppText variant="caption" className={`font-bold ${active ? 'text-[#147D64]' : 'text-[#5A7467]'}`}>
-                {label}
-              </AppText>
-            </ScalePressable>
-          ))}
-        </ScrollView>
+        <FlatList
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          data={filterData}
+          keyExtractor={(item) => item.label}
+          renderItem={renderFilterItem}
+          extraData={sortMode}
+        />
       </View>
 
       {agents.length > 0 ? (
@@ -165,33 +197,14 @@ export function ChatListHeader({
                 : agents.length}
             </AppText>
           </View>
-          <ScrollView
+          <FlatList
             horizontal
             showsHorizontalScrollIndicator={false}
             contentContainerClassName="px-4"
-          >
-            <ScalePressable
-              onPress={() => onSelectAgent(null)}
-              className={`me-2 rounded-full px-3 py-2 border ${
-                selectedAgentId ? 'bg-[#ECF5F0] border-[#DDE8E0]' : 'bg-[#DDF4EB] border-[#147D6473]'
-              }`}
-            >
-              <AppText
-                variant="caption"
-                className={`font-bold ${selectedAgentId ? 'text-[#5A7467]' : 'text-[#147D64]'}`}
-              >
-                {t('chat.all_agents', 'All')}
-              </AppText>
-            </ScalePressable>
-            {agents.map((item) => (
-              <View key={item.id} style={{ marginRight: 8 }}>
-                <AgentPill
-                  agent={item}
-                  onPress={() => onSelectAgent(selectedAgentId === item.id ? null : item.id)}
-                />
-              </View>
-            ))}
-          </ScrollView>
+            keyExtractor={(item) => item.id}
+            data={agentsData}
+            renderItem={renderAgentItem}
+          />
         </View>
       ) : null}
 
@@ -205,4 +218,4 @@ export function ChatListHeader({
       </View>
     </>
   );
-}
+});

--- a/frontend/src/components/chat/RoomPromptRail.tsx
+++ b/frontend/src/components/chat/RoomPromptRail.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Pressable, ScrollView, View } from 'react-native';
+import React, { useCallback, useMemo } from 'react';
+import { Pressable, View, FlatList } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { AppText } from '@/components/AppText';
 
@@ -23,7 +23,7 @@ interface RoomPromptRailProps {
   onContextPress?: (value: string) => void;
 }
 
-export function RoomPromptRail({
+export const RoomPromptRail = React.memo(function RoomPromptRail({
   prompts,
   isStreaming,
   saveLabel,
@@ -37,6 +37,50 @@ export function RoomPromptRail({
   onContextPress,
 }: RoomPromptRailProps) {
   const { t } = useTranslation();
+  const promptHeader = useMemo(() => (
+    <Pressable
+      onPress={onSave}
+      className={`mr-2 rounded-full px-3 py-2 border bg-[#DDF4EB] border-[#147D6455] ${
+        isStreaming || !canSave ? 'opacity-50' : 'opacity-100'
+      }`}
+      disabled={isStreaming || !canSave}
+    >
+      <AppText className="text-xs font-bold text-[#147D64]">{saveLabel}</AppText>
+    </Pressable>
+  ), [onSave, isStreaming, canSave, saveLabel]);
+
+  const renderPromptItem = useCallback(({ item: action }: any) => (
+    <Pressable
+      onPress={() => onPromptPress(action.text)}
+      onLongPress={() => onPromptLongPress(action)}
+      className={`mr-2 rounded-full px-3 py-2 border ${
+        action.pinned
+          ? 'bg-[#DDF4EB] border-[#147D6455] text-[#147D64]'
+          : 'bg-[#ECF5F0] border-[#DDE8E0] text-[#13251C]'
+      } ${isStreaming ? 'opacity-60' : 'opacity-100'}`}
+      disabled={isStreaming}
+    >
+      <AppText
+        className={`text-xs font-bold ${
+          action.pinned ? 'text-[#147D64]' : 'text-[#13251C]'
+        }`}
+      >
+        {action.pinned ? '★ ' : ''}
+        {action.text}
+      </AppText>
+    </Pressable>
+  ), [onPromptPress, onPromptLongPress, isStreaming]);
+
+  const renderContextItem = useCallback(({ item: value }: any) => (
+    <Pressable
+      onPress={() => onContextPress && onContextPress(value)}
+      className="mr-2 rounded-xl px-2.5 py-[7px] bg-[#ECF5F0] border border-[#DDE8E0]"
+    >
+      <AppText variant="caption" className="text-[#5A7467] font-bold">
+        {value}
+      </AppText>
+    </Pressable>
+  ), [onContextPress]);
 
   return (
     <View className="px-3 pb-2">
@@ -52,65 +96,28 @@ export function RoomPromptRail({
           ) : null}
         </View>
 
-        <ScrollView
+        <FlatList
           horizontal
           showsHorizontalScrollIndicator={false}
           contentContainerClassName="px-3"
-        >
-          <Pressable
-            onPress={onSave}
-            className={`mr-2 rounded-full px-3 py-2 border bg-[#DDF4EB] border-[#147D6455] ${
-              isStreaming || !canSave ? 'opacity-50' : 'opacity-100'
-            }`}
-            disabled={isStreaming || !canSave}
-          >
-            <AppText className="text-xs font-bold text-[#147D64]">{saveLabel}</AppText>
-          </Pressable>
-
-          {prompts.map((action) => (
-            <Pressable
-              key={action.id}
-              onPress={() => onPromptPress(action.text)}
-              onLongPress={() => onPromptLongPress(action)}
-              className={`mr-2 rounded-full px-3 py-2 border ${
-                action.pinned
-                  ? 'bg-[#DDF4EB] border-[#147D6455] text-[#147D64]'
-                  : 'bg-[#ECF5F0] border-[#DDE8E0] text-[#13251C]'
-              } ${isStreaming ? 'opacity-60' : 'opacity-100'}`}
-              disabled={isStreaming}
-            >
-              <AppText
-                className={`text-xs font-bold ${
-                  action.pinned ? 'text-[#147D64]' : 'text-[#13251C]'
-                }`}
-              >
-                {action.pinned ? '★ ' : ''}
-                {action.text}
-              </AppText>
-            </Pressable>
-          ))}
-        </ScrollView>
+          data={prompts}
+          keyExtractor={(item) => item.id}
+          ListHeaderComponent={promptHeader}
+          renderItem={renderPromptItem}
+          extraData={isStreaming}
+        />
 
         {contextActions && contextActions.length > 0 && onContextPress ? (
-          <ScrollView
+          <FlatList
             horizontal
             showsHorizontalScrollIndicator={false}
             contentContainerClassName="px-3 pt-2"
-          >
-            {contextActions.map((value) => (
-              <Pressable
-                key={value}
-                onPress={() => onContextPress(value)}
-                className="mr-2 rounded-xl px-2.5 py-[7px] bg-[#ECF5F0] border border-[#DDE8E0]"
-              >
-                <AppText variant="caption" className="text-[#5A7467] font-bold">
-                  {value}
-                </AppText>
-              </Pressable>
-            ))}
-          </ScrollView>
+            data={contextActions}
+            keyExtractor={(item) => item}
+            renderItem={renderContextItem}
+          />
         ) : null}
       </View>
     </View>
   );
-}
+});


### PR DESCRIPTION
This pull request optimizes frontend list rendering performance by migrating `ScrollView` components that were mapping over data arrays to `FlatList` in the chat UI.

**Changes:**
* Refactored `ChatListHeader.tsx` to use `FlatList` for the filter bar and the agents list.
* Refactored `RoomPromptRail.tsx` to use `FlatList` for the prompts and context actions rails.
* Applied strict memoization by wrapping data arrays in `useMemo` and `renderItem` functions in `useCallback`.
* Ensured state-dependent renders update correctly by utilizing the `extraData` prop on `FlatList`s.
* Wrapped both exported components in `React.memo` to prevent unnecessary re-renders from the parent.

---
*PR created automatically by Jules for task [2917629989299587764](https://jules.google.com/task/2917629989299587764) started by @YKDBontekoe*