### PR TITLE
Refactor ProductivityScreen into modular components and hooks

### DIFF
--- a/frontend/app/(main)/productivity.tsx
+++ b/frontend/app/(main)/productivity.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import {
+  ActivityIndicator,
   Alert,
   FlatList,
   RefreshControl,
@@ -200,12 +201,18 @@ export default function ProductivityScreen() {
           />
         }
         ListEmptyComponent={
-          <ProductivityEmptyState
-            activeTab={activeTab}
-            searchQuery={searchQuery}
-            onShowCreateNote={() => setShowCreateNote(true)}
-            onShowCreateTask={() => setShowCreateTask(true)}
-          />
+          isLoading ? (
+            <View style={styles.loadingContainer}>
+              <ActivityIndicator size="large" color={T.primary.DEFAULT} />
+            </View>
+          ) : (
+            <ProductivityEmptyState
+              activeTab={activeTab}
+              searchQuery={searchQuery}
+              onShowCreateNote={() => setShowCreateNote(true)}
+              onShowCreateTask={() => setShowCreateTask(true)}
+            />
+          )
         }
       />
 
@@ -265,5 +272,10 @@ const styles = StyleSheet.create({
     color: T.onSurface.mutedLight,
     marginTop: 2,
     fontSize: 13,
+  },
+  loadingContainer: {
+    paddingVertical: S.massive,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });

--- a/frontend/app/(main)/productivity.tsx
+++ b/frontend/app/(main)/productivity.tsx
@@ -1,12 +1,9 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import {
   Alert,
   FlatList,
-  Platform,
-  Pressable,
   RefreshControl,
   StyleSheet,
-  TextInput,
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -18,10 +15,15 @@ import { CreateNoteModal } from '../../src/components/productivity/CreateNoteMod
 import { CreateTaskModal } from '../../src/components/productivity/CreateTaskModal';
 import { NoteCard } from '../../src/components/productivity/NoteCard';
 import { TaskCard } from '../../src/components/productivity/TaskCard';
+import { ProductivityHeader } from '../../src/components/productivity/ProductivityHeader';
+import { ProductivityTabs } from '../../src/components/productivity/ProductivityTabs';
+import { ProductivityEmptyState } from '../../src/components/productivity/ProductivityEmptyState';
+import { ProductivityTodayPlan } from '../../src/components/productivity/ProductivityTodayPlan';
+import { useProductivityScreen } from '../../src/hooks/useProductivityScreen';
 import { theme } from '../../src/core/theme';
-import { CalendarEvent, Note, Task } from '../../src/core/models';
-import { useProductivityStore } from '../../src/store/useProductivityStore';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
+import type { Note, Task, CalendarEvent } from '../../src/core/models';
+import type { RenderItemData } from '../../src/hooks/useProductivityScreen';
 
 const T = {
   background: { light: DESIGN_TOKENS.colors.pageBg },
@@ -42,16 +44,6 @@ const T = {
 const S = theme.spacing;
 const R = theme.borderRadius;
 
-type Tab = 'today' | 'all' | 'notes' | 'tasks';
-type TaskPriority = 'all' | 'overdue' | 'today' | 'upcoming' | 'no_due';
-
-type RenderItemData = {
-  date?: number;
-  type: 'note' | 'task' | 'event';
-  item: Note | Task | CalendarEvent;
-  id: string;
-};
-
 export default function ProductivityScreen() {
   const { t, i18n } = useTranslation();
   const router = useRouter();
@@ -59,35 +51,32 @@ export default function ProductivityScreen() {
   const params = useLocalSearchParams() as Record<string, string | string[] | undefined>;
   const openCreateTask = params.openCreateTask;
   const openCreateNote = params.openCreateNote;
-  const [activeTab, setActiveTab] = useState<Tab>('today');
-  const [taskPriority, setTaskPriority] = useState<TaskPriority>('all');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [showCreateNote, setShowCreateNote] = useState(false);
-  const [showCreateTask, setShowCreateTask] = useState(false);
-  const [todayPlan, setTodayPlan] = useState<string | null>(null);
 
   const {
-    notes,
-    tasks,
-    events,
-    fetchNotes,
-    fetchTasks,
-    fetchEvents,
+    activeTab,
+    setActiveTab,
+    taskPriority,
+    setTaskPriority,
+    searchQuery,
+    setSearchQuery,
+    showCreateNote,
+    setShowCreateNote,
+    showCreateTask,
+    setShowCreateTask,
+    todayPlan,
+    setTodayPlan,
+    dataToRender,
     isLoading,
+    handleRefresh,
+    pendingTasksCount,
+    taskPriorityCounts,
+    generateTodayPlan,
     deleteNote,
     deleteTask,
     toggleTask,
-  } = useProductivityStore();
-
-  useEffect(() => {
-    const controller = new AbortController();
-    fetchNotes(controller.signal);
-    fetchTasks(controller.signal);
-    fetchEvents(controller.signal);
-    return () => {
-      controller.abort();
-    };
-  }, [fetchEvents, fetchNotes, fetchTasks]);
+    fetchNotes,
+    fetchTasks,
+  } = useProductivityScreen();
 
   useEffect(() => {
     if (openCreateTask === '1' || openCreateTask === 'true') {
@@ -99,7 +88,7 @@ export default function ProductivityScreen() {
       );
       router.replace({ pathname, params: nextParams });
     }
-  }, [openCreateTask, params, pathname, router]);
+  }, [openCreateTask, params, pathname, router, setShowCreateTask]);
 
   useEffect(() => {
     if (openCreateNote === '1' || openCreateNote === 'true') {
@@ -111,13 +100,7 @@ export default function ProductivityScreen() {
       );
       router.replace({ pathname, params: nextParams });
     }
-  }, [openCreateNote, params, pathname, router]);
-
-  const handleRefresh = useCallback(() => {
-    fetchNotes();
-    fetchTasks();
-    fetchEvents();
-  }, [fetchEvents, fetchNotes, fetchTasks]);
+  }, [openCreateNote, params, pathname, router, setShowCreateNote]);
 
   const confirmDelete = useCallback(
     (action: () => Promise<void>) =>
@@ -135,206 +118,6 @@ export default function ProductivityScreen() {
       ),
     [t]
   );
-
-  const filteredNotes = useMemo(() => {
-    if (!searchQuery) return notes;
-    const lowerQ = searchQuery.toLowerCase();
-    return notes.filter(
-      (n) => n.title.toLowerCase().includes(lowerQ) || n.content.toLowerCase().includes(lowerQ)
-    );
-  }, [notes, searchQuery]);
-
-  const filteredTasks = useMemo(() => {
-    if (!searchQuery) return tasks;
-    const lowerQ = searchQuery.toLowerCase();
-    return tasks.filter(
-      (task) =>
-        task.title.toLowerCase().includes(lowerQ) ||
-        (task.description?.toLowerCase().includes(lowerQ) ?? false)
-    );
-  }, [searchQuery, tasks]);
-
-  const filteredEvents = useMemo(() => {
-    if (!searchQuery) return events;
-    const lowerQ = searchQuery.toLowerCase();
-    return events.filter(
-      (event) =>
-        event.title.toLowerCase().includes(lowerQ) ||
-        (event.description?.toLowerCase().includes(lowerQ) ?? false) ||
-        (event.location?.toLowerCase().includes(lowerQ) ?? false)
-    );
-  }, [events, searchQuery]);
-
-  const pendingTasksCount = useMemo(
-    () => filteredTasks.filter((task) => !task.completed).length,
-    [filteredTasks]
-  );
-
-  const getTaskPriority = useCallback((task: Task): Exclude<TaskPriority, 'all'> => {
-    if (!task.due_date) return 'no_due';
-    const now = new Date();
-    const due = new Date(task.due_date);
-    if (isNaN(due.getTime())) return 'no_due';
-    const dayStart = new Date(now);
-    dayStart.setHours(0, 0, 0, 0);
-    const tomorrow = new Date(dayStart);
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    if (due < dayStart) return 'overdue';
-    if (due >= dayStart && due < tomorrow) return 'today';
-    return 'upcoming';
-  }, []);
-
-  const taskPriorityCounts = useMemo(() => {
-    const counts: Record<TaskPriority, number> = {
-      all: 0,
-      overdue: 0,
-      today: 0,
-      upcoming: 0,
-      no_due: 0,
-    };
-    filteredTasks
-      .filter((task) => !task.completed)
-      .forEach((task) => {
-        counts.all += 1;
-        counts[getTaskPriority(task)] += 1;
-      });
-    return counts;
-  }, [filteredTasks, getTaskPriority]);
-
-  const prioritizedTasks = useMemo(() => {
-    const tasksToRank = filteredTasks.filter((task) => !task.completed);
-    const pool =
-      taskPriority === 'all'
-        ? tasksToRank
-        : tasksToRank.filter((task) => getTaskPriority(task) === taskPriority);
-    return [...pool].sort((a, b) => {
-      const aDue = a.due_date ? new Date(a.due_date).getTime() : Number.MAX_SAFE_INTEGER;
-      const bDue = b.due_date ? new Date(b.due_date).getTime() : Number.MAX_SAFE_INTEGER;
-      return aDue - bDue;
-    });
-  }, [filteredTasks, getTaskPriority, taskPriority]);
-
-  const mixedData = useMemo(() => {
-    const data: RenderItemData[] = [];
-    filteredNotes.forEach((note) => {
-      data.push({
-        type: 'note',
-        item: note,
-        id: `note-${note.id}`,
-        date: new Date(note.created_at).getTime(),
-      });
-    });
-    filteredTasks.forEach((task) => {
-      data.push({
-        type: 'task',
-        item: task,
-        id: `task-${task.id}`,
-        date: new Date(task.created_at).getTime(),
-      });
-    });
-    return data.sort((a, b) => (b.date || 0) - (a.date || 0));
-  }, [filteredNotes, filteredTasks]);
-
-  const todayData = useMemo(() => {
-    const now = new Date();
-    const start = new Date(now);
-    start.setHours(0, 0, 0, 0);
-    const end = new Date(start);
-    end.setDate(end.getDate() + 1);
-    const weekEnd = new Date(start);
-    weekEnd.setDate(weekEnd.getDate() + 7);
-
-    const overdueTasks = filteredTasks.filter((task) => {
-      if (task.completed || !task.due_date) return false;
-      return new Date(task.due_date) < start;
-    });
-
-    const dueTodayTasks = filteredTasks.filter((task) => {
-      if (task.completed || !task.due_date) return false;
-      const dueDate = new Date(task.due_date);
-      return dueDate >= start && dueDate < end;
-    });
-
-    const upcomingEvents = filteredEvents.filter((event) => {
-      const startTime = new Date(event.start_time);
-      return startTime >= start && startTime < weekEnd;
-    });
-
-    const items: RenderItemData[] = [
-      ...overdueTasks.map((task) => ({
-        type: 'task' as const,
-        item: task,
-        id: `overdue-${task.id}`,
-        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
-      })),
-      ...dueTodayTasks.map((task) => ({
-        type: 'task' as const,
-        item: task,
-        id: `today-${task.id}`,
-        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
-      })),
-      ...upcomingEvents.map((event) => ({
-        type: 'event' as const,
-        item: event,
-        id: `event-${event.id}`,
-        date: new Date(event.start_time).getTime(),
-      })),
-    ];
-
-    return items.sort((a, b) => (a.date || 0) - (b.date || 0));
-  }, [filteredEvents, filteredTasks]);
-
-  const dataToRender: RenderItemData[] =
-    activeTab === 'today'
-      ? todayData.filter((entry) => {
-          if (entry.type !== 'task') return true;
-          if (taskPriority === 'all') return true;
-          return getTaskPriority(entry.item as Task) === taskPriority;
-        })
-      : activeTab === 'all'
-        ? mixedData
-        : activeTab === 'notes'
-          ? filteredNotes.map((note) => ({ type: 'note' as const, item: note, id: note.id }))
-          : prioritizedTasks.map((task) => ({ type: 'task' as const, item: task, id: task.id }));
-
-  const generateTodayPlan = useCallback(() => {
-    const now = new Date();
-    const nextTasks = prioritizedTasks.slice(0, 3);
-    const nextEvents = [...filteredEvents]
-      .filter((event) => new Date(event.end_time) >= now)
-      .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime())
-      .slice(0, 3);
-
-    const lines: string[] = [];
-    if (taskPriorityCounts.overdue > 0) {
-      lines.push(`1) Recover overdue: start with ${taskPriorityCounts.overdue} overdue task(s).`);
-    } else {
-      lines.push('1) No overdue tasks: start with highest-impact open work.');
-    }
-
-    if (nextTasks.length > 0) {
-      lines.push(`2) Focus block: ${nextTasks.map((task) => task.title).join(', ')}.`);
-    } else {
-      lines.push('2) Focus block: no pending tasks, use this for planning or review.');
-    }
-
-    if (nextEvents.length > 0) {
-      const eventLine = nextEvents
-        .map((event) =>
-          new Intl.DateTimeFormat(i18n.language, {
-            hour: '2-digit',
-            minute: '2-digit',
-          }).format(new Date(event.start_time))
-        )
-        .join(', ');
-      lines.push(`3) Calendar checkpoints at ${eventLine}.`);
-    } else {
-      lines.push('3) Calendar is light: reserve time for deep work and wrap-up.');
-    }
-
-    setTodayPlan(lines.join('\n'));
-    setActiveTab('today');
-  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue]);
 
   const renderItem = useCallback(
     ({ item }: { item: RenderItemData }) => {
@@ -379,145 +162,22 @@ export default function ProductivityScreen() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.headerContainer}>
-        <View style={styles.headerRow}>
-          <View>
-            <AppText variant="h1" style={styles.headerTitle}>
-              {t('productivity.title') || 'Workspace'}
-            </AppText>
-            <AppText style={styles.headerSubtitle}>
-              {pendingTasksCount === 0
-                ? t('productivity.header.subtitle.empty') || "You're all caught up for today."
-                : t('productivity.header.subtitle.pending', { count: pendingTasksCount }) ||
-                  `You have ${pendingTasksCount} tasks pending.`}
-            </AppText>
-          </View>
+      <ProductivityHeader
+        pendingTasksCount={pendingTasksCount}
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        onGeneratePlan={generateTodayPlan}
+        onShowCreateNote={() => setShowCreateNote(true)}
+        onShowCreateTask={() => setShowCreateTask(true)}
+      />
 
-          <View style={styles.headerActions}>
-            <Pressable
-              onPress={generateTodayPlan}
-              style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
-            >
-              <Ionicons name="sparkles" size={20} color={T.primary.DEFAULT} />
-            </Pressable>
-            <Pressable
-              onPress={() => setShowCreateNote(true)}
-              style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
-            >
-              <Ionicons name="document-text" size={20} color={T.primary.DEFAULT} />
-            </Pressable>
-            <Pressable
-              onPress={() => setShowCreateTask(true)}
-              style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
-            >
-              <Ionicons name="checkbox" size={20} color={T.primary.DEFAULT} />
-            </Pressable>
-          </View>
-        </View>
-
-        <View style={styles.searchContainer}>
-          <Ionicons
-            name="search"
-            size={18}
-            color={T.onSurface.mutedLight}
-            style={styles.searchIcon}
-          />
-          <TextInput
-            value={searchQuery}
-            onChangeText={setSearchQuery}
-            placeholder={t('productivity.search') || 'Search notes & tasks...'}
-            placeholderTextColor={T.onSurface.disabledLight}
-            style={styles.searchInput}
-            clearButtonMode="while-editing"
-          />
-        </View>
-      </View>
-
-      <View style={styles.tabsContainer}>
-        {(['today', 'all', 'notes', 'tasks'] as const).map((tab) => (
-          <Pressable
-            key={tab}
-            onPress={() => setActiveTab(tab)}
-            style={({ pressed }) => [
-              styles.tabButton,
-              activeTab === tab && styles.tabButtonActive,
-              pressed && activeTab !== tab && { opacity: 0.6 },
-            ]}
-          >
-            <AppText style={[styles.tabText, activeTab === tab && styles.tabTextActive]}>
-              {tab === 'today'
-                ? t('productivity.today')
-                : tab === 'all'
-                  ? t('productivity.all') || 'All'
-                  : tab === 'notes'
-                    ? t('productivity.notes') || 'Notes'
-                    : t('productivity.tasks') || 'Tasks'}
-            </AppText>
-          </Pressable>
-        ))}
-      </View>
-
-      {(activeTab === 'tasks' || activeTab === 'today') && (
-        <View
-          style={{
-            flexDirection: 'row',
-            flexWrap: 'wrap',
-            marginHorizontal: S.xl,
-            marginBottom: S.sm,
-          }}
-        >
-          {(
-            [
-              { key: 'all', label: t('productivity.priority.all', { count: taskPriorityCounts.all }) },
-              {
-                key: 'overdue',
-                label: t('productivity.priority.overdue', { count: taskPriorityCounts.overdue }),
-              },
-              {
-                key: 'today',
-                label: t('productivity.priority.today', { count: taskPriorityCounts.today }),
-              },
-              {
-                key: 'upcoming',
-                label: t('productivity.priority.upcoming', { count: taskPriorityCounts.upcoming }),
-              },
-              {
-                key: 'no_due',
-                label: t('productivity.priority.no_due', { count: taskPriorityCounts.no_due }),
-              },
-            ] as const
-          ).map((option) => (
-            <Pressable
-              key={option.key}
-              onPress={() => setTaskPriority(option.key)}
-              style={({ pressed }) => [
-                {
-                  borderRadius: 12,
-                  borderWidth: 1,
-                  borderColor: taskPriority === option.key ? T.primary.DEFAULT : T.border.light,
-                  backgroundColor:
-                    taskPriority === option.key ? T.primary.surfaceLight : T.surface.light,
-                  paddingHorizontal: 10,
-                  paddingVertical: 6,
-                  marginRight: 8,
-                  marginBottom: 8,
-                },
-                pressed && { opacity: 0.8 },
-              ]}
-            >
-              <AppText
-                variant="caption"
-                style={{
-                  color: taskPriority === option.key ? T.primary.DEFAULT : T.onSurface.mutedLight,
-                  fontWeight: '700',
-                }}
-              >
-                {option.label}
-              </AppText>
-            </Pressable>
-          ))}
-        </View>
-      )}
+      <ProductivityTabs
+        activeTab={activeTab}
+        setActiveTab={setActiveTab}
+        taskPriority={taskPriority}
+        setTaskPriority={setTaskPriority}
+        taskPriorityCounts={taskPriorityCounts}
+      />
 
       <FlatList
         data={dataToRender}
@@ -533,118 +193,19 @@ export default function ProductivityScreen() {
         }
         renderItem={renderItem}
         ListHeaderComponent={
-          activeTab === 'today' && todayPlan ? (
-            <View
-              style={{
-                borderRadius: R.xl,
-                backgroundColor: T.primary.surfaceLight,
-                borderWidth: 1,
-                borderColor: T.border.light,
-                padding: S.lg,
-                marginBottom: S.md,
-              }}
-            >
-              <View
-                style={{
-                  flexDirection: 'row',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                }}
-              >
-                <AppText style={{ color: T.onSurface.light, fontWeight: '700', fontSize: 15 }}>
-                  Today plan
-                </AppText>
-                <Pressable onPress={() => setTodayPlan(null)}>
-                  <Ionicons name="close" size={16} color={T.onSurface.mutedLight} />
-                </Pressable>
-              </View>
-              <AppText style={{ color: T.onSurface.mutedLight, marginTop: 8, lineHeight: 20 }}>
-                {todayPlan}
-              </AppText>
-            </View>
-          ) : null
+          <ProductivityTodayPlan
+            activeTab={activeTab}
+            todayPlan={todayPlan}
+            onClose={() => setTodayPlan(null)}
+          />
         }
         ListEmptyComponent={
-          <View style={styles.emptyContainer}>
-            <View style={styles.emptyIconCircle}>
-              <Ionicons
-                name={
-                  activeTab === 'notes'
-                    ? 'document-text'
-                    : activeTab === 'tasks'
-                      ? 'checkbox'
-                      : activeTab === 'today'
-                        ? 'sunny-outline'
-                        : 'planet'
-                }
-                size={42}
-                color={T.primary.DEFAULT}
-              />
-            </View>
-            <AppText variant="h3" style={styles.emptyTitle}>
-              {searchQuery
-                ? t('productivity.no_matches') || 'No matches found'
-                : activeTab === 'notes'
-                  ? t('productivity.no_notes') || 'No Notes'
-                  : activeTab === 'tasks'
-                    ? t('productivity.no_tasks') || 'No Tasks'
-                    : activeTab === 'today'
-                      ? t('productivity.nothing_urgent_today')
-                      : t('productivity.workspace_clear') || 'Your workspace is clear'}
-            </AppText>
-            <AppText style={styles.emptySubtitle}>
-              {searchQuery
-                ? t('productivity.try_adjust_search') || 'Try adjusting your search terms.'
-                : activeTab === 'today'
-                  ? t('productivity.today_empty_detail')
-                  : t('productivity.capture_thoughts') ||
-                    'Capture your thoughts and track what needs to get done.'}
-            </AppText>
-
-            {!searchQuery && (
-              <View style={styles.emptyActions}>
-                {(activeTab === 'all' || activeTab === 'notes') && (
-                  <Pressable
-                    onPress={() => setShowCreateNote(true)}
-                    style={({ pressed }) => [styles.emptyButton, pressed && { opacity: 0.8 }]}
-                  >
-                    <Ionicons name="add" size={18} color={T.white} style={{ marginEnd: 6 }} />
-                    <AppText style={styles.emptyButtonText}>
-                      {t('productivity.newNote') || 'New Note'}
-                    </AppText>
-                  </Pressable>
-                )}
-                {(activeTab === 'all' || activeTab === 'tasks' || activeTab === 'today') && (
-                  <Pressable
-                    onPress={() => setShowCreateTask(true)}
-                    style={({ pressed }) => [
-                      styles.emptyButton,
-                      (activeTab === 'all' || activeTab === 'today') && styles.emptyButtonSecondary,
-                      pressed && { opacity: 0.8 },
-                    ]}
-                  >
-                    <Ionicons
-                      name="add"
-                      size={18}
-                      color={
-                        activeTab === 'all' || activeTab === 'today' ? T.primary.DEFAULT : T.white
-                      }
-                      style={{ marginEnd: 6 }}
-                    />
-                    <AppText
-                      style={
-                        activeTab === 'all' || activeTab === 'today'
-                          ? styles.emptyButtonTextSecondary
-                          : styles.emptyButtonText
-                      }
-                    >
-                      {t('productivity.new_task')}
-                    </AppText>
-                  </Pressable>
-                )}
-              </View>
-            )}
-          </View>
+          <ProductivityEmptyState
+            activeTab={activeTab}
+            searchQuery={searchQuery}
+            onShowCreateNote={() => setShowCreateNote(true)}
+            onShowCreateTask={() => setShowCreateTask(true)}
+          />
         }
       />
 
@@ -666,93 +227,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: T.background.light,
-  },
-  headerContainer: {
-    paddingHorizontal: S.xl,
-    paddingTop: S.md,
-    paddingBottom: S.lg,
-    backgroundColor: T.surface.light,
-    ...theme.elevation.sm,
-    zIndex: 10,
-  },
-  headerRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: S.lg,
-  },
-  headerTitle: {
-    color: T.onSurface.light,
-    fontSize: 28,
-    fontWeight: '800',
-    letterSpacing: -0.5,
-  },
-  headerSubtitle: {
-    color: T.onSurface.mutedLight,
-    fontSize: 14,
-    marginTop: S.xs,
-  },
-  headerActions: {
-    flexDirection: 'row',
-    gap: S.sm,
-  },
-  iconButton: {
-    width: 40,
-    height: 40,
-    borderRadius: R.full,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  searchContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.background.light,
-    borderRadius: R.lg,
-    paddingHorizontal: S.md,
-    height: 44,
-    borderWidth: 1,
-    borderColor: T.border.light,
-  },
-  searchIcon: {
-    marginRight: S.sm,
-  },
-  searchInput: {
-    flex: 1,
-    color: T.onSurface.light,
-    fontSize: 16,
-    height: '100%',
-  },
-  tabsContainer: {
-    flexDirection: 'row',
-    backgroundColor: T.surface.highLight,
-    borderRadius: R.xl,
-    padding: S.xs,
-    marginHorizontal: S.xl,
-    marginTop: S.lg,
-    marginBottom: S.md,
-    borderWidth: 1,
-    borderColor: T.border.light,
-  },
-  tabButton: {
-    flex: 1,
-    paddingVertical: S.sm,
-    alignItems: 'center',
-    borderRadius: R.lg,
-    backgroundColor: T.transparent,
-  },
-  tabButtonActive: {
-    backgroundColor: T.surface.light,
-    ...theme.elevation.sm,
-  },
-  tabText: {
-    fontSize: 14,
-    fontWeight: '500',
-    color: T.onSurface.mutedLight,
-  },
-  tabTextActive: {
-    fontWeight: '700',
-    color: T.onSurface.light,
   },
   listContent: {
     paddingHorizontal: S.xl,
@@ -791,68 +265,5 @@ const styles = StyleSheet.create({
     color: T.onSurface.mutedLight,
     marginTop: 2,
     fontSize: 13,
-  },
-  emptyContainer: {
-    alignItems: 'center',
-    paddingVertical: S.massive,
-  },
-  emptyIconCircle: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: S.lg,
-  },
-  emptyTitle: {
-    marginBottom: S.sm,
-    textAlign: 'center',
-    color: T.onSurface.light,
-  },
-  emptySubtitle: {
-    textAlign: 'center',
-    marginBottom: S.xl,
-    color: T.onSurface.mutedLight,
-    paddingHorizontal: S.xxxl,
-    lineHeight: 22,
-  },
-  emptyActions: {
-    flexDirection: 'row',
-    gap: S.md,
-  },
-  emptyButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.primary.DEFAULT,
-    borderRadius: R.xl,
-    paddingVertical: S.md,
-    paddingHorizontal: S.xl,
-    ...theme.elevation.md,
-  },
-  emptyButtonSecondary: {
-    backgroundColor: T.primary.surfaceLight,
-    ...Platform.select({
-      ios: {
-        shadowOpacity: 0,
-        elevation: 0,
-      },
-      android: {
-        elevation: 0,
-      },
-      default: {
-        elevation: 0,
-      },
-    }),
-  },
-  emptyButtonText: {
-    color: T.white,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-  emptyButtonTextSecondary: {
-    color: T.primary.DEFAULT,
-    fontWeight: '700',
-    fontSize: 15,
   },
 });

--- a/frontend/src/components/productivity/ProductivityEmptyState.tsx
+++ b/frontend/src/components/productivity/ProductivityEmptyState.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { View, StyleSheet, Pressable, Platform } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import { AppText } from '../AppText';
+import { theme } from '../../core/theme';
+import { DESIGN_TOKENS } from '@/core/design/tokens';
+import type { Tab } from './ProductivityTabs';
+
+const S = theme.spacing;
+const R = theme.borderRadius;
+
+const T = {
+  background: { light: DESIGN_TOKENS.colors.pageBg },
+  surface: { light: DESIGN_TOKENS.colors.surface, highLight: DESIGN_TOKENS.colors.surfaceSoft },
+  border: { light: DESIGN_TOKENS.colors.border },
+  onSurface: {
+    light: DESIGN_TOKENS.colors.text,
+    mutedLight: DESIGN_TOKENS.colors.muted,
+    disabledLight: DESIGN_TOKENS.colors.faint,
+  },
+  primary: {
+    DEFAULT: DESIGN_TOKENS.colors.primary,
+    surfaceLight: DESIGN_TOKENS.colors.primarySoft,
+  },
+  white: '#FFFFFF',
+  transparent: 'transparent',
+};
+
+interface Props {
+  activeTab: Tab;
+  searchQuery: string;
+  onShowCreateNote: () => void;
+  onShowCreateTask: () => void;
+}
+
+export const ProductivityEmptyState = React.memo(({
+  activeTab,
+  searchQuery,
+  onShowCreateNote,
+  onShowCreateTask,
+}: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <View style={styles.emptyContainer}>
+      <View style={styles.emptyIconCircle}>
+        <Ionicons
+          name={
+            activeTab === 'notes'
+              ? 'document-text'
+              : activeTab === 'tasks'
+                ? 'checkbox'
+                : activeTab === 'today'
+                  ? 'sunny-outline'
+                  : 'planet'
+          }
+          size={42}
+          color={T.primary.DEFAULT}
+        />
+      </View>
+      <AppText variant="h3" style={styles.emptyTitle}>
+        {searchQuery
+          ? t('productivity.no_matches') || 'No matches found'
+          : activeTab === 'notes'
+            ? t('productivity.no_notes') || 'No Notes'
+            : activeTab === 'tasks'
+              ? t('productivity.no_tasks') || 'No Tasks'
+              : activeTab === 'today'
+                ? t('productivity.nothing_urgent_today') || 'Nothing urgent today'
+                : t('productivity.workspace_clear') || 'Your workspace is clear'}
+      </AppText>
+      <AppText style={styles.emptySubtitle}>
+        {searchQuery
+          ? t('productivity.try_adjust_search') || 'Try adjusting your search terms.'
+          : activeTab === 'today'
+            ? t('productivity.today_empty_detail') || 'Enjoy the rest of your day!'
+            : t('productivity.capture_thoughts') ||
+              'Capture your thoughts and track what needs to get done.'}
+      </AppText>
+
+      {!searchQuery && (
+        <View style={styles.emptyActions}>
+          {(activeTab === 'all' || activeTab === 'notes') && (
+            <Pressable
+              onPress={onShowCreateNote}
+              style={({ pressed }) => [styles.emptyButton, pressed && { opacity: 0.8 }]}
+            >
+              <Ionicons name="add" size={18} color={T.white} style={{ marginEnd: 6 }} />
+              <AppText style={styles.emptyButtonText}>
+                {t('productivity.newNote') || 'New Note'}
+              </AppText>
+            </Pressable>
+          )}
+          {(activeTab === 'all' || activeTab === 'tasks' || activeTab === 'today') && (
+            <Pressable
+              onPress={onShowCreateTask}
+              style={({ pressed }) => [
+                styles.emptyButton,
+                (activeTab === 'all' || activeTab === 'today') && styles.emptyButtonSecondary,
+                pressed && { opacity: 0.8 },
+              ]}
+            >
+              <Ionicons
+                name="add"
+                size={18}
+                color={
+                  activeTab === 'all' || activeTab === 'today' ? T.primary.DEFAULT : T.white
+                }
+                style={{ marginEnd: 6 }}
+              />
+              <AppText
+                style={
+                  activeTab === 'all' || activeTab === 'today'
+                    ? styles.emptyButtonTextSecondary
+                    : styles.emptyButtonText
+                }
+              >
+                {t('productivity.new_task') || 'New Task'}
+              </AppText>
+            </Pressable>
+          )}
+        </View>
+      )}
+    </View>
+  );
+});
+
+ProductivityEmptyState.displayName = 'ProductivityEmptyState';
+
+const styles = StyleSheet.create({
+  emptyContainer: {
+    alignItems: 'center',
+    paddingVertical: S.massive,
+  },
+  emptyIconCircle: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: T.primary.surfaceLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: S.lg,
+  },
+  emptyTitle: {
+    marginBottom: S.sm,
+    textAlign: 'center',
+    color: T.onSurface.light,
+  },
+  emptySubtitle: {
+    textAlign: 'center',
+    marginBottom: S.xl,
+    color: T.onSurface.mutedLight,
+    paddingHorizontal: S.xxxl,
+    lineHeight: 22,
+  },
+  emptyActions: {
+    flexDirection: 'row',
+    gap: S.md,
+  },
+  emptyButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: T.primary.DEFAULT,
+    borderRadius: R.xl,
+    paddingVertical: S.md,
+    paddingHorizontal: S.xl,
+    ...theme.elevation.md,
+  },
+  emptyButtonSecondary: {
+    backgroundColor: T.primary.surfaceLight,
+    ...Platform.select({
+      ios: {
+        shadowOpacity: 0,
+        elevation: 0,
+      },
+      android: {
+        elevation: 0,
+      },
+      default: {
+        elevation: 0,
+      },
+    }),
+  },
+  emptyButtonText: {
+    color: T.white,
+    fontWeight: '700',
+    fontSize: 15,
+  },
+  emptyButtonTextSecondary: {
+    color: T.primary.DEFAULT,
+    fontWeight: '700',
+    fontSize: 15,
+  },
+});

--- a/frontend/src/components/productivity/ProductivityEmptyState.tsx
+++ b/frontend/src/components/productivity/ProductivityEmptyState.tsx
@@ -1,30 +1,16 @@
 import React from 'react';
-import { View, StyleSheet, Pressable, Platform } from 'react-native';
+import { View, Pressable, Platform, PressableStateCallbackType } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import { AppText } from '../AppText';
-import { theme } from '../../core/theme';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
 import type { Tab } from './ProductivityTabs';
 
-const S = theme.spacing;
-const R = theme.borderRadius;
-
 const T = {
-  background: { light: DESIGN_TOKENS.colors.pageBg },
-  surface: { light: DESIGN_TOKENS.colors.surface, highLight: DESIGN_TOKENS.colors.surfaceSoft },
-  border: { light: DESIGN_TOKENS.colors.border },
-  onSurface: {
-    light: DESIGN_TOKENS.colors.text,
-    mutedLight: DESIGN_TOKENS.colors.muted,
-    disabledLight: DESIGN_TOKENS.colors.faint,
-  },
+  white: '#FFFFFF',
   primary: {
     DEFAULT: DESIGN_TOKENS.colors.primary,
-    surfaceLight: DESIGN_TOKENS.colors.primarySoft,
   },
-  white: '#FFFFFF',
-  transparent: 'transparent',
 };
 
 interface Props {
@@ -43,8 +29,8 @@ export const ProductivityEmptyState = React.memo(({
   const { t } = useTranslation();
 
   return (
-    <View style={styles.emptyContainer}>
-      <View style={styles.emptyIconCircle}>
+    <View className="items-center py-20">
+      <View className="w-20 h-20 rounded-full bg-primary/10 items-center justify-center mb-4">
         <Ionicons
           name={
             activeTab === 'notes'
@@ -59,7 +45,7 @@ export const ProductivityEmptyState = React.memo(({
           color={T.primary.DEFAULT}
         />
       </View>
-      <AppText variant="h3" style={styles.emptyTitle}>
+      <AppText variant="h3" className="mb-2 text-center text-text">
         {searchQuery
           ? t('productivity.no_matches') || 'No matches found'
           : activeTab === 'notes'
@@ -70,7 +56,7 @@ export const ProductivityEmptyState = React.memo(({
                 ? t('productivity.nothing_urgent_today') || 'Nothing urgent today'
                 : t('productivity.workspace_clear') || 'Your workspace is clear'}
       </AppText>
-      <AppText style={styles.emptySubtitle}>
+      <AppText className="text-center mb-6 text-muted px-12 leading-relaxed">
         {searchQuery
           ? t('productivity.try_adjust_search') || 'Try adjusting your search terms.'
           : activeTab === 'today'
@@ -80,14 +66,17 @@ export const ProductivityEmptyState = React.memo(({
       </AppText>
 
       {!searchQuery && (
-        <View style={styles.emptyActions}>
+        <View className="flex-row gap-4">
           {(activeTab === 'all' || activeTab === 'notes') && (
             <Pressable
               onPress={onShowCreateNote}
-              style={({ pressed }) => [styles.emptyButton, pressed && { opacity: 0.8 }]}
+              style={({ pressed }: PressableStateCallbackType) => [
+                pressed ? { opacity: 0.8 } : undefined
+              ]}
+              className="flex-row items-center bg-primary rounded-xl py-3 px-6 shadow-md"
             >
               <Ionicons name="add" size={18} color={T.white} style={{ marginEnd: 6 }} />
-              <AppText style={styles.emptyButtonText}>
+              <AppText className="text-white font-bold text-[15px]">
                 {t('productivity.newNote') || 'New Note'}
               </AppText>
             </Pressable>
@@ -95,11 +84,15 @@ export const ProductivityEmptyState = React.memo(({
           {(activeTab === 'all' || activeTab === 'tasks' || activeTab === 'today') && (
             <Pressable
               onPress={onShowCreateTask}
-              style={({ pressed }) => [
-                styles.emptyButton,
-                (activeTab === 'all' || activeTab === 'today') && styles.emptyButtonSecondary,
-                pressed && { opacity: 0.8 },
+              style={({ pressed }: PressableStateCallbackType) => [
+                (activeTab === 'all' || activeTab === 'today') && Platform.OS !== 'web'
+                  ? { shadowOpacity: 0, elevation: 0 }
+                  : undefined,
+                pressed ? { opacity: 0.8 } : undefined
               ]}
+              className={`flex-row items-center rounded-xl py-3 px-6 shadow-md ${
+                activeTab === 'all' || activeTab === 'today' ? 'bg-primary/10 shadow-none' : 'bg-primary'
+              }`}
             >
               <Ionicons
                 name="add"
@@ -110,11 +103,11 @@ export const ProductivityEmptyState = React.memo(({
                 style={{ marginEnd: 6 }}
               />
               <AppText
-                style={
+                className={`font-bold text-[15px] ${
                   activeTab === 'all' || activeTab === 'today'
-                    ? styles.emptyButtonTextSecondary
-                    : styles.emptyButtonText
-                }
+                    ? 'text-primary'
+                    : 'text-white'
+                }`}
               >
                 {t('productivity.new_task') || 'New Task'}
               </AppText>
@@ -127,69 +120,3 @@ export const ProductivityEmptyState = React.memo(({
 });
 
 ProductivityEmptyState.displayName = 'ProductivityEmptyState';
-
-const styles = StyleSheet.create({
-  emptyContainer: {
-    alignItems: 'center',
-    paddingVertical: S.massive,
-  },
-  emptyIconCircle: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: S.lg,
-  },
-  emptyTitle: {
-    marginBottom: S.sm,
-    textAlign: 'center',
-    color: T.onSurface.light,
-  },
-  emptySubtitle: {
-    textAlign: 'center',
-    marginBottom: S.xl,
-    color: T.onSurface.mutedLight,
-    paddingHorizontal: S.xxxl,
-    lineHeight: 22,
-  },
-  emptyActions: {
-    flexDirection: 'row',
-    gap: S.md,
-  },
-  emptyButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.primary.DEFAULT,
-    borderRadius: R.xl,
-    paddingVertical: S.md,
-    paddingHorizontal: S.xl,
-    ...theme.elevation.md,
-  },
-  emptyButtonSecondary: {
-    backgroundColor: T.primary.surfaceLight,
-    ...Platform.select({
-      ios: {
-        shadowOpacity: 0,
-        elevation: 0,
-      },
-      android: {
-        elevation: 0,
-      },
-      default: {
-        elevation: 0,
-      },
-    }),
-  },
-  emptyButtonText: {
-    color: T.white,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-  emptyButtonTextSecondary: {
-    color: T.primary.DEFAULT,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-});

--- a/frontend/src/components/productivity/ProductivityHeader.tsx
+++ b/frontend/src/components/productivity/ProductivityHeader.tsx
@@ -1,29 +1,18 @@
-import React from 'react';
-import { View, StyleSheet, Pressable, TextInput } from 'react-native';
+import React, { useState, useEffect, useRef } from 'react';
+import { View, Pressable, TextInput, PressableStateCallbackType } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import { AppText } from '../AppText';
-import { theme } from '../../core/theme';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
 
-const S = theme.spacing;
-const R = theme.borderRadius;
-
 const T = {
-  background: { light: DESIGN_TOKENS.colors.pageBg },
-  surface: { light: DESIGN_TOKENS.colors.surface, highLight: DESIGN_TOKENS.colors.surfaceSoft },
-  border: { light: DESIGN_TOKENS.colors.border },
   onSurface: {
-    light: DESIGN_TOKENS.colors.text,
     mutedLight: DESIGN_TOKENS.colors.muted,
     disabledLight: DESIGN_TOKENS.colors.faint,
   },
   primary: {
     DEFAULT: DESIGN_TOKENS.colors.primary,
-    surfaceLight: DESIGN_TOKENS.colors.primarySoft,
   },
-  white: '#FFFFFF',
-  transparent: 'transparent',
 };
 
 interface Props {
@@ -44,15 +33,33 @@ export const ProductivityHeader = React.memo(({
   onShowCreateTask,
 }: Props) => {
   const { t } = useTranslation();
+  const [localSearch, setLocalSearch] = useState(searchQuery);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = setTimeout(() => {
+      setSearchQuery(localSearch);
+    }, 300);
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [localSearch, setSearchQuery]);
+
+  useEffect(() => {
+    setLocalSearch(searchQuery);
+  }, [searchQuery]);
 
   return (
-    <View style={styles.headerContainer}>
-      <View style={styles.headerRow}>
+    <View className="px-6 pt-4 pb-5 bg-surface shadow-sm z-10 elevation-sm">
+      <View className="flex-row justify-between items-center mb-5">
         <View>
-          <AppText variant="h1" style={styles.headerTitle}>
+          <AppText variant="h1" className="text-text text-[28px] font-extrabold tracking-tight">
             {t('productivity.title') || 'Workspace'}
           </AppText>
-          <AppText style={styles.headerSubtitle}>
+          <AppText className="text-muted text-[14px] mt-1">
             {pendingTasksCount === 0
               ? t('productivity.header.subtitle.empty') || "You're all caught up for today."
               : t('productivity.header.subtitle.pending', { count: pendingTasksCount }) ||
@@ -60,41 +67,50 @@ export const ProductivityHeader = React.memo(({
           </AppText>
         </View>
 
-        <View style={styles.headerActions}>
+        <View className="flex-row gap-2">
           <Pressable
             onPress={onGeneratePlan}
-            style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
+            accessibilityRole="button"
+            accessibilityLabel="Generate plan"
+            style={({ pressed }: PressableStateCallbackType) => [pressed ? { opacity: 0.7 } : undefined]}
+            className="w-10 h-10 rounded-full bg-primary/10 items-center justify-center"
           >
             <Ionicons name="sparkles" size={20} color={T.primary.DEFAULT} />
           </Pressable>
           <Pressable
             onPress={onShowCreateNote}
-            style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
+            accessibilityRole="button"
+            accessibilityLabel="Create note"
+            style={({ pressed }: PressableStateCallbackType) => [pressed ? { opacity: 0.7 } : undefined]}
+            className="w-10 h-10 rounded-full bg-primary/10 items-center justify-center"
           >
             <Ionicons name="document-text" size={20} color={T.primary.DEFAULT} />
           </Pressable>
           <Pressable
             onPress={onShowCreateTask}
-            style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
+            accessibilityRole="button"
+            accessibilityLabel="Create task"
+            style={({ pressed }: PressableStateCallbackType) => [pressed ? { opacity: 0.7 } : undefined]}
+            className="w-10 h-10 rounded-full bg-primary/10 items-center justify-center"
           >
             <Ionicons name="checkbox" size={20} color={T.primary.DEFAULT} />
           </Pressable>
         </View>
       </View>
 
-      <View style={styles.searchContainer}>
+      <View className="flex-row items-center bg-page rounded-lg px-3 h-11 border border-border">
         <Ionicons
           name="search"
           size={18}
           color={T.onSurface.mutedLight}
-          style={styles.searchIcon}
+          style={{ marginRight: 8 }}
         />
         <TextInput
-          value={searchQuery}
-          onChangeText={setSearchQuery}
+          value={localSearch}
+          onChangeText={setLocalSearch}
           placeholder={t('productivity.search') || 'Search notes & tasks...'}
           placeholderTextColor={T.onSurface.disabledLight}
-          style={styles.searchInput}
+          className="flex-1 text-text text-[16px] h-full"
           clearButtonMode="while-editing"
         />
       </View>
@@ -103,62 +119,3 @@ export const ProductivityHeader = React.memo(({
 });
 
 ProductivityHeader.displayName = 'ProductivityHeader';
-
-const styles = StyleSheet.create({
-  headerContainer: {
-    paddingHorizontal: S.xl,
-    paddingTop: S.md,
-    paddingBottom: S.lg,
-    backgroundColor: T.surface.light,
-    ...theme.elevation.sm,
-    zIndex: 10,
-  },
-  headerRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: S.lg,
-  },
-  headerTitle: {
-    color: T.onSurface.light,
-    fontSize: 28,
-    fontWeight: '800',
-    letterSpacing: -0.5,
-  },
-  headerSubtitle: {
-    color: T.onSurface.mutedLight,
-    fontSize: 14,
-    marginTop: S.xs,
-  },
-  headerActions: {
-    flexDirection: 'row',
-    gap: S.sm,
-  },
-  iconButton: {
-    width: 40,
-    height: 40,
-    borderRadius: R.full,
-    backgroundColor: T.primary.surfaceLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  searchContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: T.background.light,
-    borderRadius: R.lg,
-    paddingHorizontal: S.md,
-    height: 44,
-    borderWidth: 1,
-    borderColor: T.border.light,
-  },
-  searchIcon: {
-    marginRight: S.sm,
-  },
-  searchInput: {
-    flex: 1,
-    color: T.onSurface.light,
-    fontSize: 16,
-    height: '100%',
-  },
-});

--- a/frontend/src/components/productivity/ProductivityHeader.tsx
+++ b/frontend/src/components/productivity/ProductivityHeader.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { View, StyleSheet, Pressable, TextInput } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import { AppText } from '../AppText';
+import { theme } from '../../core/theme';
+import { DESIGN_TOKENS } from '@/core/design/tokens';
+
+const S = theme.spacing;
+const R = theme.borderRadius;
+
+const T = {
+  background: { light: DESIGN_TOKENS.colors.pageBg },
+  surface: { light: DESIGN_TOKENS.colors.surface, highLight: DESIGN_TOKENS.colors.surfaceSoft },
+  border: { light: DESIGN_TOKENS.colors.border },
+  onSurface: {
+    light: DESIGN_TOKENS.colors.text,
+    mutedLight: DESIGN_TOKENS.colors.muted,
+    disabledLight: DESIGN_TOKENS.colors.faint,
+  },
+  primary: {
+    DEFAULT: DESIGN_TOKENS.colors.primary,
+    surfaceLight: DESIGN_TOKENS.colors.primarySoft,
+  },
+  white: '#FFFFFF',
+  transparent: 'transparent',
+};
+
+interface Props {
+  pendingTasksCount: number;
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  onGeneratePlan: () => void;
+  onShowCreateNote: () => void;
+  onShowCreateTask: () => void;
+}
+
+export const ProductivityHeader = React.memo(({
+  pendingTasksCount,
+  searchQuery,
+  setSearchQuery,
+  onGeneratePlan,
+  onShowCreateNote,
+  onShowCreateTask,
+}: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <View style={styles.headerContainer}>
+      <View style={styles.headerRow}>
+        <View>
+          <AppText variant="h1" style={styles.headerTitle}>
+            {t('productivity.title') || 'Workspace'}
+          </AppText>
+          <AppText style={styles.headerSubtitle}>
+            {pendingTasksCount === 0
+              ? t('productivity.header.subtitle.empty') || "You're all caught up for today."
+              : t('productivity.header.subtitle.pending', { count: pendingTasksCount }) ||
+                `You have ${pendingTasksCount} tasks pending.`}
+          </AppText>
+        </View>
+
+        <View style={styles.headerActions}>
+          <Pressable
+            onPress={onGeneratePlan}
+            style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
+          >
+            <Ionicons name="sparkles" size={20} color={T.primary.DEFAULT} />
+          </Pressable>
+          <Pressable
+            onPress={onShowCreateNote}
+            style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
+          >
+            <Ionicons name="document-text" size={20} color={T.primary.DEFAULT} />
+          </Pressable>
+          <Pressable
+            onPress={onShowCreateTask}
+            style={({ pressed }) => [styles.iconButton, pressed && { opacity: 0.7 }]}
+          >
+            <Ionicons name="checkbox" size={20} color={T.primary.DEFAULT} />
+          </Pressable>
+        </View>
+      </View>
+
+      <View style={styles.searchContainer}>
+        <Ionicons
+          name="search"
+          size={18}
+          color={T.onSurface.mutedLight}
+          style={styles.searchIcon}
+        />
+        <TextInput
+          value={searchQuery}
+          onChangeText={setSearchQuery}
+          placeholder={t('productivity.search') || 'Search notes & tasks...'}
+          placeholderTextColor={T.onSurface.disabledLight}
+          style={styles.searchInput}
+          clearButtonMode="while-editing"
+        />
+      </View>
+    </View>
+  );
+});
+
+ProductivityHeader.displayName = 'ProductivityHeader';
+
+const styles = StyleSheet.create({
+  headerContainer: {
+    paddingHorizontal: S.xl,
+    paddingTop: S.md,
+    paddingBottom: S.lg,
+    backgroundColor: T.surface.light,
+    ...theme.elevation.sm,
+    zIndex: 10,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: S.lg,
+  },
+  headerTitle: {
+    color: T.onSurface.light,
+    fontSize: 28,
+    fontWeight: '800',
+    letterSpacing: -0.5,
+  },
+  headerSubtitle: {
+    color: T.onSurface.mutedLight,
+    fontSize: 14,
+    marginTop: S.xs,
+  },
+  headerActions: {
+    flexDirection: 'row',
+    gap: S.sm,
+  },
+  iconButton: {
+    width: 40,
+    height: 40,
+    borderRadius: R.full,
+    backgroundColor: T.primary.surfaceLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  searchContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: T.background.light,
+    borderRadius: R.lg,
+    paddingHorizontal: S.md,
+    height: 44,
+    borderWidth: 1,
+    borderColor: T.border.light,
+  },
+  searchIcon: {
+    marginRight: S.sm,
+  },
+  searchInput: {
+    flex: 1,
+    color: T.onSurface.light,
+    fontSize: 16,
+    height: '100%',
+  },
+});

--- a/frontend/src/components/productivity/ProductivityTabs.tsx
+++ b/frontend/src/components/productivity/ProductivityTabs.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { View, StyleSheet, Pressable } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { AppText } from '../AppText';
+import { theme } from '../../core/theme';
+import { DESIGN_TOKENS } from '@/core/design/tokens';
+
+const S = theme.spacing;
+const R = theme.borderRadius;
+
+const T = {
+  background: { light: DESIGN_TOKENS.colors.pageBg },
+  surface: { light: DESIGN_TOKENS.colors.surface, highLight: DESIGN_TOKENS.colors.surfaceSoft },
+  border: { light: DESIGN_TOKENS.colors.border },
+  onSurface: {
+    light: DESIGN_TOKENS.colors.text,
+    mutedLight: DESIGN_TOKENS.colors.muted,
+    disabledLight: DESIGN_TOKENS.colors.faint,
+  },
+  primary: {
+    DEFAULT: DESIGN_TOKENS.colors.primary,
+    surfaceLight: DESIGN_TOKENS.colors.primarySoft,
+  },
+  white: '#FFFFFF',
+  transparent: 'transparent',
+};
+
+export type Tab = 'today' | 'all' | 'notes' | 'tasks';
+export type TaskPriority = 'all' | 'overdue' | 'today' | 'upcoming' | 'no_due';
+
+interface Props {
+  activeTab: Tab;
+  setActiveTab: (tab: Tab) => void;
+  taskPriority: TaskPriority;
+  setTaskPriority: (priority: TaskPriority) => void;
+  taskPriorityCounts: Record<TaskPriority, number>;
+}
+
+export const ProductivityTabs = React.memo(({
+  activeTab,
+  setActiveTab,
+  taskPriority,
+  setTaskPriority,
+  taskPriorityCounts,
+}: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <View>
+      <View style={styles.tabsContainer}>
+        {(['today', 'all', 'notes', 'tasks'] as const).map((tab) => (
+          <Pressable
+            key={tab}
+            onPress={() => setActiveTab(tab)}
+            style={({ pressed }) => [
+              styles.tabButton,
+              activeTab === tab && styles.tabButtonActive,
+              pressed && activeTab !== tab && { opacity: 0.6 },
+            ]}
+          >
+            <AppText style={[styles.tabText, activeTab === tab && styles.tabTextActive]}>
+              {tab === 'today'
+                ? t('productivity.today')
+                : tab === 'all'
+                  ? t('productivity.all') || 'All'
+                  : tab === 'notes'
+                    ? t('productivity.notes') || 'Notes'
+                    : t('productivity.tasks') || 'Tasks'}
+            </AppText>
+          </Pressable>
+        ))}
+      </View>
+
+      {(activeTab === 'tasks' || activeTab === 'today') && (
+        <View
+          style={{
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            marginHorizontal: S.xl,
+            marginBottom: S.sm,
+          }}
+        >
+          {(
+            [
+              { key: 'all', label: t('productivity.priority.all', { count: taskPriorityCounts.all }) },
+              {
+                key: 'overdue',
+                label: t('productivity.priority.overdue', { count: taskPriorityCounts.overdue }),
+              },
+              {
+                key: 'today',
+                label: t('productivity.priority.today', { count: taskPriorityCounts.today }),
+              },
+              {
+                key: 'upcoming',
+                label: t('productivity.priority.upcoming', { count: taskPriorityCounts.upcoming }),
+              },
+              {
+                key: 'no_due',
+                label: t('productivity.priority.no_due', { count: taskPriorityCounts.no_due }),
+              },
+            ] as const
+          ).map((option) => (
+            <Pressable
+              key={option.key}
+              onPress={() => setTaskPriority(option.key)}
+              style={({ pressed }) => [
+                {
+                  borderRadius: 12,
+                  borderWidth: 1,
+                  borderColor: taskPriority === option.key ? T.primary.DEFAULT : T.border.light,
+                  backgroundColor:
+                    taskPriority === option.key ? T.primary.surfaceLight : T.surface.light,
+                  paddingHorizontal: 10,
+                  paddingVertical: 6,
+                  marginRight: 8,
+                  marginBottom: 8,
+                },
+                pressed && { opacity: 0.8 },
+              ]}
+            >
+              <AppText
+                variant="caption"
+                style={{
+                  color: taskPriority === option.key ? T.primary.DEFAULT : T.onSurface.mutedLight,
+                  fontWeight: '700',
+                }}
+              >
+                {option.label}
+              </AppText>
+            </Pressable>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+});
+
+ProductivityTabs.displayName = 'ProductivityTabs';
+
+const styles = StyleSheet.create({
+  tabsContainer: {
+    flexDirection: 'row',
+    backgroundColor: T.surface.highLight,
+    borderRadius: R.xl,
+    padding: S.xs,
+    marginHorizontal: S.xl,
+    marginTop: S.lg,
+    marginBottom: S.md,
+    borderWidth: 1,
+    borderColor: T.border.light,
+  },
+  tabButton: {
+    flex: 1,
+    paddingVertical: S.sm,
+    alignItems: 'center',
+    borderRadius: R.lg,
+    backgroundColor: T.transparent,
+  },
+  tabButtonActive: {
+    backgroundColor: T.surface.light,
+    ...theme.elevation.sm,
+  },
+  tabText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: T.onSurface.mutedLight,
+  },
+  tabTextActive: {
+    fontWeight: '700',
+    color: T.onSurface.light,
+  },
+});

--- a/frontend/src/components/productivity/ProductivityTabs.tsx
+++ b/frontend/src/components/productivity/ProductivityTabs.tsx
@@ -1,29 +1,7 @@
 import React from 'react';
-import { View, StyleSheet, Pressable } from 'react-native';
+import { View, Pressable, PressableStateCallbackType } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { AppText } from '../AppText';
-import { theme } from '../../core/theme';
-import { DESIGN_TOKENS } from '@/core/design/tokens';
-
-const S = theme.spacing;
-const R = theme.borderRadius;
-
-const T = {
-  background: { light: DESIGN_TOKENS.colors.pageBg },
-  surface: { light: DESIGN_TOKENS.colors.surface, highLight: DESIGN_TOKENS.colors.surfaceSoft },
-  border: { light: DESIGN_TOKENS.colors.border },
-  onSurface: {
-    light: DESIGN_TOKENS.colors.text,
-    mutedLight: DESIGN_TOKENS.colors.muted,
-    disabledLight: DESIGN_TOKENS.colors.faint,
-  },
-  primary: {
-    DEFAULT: DESIGN_TOKENS.colors.primary,
-    surfaceLight: DESIGN_TOKENS.colors.primarySoft,
-  },
-  white: '#FFFFFF',
-  transparent: 'transparent',
-};
 
 export type Tab = 'today' | 'all' | 'notes' | 'tasks';
 export type TaskPriority = 'all' | 'overdue' | 'today' | 'upcoming' | 'no_due';
@@ -47,18 +25,17 @@ export const ProductivityTabs = React.memo(({
 
   return (
     <View>
-      <View style={styles.tabsContainer}>
+      <View className="flex-row bg-surfaceSoft rounded-xl p-1 mx-6 mt-5 mb-4 border border-border">
         {(['today', 'all', 'notes', 'tasks'] as const).map((tab) => (
           <Pressable
             key={tab}
             onPress={() => setActiveTab(tab)}
-            style={({ pressed }) => [
-              styles.tabButton,
-              activeTab === tab && styles.tabButtonActive,
-              pressed && activeTab !== tab && { opacity: 0.6 },
+            style={({ pressed }: PressableStateCallbackType) => [
+              pressed && activeTab !== tab ? { opacity: 0.6 } : undefined,
             ]}
+            className={`flex-1 py-2 items-center rounded-lg bg-transparent ${activeTab === tab ? 'bg-surface shadow-sm elevation-sm' : ''}`}
           >
-            <AppText style={[styles.tabText, activeTab === tab && styles.tabTextActive]}>
+            <AppText className={`text-[14px] font-medium text-muted ${activeTab === tab ? 'font-bold text-text' : ''}`}>
               {tab === 'today'
                 ? t('productivity.today')
                 : tab === 'all'
@@ -72,14 +49,7 @@ export const ProductivityTabs = React.memo(({
       </View>
 
       {(activeTab === 'tasks' || activeTab === 'today') && (
-        <View
-          style={{
-            flexDirection: 'row',
-            flexWrap: 'wrap',
-            marginHorizontal: S.xl,
-            marginBottom: S.sm,
-          }}
-        >
+        <View className="flex-row flex-wrap mx-6 mb-2">
           {(
             [
               { key: 'all', label: t('productivity.priority.all', { count: taskPriorityCounts.all }) },
@@ -104,27 +74,20 @@ export const ProductivityTabs = React.memo(({
             <Pressable
               key={option.key}
               onPress={() => setTaskPriority(option.key)}
-              style={({ pressed }) => [
-                {
-                  borderRadius: 12,
-                  borderWidth: 1,
-                  borderColor: taskPriority === option.key ? T.primary.DEFAULT : T.border.light,
-                  backgroundColor:
-                    taskPriority === option.key ? T.primary.surfaceLight : T.surface.light,
-                  paddingHorizontal: 10,
-                  paddingVertical: 6,
-                  marginRight: 8,
-                  marginBottom: 8,
-                },
-                pressed && { opacity: 0.8 },
+              style={({ pressed }: PressableStateCallbackType) => [
+                pressed ? { opacity: 0.8 } : undefined,
               ]}
+              className={`rounded-xl border px-2.5 py-1.5 mr-2 mb-2 ${
+                taskPriority === option.key
+                  ? 'border-primary bg-primary/10'
+                  : 'border-border bg-surface'
+              }`}
             >
               <AppText
                 variant="caption"
-                style={{
-                  color: taskPriority === option.key ? T.primary.DEFAULT : T.onSurface.mutedLight,
-                  fontWeight: '700',
-                }}
+                className={`font-bold ${
+                  taskPriority === option.key ? 'text-primary' : 'text-muted'
+                }`}
               >
                 {option.label}
               </AppText>
@@ -137,37 +100,3 @@ export const ProductivityTabs = React.memo(({
 });
 
 ProductivityTabs.displayName = 'ProductivityTabs';
-
-const styles = StyleSheet.create({
-  tabsContainer: {
-    flexDirection: 'row',
-    backgroundColor: T.surface.highLight,
-    borderRadius: R.xl,
-    padding: S.xs,
-    marginHorizontal: S.xl,
-    marginTop: S.lg,
-    marginBottom: S.md,
-    borderWidth: 1,
-    borderColor: T.border.light,
-  },
-  tabButton: {
-    flex: 1,
-    paddingVertical: S.sm,
-    alignItems: 'center',
-    borderRadius: R.lg,
-    backgroundColor: T.transparent,
-  },
-  tabButtonActive: {
-    backgroundColor: T.surface.light,
-    ...theme.elevation.sm,
-  },
-  tabText: {
-    fontSize: 14,
-    fontWeight: '500',
-    color: T.onSurface.mutedLight,
-  },
-  tabTextActive: {
-    fontWeight: '700',
-    color: T.onSurface.light,
-  },
-});

--- a/frontend/src/components/productivity/ProductivityTodayPlan.tsx
+++ b/frontend/src/components/productivity/ProductivityTodayPlan.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { View, StyleSheet, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { AppText } from '../AppText';
+import { theme } from '../../core/theme';
+import { DESIGN_TOKENS } from '@/core/design/tokens';
+import type { Tab } from './ProductivityTabs';
+
+const S = theme.spacing;
+const R = theme.borderRadius;
+
+const T = {
+  background: { light: DESIGN_TOKENS.colors.pageBg },
+  surface: { light: DESIGN_TOKENS.colors.surface, highLight: DESIGN_TOKENS.colors.surfaceSoft },
+  border: { light: DESIGN_TOKENS.colors.border },
+  onSurface: {
+    light: DESIGN_TOKENS.colors.text,
+    mutedLight: DESIGN_TOKENS.colors.muted,
+    disabledLight: DESIGN_TOKENS.colors.faint,
+  },
+  primary: {
+    DEFAULT: DESIGN_TOKENS.colors.primary,
+    surfaceLight: DESIGN_TOKENS.colors.primarySoft,
+  },
+  white: '#FFFFFF',
+  transparent: 'transparent',
+};
+
+interface Props {
+  activeTab: Tab;
+  todayPlan: string | null;
+  onClose: () => void;
+}
+
+export const ProductivityTodayPlan = React.memo(({
+  activeTab,
+  todayPlan,
+  onClose,
+}: Props) => {
+  if (activeTab !== 'today' || !todayPlan) {
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <AppText style={styles.title}>Today plan</AppText>
+        <Pressable onPress={onClose}>
+          <Ionicons name="close" size={16} color={T.onSurface.mutedLight} />
+        </Pressable>
+      </View>
+      <AppText style={styles.content}>{todayPlan}</AppText>
+    </View>
+  );
+});
+
+ProductivityTodayPlan.displayName = 'ProductivityTodayPlan';
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: R.xl,
+    backgroundColor: T.primary.surfaceLight,
+    borderWidth: 1,
+    borderColor: T.border.light,
+    padding: S.lg,
+    marginBottom: S.md,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  title: {
+    color: T.onSurface.light,
+    fontWeight: '700',
+    fontSize: 15,
+  },
+  content: {
+    color: T.onSurface.mutedLight,
+    marginTop: 8,
+    lineHeight: 20,
+  },
+});

--- a/frontend/src/components/productivity/ProductivityTodayPlan.tsx
+++ b/frontend/src/components/productivity/ProductivityTodayPlan.tsx
@@ -1,29 +1,14 @@
 import React from 'react';
-import { View, StyleSheet, Pressable } from 'react-native';
+import { View, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { AppText } from '../AppText';
-import { theme } from '../../core/theme';
 import { DESIGN_TOKENS } from '@/core/design/tokens';
 import type { Tab } from './ProductivityTabs';
 
-const S = theme.spacing;
-const R = theme.borderRadius;
-
 const T = {
-  background: { light: DESIGN_TOKENS.colors.pageBg },
-  surface: { light: DESIGN_TOKENS.colors.surface, highLight: DESIGN_TOKENS.colors.surfaceSoft },
-  border: { light: DESIGN_TOKENS.colors.border },
   onSurface: {
-    light: DESIGN_TOKENS.colors.text,
     mutedLight: DESIGN_TOKENS.colors.muted,
-    disabledLight: DESIGN_TOKENS.colors.faint,
   },
-  primary: {
-    DEFAULT: DESIGN_TOKENS.colors.primary,
-    surfaceLight: DESIGN_TOKENS.colors.primarySoft,
-  },
-  white: '#FFFFFF',
-  transparent: 'transparent',
 };
 
 interface Props {
@@ -42,42 +27,20 @@ export const ProductivityTodayPlan = React.memo(({
   }
 
   return (
-    <View style={styles.container}>
-      <View style={styles.header}>
-        <AppText style={styles.title}>Today plan</AppText>
-        <Pressable onPress={onClose}>
+    <View className="rounded-xl bg-primary/10 border border-border p-4 mb-3">
+      <View className="flex-row justify-between items-center">
+        <AppText className="text-text font-bold text-[15px]">Today plan</AppText>
+        <Pressable
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel="Dismiss today plan"
+        >
           <Ionicons name="close" size={16} color={T.onSurface.mutedLight} />
         </Pressable>
       </View>
-      <AppText style={styles.content}>{todayPlan}</AppText>
+      <AppText className="text-muted mt-2 leading-[20px]">{todayPlan}</AppText>
     </View>
   );
 });
 
 ProductivityTodayPlan.displayName = 'ProductivityTodayPlan';
-
-const styles = StyleSheet.create({
-  container: {
-    borderRadius: R.xl,
-    backgroundColor: T.primary.surfaceLight,
-    borderWidth: 1,
-    borderColor: T.border.light,
-    padding: S.lg,
-    marginBottom: S.md,
-  },
-  header: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  title: {
-    color: T.onSurface.light,
-    fontWeight: '700',
-    fontSize: 15,
-  },
-  content: {
-    color: T.onSurface.mutedLight,
-    marginTop: 8,
-    lineHeight: 20,
-  },
-});

--- a/frontend/src/hooks/useProductivityScreen.ts
+++ b/frontend/src/hooks/useProductivityScreen.ts
@@ -145,8 +145,16 @@ export function useProductivityScreen() {
         date: new Date(task.created_at).getTime(),
       });
     });
+    filteredEvents.forEach((event) => {
+      data.push({
+        type: 'event',
+        item: event,
+        id: `event-${event.id}`,
+        date: new Date(event.start_time).getTime(),
+      });
+    });
     return data.sort((a, b) => (b.date || 0) - (a.date || 0));
-  }, [filteredNotes, filteredTasks]);
+  }, [filteredNotes, filteredTasks, filteredEvents]);
 
   const todayData = useMemo(() => {
     const now = new Date();
@@ -197,12 +205,24 @@ export function useProductivityScreen() {
     return items.sort((a, b) => (a.date || 0) - (b.date || 0));
   }, [filteredEvents, filteredTasks]);
 
+  const effectiveTaskPriority = useMemo(() => {
+    if (activeTab === 'today') {
+      const supportedPriorities = new Set(
+        todayData.filter((i) => i.type === 'task').map((t) => getTaskPriority(t.item as Task))
+      );
+      if (taskPriority !== 'all' && !supportedPriorities.has(taskPriority)) {
+        return 'all';
+      }
+    }
+    return taskPriority;
+  }, [activeTab, getTaskPriority, taskPriority, todayData]);
+
   const dataToRender: RenderItemData[] =
     activeTab === 'today'
       ? todayData.filter((entry) => {
           if (entry.type !== 'task') return true;
-          if (taskPriority === 'all') return true;
-          return getTaskPriority(entry.item as Task) === taskPriority;
+          if (effectiveTaskPriority === 'all') return true;
+          return getTaskPriority(entry.item as Task) === effectiveTaskPriority;
         })
       : activeTab === 'all'
         ? mixedData
@@ -212,7 +232,14 @@ export function useProductivityScreen() {
 
   const generateTodayPlan = useCallback(() => {
     const now = new Date();
-    const nextTasks = prioritizedTasks.slice(0, 3);
+    const allOpenPrioritizedTasks = [...filteredTasks.filter((task) => !task.completed)].sort(
+      (a, b) => {
+        const aDue = a.due_date ? new Date(a.due_date).getTime() : Number.MAX_SAFE_INTEGER;
+        const bDue = b.due_date ? new Date(b.due_date).getTime() : Number.MAX_SAFE_INTEGER;
+        return aDue - bDue;
+      }
+    );
+    const nextTasks = allOpenPrioritizedTasks.slice(0, 3);
     const nextEvents = [...filteredEvents]
       .filter((event) => new Date(event.end_time) >= now)
       .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime())
@@ -247,12 +274,12 @@ export function useProductivityScreen() {
 
     setTodayPlan(lines.join('\n'));
     setActiveTab('today');
-  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue]);
+  }, [filteredEvents, filteredTasks, i18n.language, taskPriorityCounts.overdue]);
 
   return {
     activeTab,
     setActiveTab,
-    taskPriority,
+    taskPriority: effectiveTaskPriority,
     setTaskPriority,
     searchQuery,
     setSearchQuery,

--- a/frontend/src/hooks/useProductivityScreen.ts
+++ b/frontend/src/hooks/useProductivityScreen.ts
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CalendarEvent, Note, Task } from '../core/models';
+import { useProductivityStore } from '../store/useProductivityStore';
+import type { Tab, TaskPriority } from '../components/productivity/ProductivityTabs';
+
+export type RenderItemData = {
+  date?: number;
+  type: 'note' | 'task' | 'event';
+  item: Note | Task | CalendarEvent;
+  id: string;
+};
+
+export function useProductivityScreen() {
+  const { i18n } = useTranslation();
+  const [activeTab, setActiveTab] = useState<Tab>('today');
+  const [taskPriority, setTaskPriority] = useState<TaskPriority>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showCreateNote, setShowCreateNote] = useState(false);
+  const [showCreateTask, setShowCreateTask] = useState(false);
+  const [todayPlan, setTodayPlan] = useState<string | null>(null);
+
+  const {
+    notes,
+    tasks,
+    events,
+    fetchNotes,
+    fetchTasks,
+    fetchEvents,
+    isLoading,
+    deleteNote,
+    deleteTask,
+    toggleTask,
+  } = useProductivityStore();
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchNotes(controller.signal);
+    fetchTasks(controller.signal);
+    fetchEvents(controller.signal);
+    return () => {
+      controller.abort();
+    };
+  }, [fetchEvents, fetchNotes, fetchTasks]);
+
+  const handleRefresh = useCallback(() => {
+    fetchNotes();
+    fetchTasks();
+    fetchEvents();
+  }, [fetchEvents, fetchNotes, fetchTasks]);
+
+  const filteredNotes = useMemo(() => {
+    if (!searchQuery) return notes;
+    const lowerQ = searchQuery.toLowerCase();
+    return notes.filter(
+      (n) => n.title.toLowerCase().includes(lowerQ) || n.content.toLowerCase().includes(lowerQ)
+    );
+  }, [notes, searchQuery]);
+
+  const filteredTasks = useMemo(() => {
+    if (!searchQuery) return tasks;
+    const lowerQ = searchQuery.toLowerCase();
+    return tasks.filter(
+      (task) =>
+        task.title.toLowerCase().includes(lowerQ) ||
+        (task.description?.toLowerCase().includes(lowerQ) ?? false)
+    );
+  }, [searchQuery, tasks]);
+
+  const filteredEvents = useMemo(() => {
+    if (!searchQuery) return events;
+    const lowerQ = searchQuery.toLowerCase();
+    return events.filter(
+      (event) =>
+        event.title.toLowerCase().includes(lowerQ) ||
+        (event.description?.toLowerCase().includes(lowerQ) ?? false) ||
+        (event.location?.toLowerCase().includes(lowerQ) ?? false)
+    );
+  }, [events, searchQuery]);
+
+  const pendingTasksCount = useMemo(
+    () => filteredTasks.filter((task) => !task.completed).length,
+    [filteredTasks]
+  );
+
+  const getTaskPriority = useCallback((task: Task): Exclude<TaskPriority, 'all'> => {
+    if (!task.due_date) return 'no_due';
+    const now = new Date();
+    const due = new Date(task.due_date);
+    if (isNaN(due.getTime())) return 'no_due';
+    const dayStart = new Date(now);
+    dayStart.setHours(0, 0, 0, 0);
+    const tomorrow = new Date(dayStart);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    if (due < dayStart) return 'overdue';
+    if (due >= dayStart && due < tomorrow) return 'today';
+    return 'upcoming';
+  }, []);
+
+  const taskPriorityCounts = useMemo(() => {
+    const counts: Record<TaskPriority, number> = {
+      all: 0,
+      overdue: 0,
+      today: 0,
+      upcoming: 0,
+      no_due: 0,
+    };
+    filteredTasks
+      .filter((task) => !task.completed)
+      .forEach((task) => {
+        counts.all += 1;
+        counts[getTaskPriority(task)] += 1;
+      });
+    return counts;
+  }, [filteredTasks, getTaskPriority]);
+
+  const prioritizedTasks = useMemo(() => {
+    const tasksToRank = filteredTasks.filter((task) => !task.completed);
+    const pool =
+      taskPriority === 'all'
+        ? tasksToRank
+        : tasksToRank.filter((task) => getTaskPriority(task) === taskPriority);
+    return [...pool].sort((a, b) => {
+      const aDue = a.due_date ? new Date(a.due_date).getTime() : Number.MAX_SAFE_INTEGER;
+      const bDue = b.due_date ? new Date(b.due_date).getTime() : Number.MAX_SAFE_INTEGER;
+      return aDue - bDue;
+    });
+  }, [filteredTasks, getTaskPriority, taskPriority]);
+
+  const mixedData = useMemo(() => {
+    const data: RenderItemData[] = [];
+    filteredNotes.forEach((note) => {
+      data.push({
+        type: 'note',
+        item: note,
+        id: `note-${note.id}`,
+        date: new Date(note.created_at).getTime(),
+      });
+    });
+    filteredTasks.forEach((task) => {
+      data.push({
+        type: 'task',
+        item: task,
+        id: `task-${task.id}`,
+        date: new Date(task.created_at).getTime(),
+      });
+    });
+    return data.sort((a, b) => (b.date || 0) - (a.date || 0));
+  }, [filteredNotes, filteredTasks]);
+
+  const todayData = useMemo(() => {
+    const now = new Date();
+    const start = new Date(now);
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(start);
+    end.setDate(end.getDate() + 1);
+    const weekEnd = new Date(start);
+    weekEnd.setDate(weekEnd.getDate() + 7);
+
+    const overdueTasks = filteredTasks.filter((task) => {
+      if (task.completed || !task.due_date) return false;
+      return new Date(task.due_date) < start;
+    });
+
+    const dueTodayTasks = filteredTasks.filter((task) => {
+      if (task.completed || !task.due_date) return false;
+      const dueDate = new Date(task.due_date);
+      return dueDate >= start && dueDate < end;
+    });
+
+    const upcomingEvents = filteredEvents.filter((event) => {
+      const startTime = new Date(event.start_time);
+      return startTime >= start && startTime < weekEnd;
+    });
+
+    const items: RenderItemData[] = [
+      ...overdueTasks.map((task) => ({
+        type: 'task' as const,
+        item: task,
+        id: `overdue-${task.id}`,
+        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
+      })),
+      ...dueTodayTasks.map((task) => ({
+        type: 'task' as const,
+        item: task,
+        id: `today-${task.id}`,
+        date: task.due_date ? new Date(task.due_date).getTime() : undefined,
+      })),
+      ...upcomingEvents.map((event) => ({
+        type: 'event' as const,
+        item: event,
+        id: `event-${event.id}`,
+        date: new Date(event.start_time).getTime(),
+      })),
+    ];
+
+    return items.sort((a, b) => (a.date || 0) - (b.date || 0));
+  }, [filteredEvents, filteredTasks]);
+
+  const dataToRender: RenderItemData[] =
+    activeTab === 'today'
+      ? todayData.filter((entry) => {
+          if (entry.type !== 'task') return true;
+          if (taskPriority === 'all') return true;
+          return getTaskPriority(entry.item as Task) === taskPriority;
+        })
+      : activeTab === 'all'
+        ? mixedData
+        : activeTab === 'notes'
+          ? filteredNotes.map((note) => ({ type: 'note' as const, item: note, id: note.id }))
+          : prioritizedTasks.map((task) => ({ type: 'task' as const, item: task, id: task.id }));
+
+  const generateTodayPlan = useCallback(() => {
+    const now = new Date();
+    const nextTasks = prioritizedTasks.slice(0, 3);
+    const nextEvents = [...filteredEvents]
+      .filter((event) => new Date(event.end_time) >= now)
+      .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime())
+      .slice(0, 3);
+
+    const lines: string[] = [];
+    if (taskPriorityCounts.overdue > 0) {
+      lines.push(`1) Recover overdue: start with ${taskPriorityCounts.overdue} overdue task(s).`);
+    } else {
+      lines.push('1) No overdue tasks: start with highest-impact open work.');
+    }
+
+    if (nextTasks.length > 0) {
+      lines.push(`2) Focus block: ${nextTasks.map((task) => task.title).join(', ')}.`);
+    } else {
+      lines.push('2) Focus block: no pending tasks, use this for planning or review.');
+    }
+
+    if (nextEvents.length > 0) {
+      const eventLine = nextEvents
+        .map((event) =>
+          new Intl.DateTimeFormat(i18n.language, {
+            hour: '2-digit',
+            minute: '2-digit',
+          }).format(new Date(event.start_time))
+        )
+        .join(', ');
+      lines.push(`3) Calendar checkpoints at ${eventLine}.`);
+    } else {
+      lines.push('3) Calendar is light: reserve time for deep work and wrap-up.');
+    }
+
+    setTodayPlan(lines.join('\n'));
+    setActiveTab('today');
+  }, [filteredEvents, i18n.language, prioritizedTasks, taskPriorityCounts.overdue]);
+
+  return {
+    activeTab,
+    setActiveTab,
+    taskPriority,
+    setTaskPriority,
+    searchQuery,
+    setSearchQuery,
+    showCreateNote,
+    setShowCreateNote,
+    showCreateTask,
+    setShowCreateTask,
+    todayPlan,
+    setTodayPlan,
+    dataToRender,
+    isLoading,
+    handleRefresh,
+    pendingTasksCount,
+    taskPriorityCounts,
+    generateTodayPlan,
+    deleteNote,
+    deleteTask,
+    toggleTask,
+    fetchNotes,
+    fetchTasks,
+  };
+}


### PR DESCRIPTION
Decomposed the `ProductivityScreen` God Widget into smaller components and extracted its logic into a custom hook.

---
*PR created automatically by Jules for task [4320521121427285101](https://jules.google.com/task/4320521121427285101) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the productivity screen UI into modular components (headers, tabs, empty states, and today plan sections) for better separation of concerns.
  * Unified state management for the productivity screen to consolidate all logic handling related to search, filtering, task prioritization, and plan generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->