### PR TITLE
docs: Audit and update documentation flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ The following AI agents actively monitor and modify the Miru codebase. Their act
 - Scheduled weekly (Monday 9 AM UTC) or via manual dispatch to generate a performance report.
 **Scope:** Authorized to modify backend Python files, frontend React Native (TypeScript) files, and tests. Not authorized to restructure databases without human approval.
 **Note on Prompt:** Jules is instructed to strictly follow project architecture and code style: 100-char lines, type hints/explicit types, double quotes for Python, single quotes for TypeScript, specific import orders (`stdlib` → `third-party` → `first-party`), use `str | None` not `Optional[str]`, use `const` for components/internal functions, include `from __future__ import annotations`, log errors with context (`logger.exception()`), and structure domains in `backend/app/domain/<domain>/` and routes in `backend/app/api/v1/`.
+// DOCS(miru-agent): prompt mismatch
 
 ### 2. CodeRabbit
 
@@ -80,6 +81,7 @@ The following AI agents actively monitor and modify the Miru codebase. Their act
 - Automatically invoked when the "PR Checks and Linting" CI workflow completes successfully on a PR branch.
 - Retries automatically every 30 minutes via a queue processor if rate-limited (label `coderabbit:queued`).
 **Scope:** Reviews all modified files in a PR. Posts actionable comments. When 0 actionable comments are found, it triggers the `ai-approved` label.
+// DOCS(miru-agent): prompt mismatch
 
 ## Project Structure
 

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -99,6 +99,7 @@ async def _handle_send_message(
 # ---------------------------------------------------------------------------
 # WebSocket endpoint
 # ---------------------------------------------------------------------------
+# DOCS(miru-agent): undocumented endpoint
 @router.websocket("/ws/chat")
 async def websocket_chat_hub(
     websocket: WebSocket,


### PR DESCRIPTION
Audited codebase documentation as requested. Checked architectural boundaries, verified JSDoc blocks in UI components (like `AgentAvatar`, `BackendSplash`, `AppText`), verified `README.md` endpoints and environment variables, and added explicit `DOCS(miru-agent)` tags to signal documentation discrepancies.

---
*PR created automatically by Jules for task [12692570832880675860](https://jules.google.com/task/12692570832880675860) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation comments for code reference and maintenance organization.

* **Chores**
  * Added documentation markers for endpoint tracking and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->