### PR TITLE
Refactor AuthService to decouple JWT verification into Infrastructure

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -39,6 +39,10 @@ def get_auth_repo(db: SupabaseClient) -> AuthRepository:
     return AuthRepository(db)
 
 
+# Global singleton instance of the JWT verifier to reuse the PyJWKClient cache
+_jwt_verifier = SupabaseJWTVerifier()
+
+
 # ---------------------------------------------------------------------------
 # Service factories
 # ---------------------------------------------------------------------------
@@ -64,4 +68,4 @@ def get_memory_service(
 
 
 def get_auth_service(repo: Annotated[AuthRepository, Depends(get_auth_repo)]) -> AuthService:
-    return AuthService(repo, SupabaseJWTVerifier())
+    return AuthService(repo, _jwt_verifier)

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -11,6 +11,7 @@ from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
 from app.domain.memory.service import MemoryService
 from app.infrastructure.database.supabase import SupabaseClient
+from app.infrastructure.external.jwt_verifier import SupabaseJWTVerifier
 from app.infrastructure.repositories.agent_repo import AgentRepository
 from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
@@ -63,4 +64,4 @@ def get_memory_service(
 
 
 def get_auth_service(repo: Annotated[AuthRepository, Depends(get_auth_repo)]) -> AuthService:
-    return AuthService(repo)
+    return AuthService(repo, SupabaseJWTVerifier())

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -29,6 +29,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
+from app.api.dependencies import _jwt_verifier
 from app.domain.agents.service import AgentService
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
@@ -52,7 +53,7 @@ logger = logging.getLogger(__name__)
 async def _verify_token(token: str) -> UUID | None:
     """Decode a Supabase JWT by delegating to AuthService.decode_jwt."""
     try:
-        auth_service = AuthService(AuthRepository(get_supabase()))
+        auth_service = AuthService(AuthRepository(get_supabase()), _jwt_verifier)
         payload = await auth_service.decode_jwt(token)
         return payload.sub
     except Exception:

--- a/backend/app/domain/auth/interfaces.py
+++ b/backend/app/domain/auth/interfaces.py
@@ -6,6 +6,15 @@ from typing import Protocol
 from uuid import UUID
 
 from app.domain.auth.entities import Passkey, PasskeyCreate
+from app.domain.auth.schemas import JWTPayload
+
+
+class TokenVerifierProtocol(Protocol):
+    """Protocol for verifying and decoding authentication tokens."""
+
+    async def decode_token(self, token: str) -> JWTPayload:
+        """Decode and verify a JWT."""
+        ...
 
 
 class AuthRepositoryProtocol(Protocol):

--- a/backend/app/domain/auth/interfaces.py
+++ b/backend/app/domain/auth/interfaces.py
@@ -14,7 +14,7 @@ class TokenVerifierProtocol(Protocol):
 
     async def decode_token(self, token: str) -> JWTPayload:
         """Decode and verify a JWT."""
-        ...
+        pass
 
 
 class AuthRepositoryProtocol(Protocol):
@@ -24,16 +24,16 @@ class AuthRepositoryProtocol(Protocol):
         self, user_id: str | UUID, limit: int = 50, cursor: str | None = None
     ) -> tuple[list[Passkey], str | None]:
         """Fetch all registered passkeys for a user with pagination."""
-        ...
+        pass
 
     async def update_sign_count(self, passkey_id: str | UUID, new_count: int) -> None:
         """Update the signature count for a passkey."""
-        ...
+        pass
 
     async def create_passkey(self, input: PasskeyCreate) -> Passkey:
         """Insert a new passkey record."""
-        ...
+        pass
 
     async def delete_passkey(self, passkey_id: str | UUID, user_id: str | UUID) -> bool:
         """Delete a passkey belonging to a user."""
-        ...
+        pass

--- a/backend/app/domain/auth/service.py
+++ b/backend/app/domain/auth/service.py
@@ -6,22 +6,19 @@ import logging
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-import jwt
-
-from app.core.config import get_settings
 from app.domain.auth.entities import Passkey
 from app.domain.auth.schemas import JWTPayload
 
 if TYPE_CHECKING:
-    from app.domain.auth.interfaces import AuthRepositoryProtocol
+    from app.domain.auth.interfaces import AuthRepositoryProtocol, TokenVerifierProtocol
 
 logger = logging.getLogger(__name__)
 
 
 class AuthService:
-    def __init__(self, repo: AuthRepositoryProtocol) -> None:
+    def __init__(self, repo: AuthRepositoryProtocol, token_verifier: TokenVerifierProtocol) -> None:
         self.repo = repo
-        self._jwks_client: jwt.PyJWKClient | None = None
+        self.token_verifier = token_verifier
 
     async def list_passkeys(
         self, user_id: str | UUID, limit: int = 50, cursor: str | None = None
@@ -29,44 +26,9 @@ class AuthService:
         """Fetch a paginated list of passkeys for a user."""
         return await self.repo.get_passkeys_by_user(user_id, limit=limit, cursor=cursor)
 
-    def _get_jwks_client(self) -> jwt.PyJWKClient:
-        if self._jwks_client is None:
-            settings = get_settings()
-            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
-            self._jwks_client = jwt.PyJWKClient(jwks_url)
-        return self._jwks_client
-
     async def decode_jwt(self, token: str) -> JWTPayload:
-        """Decode and verify a Supabase JWT."""
-        settings = get_settings()
-        try:
-            try:
-                header = jwt.get_unverified_header(token)
-            except Exception as header_exc:
-                raise jwt.DecodeError("Invalid token format") from header_exc
-
-            alg = header.get("alg")
-
-            if alg == "HS256":
-                payload = jwt.decode(
-                    token,
-                    settings.supabase_jwt_secret,
-                    algorithms=["HS256"],
-                    audience="authenticated",
-                )
-            else:
-                jwks_client = self._get_jwks_client()
-                signing_key = jwks_client.get_signing_key_from_jwt(token)
-                payload = jwt.decode(
-                    token,
-                    signing_key.key,
-                    algorithms=["ES256", "RS256"],
-                    audience="authenticated",
-                )
-            return JWTPayload(**payload)
-        except Exception as exc:
-            logger.warning("JWT validation failed: %s", exc)
-            raise
+        """Decode and verify a JWT using the injected token verifier."""
+        return await self.token_verifier.decode_token(token)
 
     # --- WebAuthn / Passkey Logic (Authlib Integration) ---
 

--- a/backend/app/infrastructure/external/jwt_verifier.py
+++ b/backend/app/infrastructure/external/jwt_verifier.py
@@ -32,7 +32,7 @@ class SupabaseJWTVerifier(TokenVerifierProtocol):
         try:
             try:
                 header = jwt.get_unverified_header(token)
-            except Exception as header_exc:
+            except jwt.PyJWTError as header_exc:
                 raise jwt.DecodeError("Invalid token format") from header_exc
 
             alg = header.get("alg")
@@ -54,6 +54,9 @@ class SupabaseJWTVerifier(TokenVerifierProtocol):
                     audience="authenticated",
                 )
             return JWTPayload(**payload)
-        except Exception as exc:
+        except jwt.PyJWTError as exc:
             logger.warning("JWT validation failed: %s", exc)
+            raise
+        except Exception:
+            logger.exception("Unexpected error during JWT validation")
             raise

--- a/backend/app/infrastructure/external/jwt_verifier.py
+++ b/backend/app/infrastructure/external/jwt_verifier.py
@@ -1,0 +1,59 @@
+"""JWT verifier infrastructure implementation."""
+
+from __future__ import annotations
+
+import logging
+
+import jwt
+
+from app.core.config import get_settings
+from app.domain.auth.interfaces import TokenVerifierProtocol
+from app.domain.auth.schemas import JWTPayload
+
+logger = logging.getLogger(__name__)
+
+
+class SupabaseJWTVerifier(TokenVerifierProtocol):
+    """Verifies and decodes Supabase JWTs."""
+
+    def __init__(self) -> None:
+        self._jwks_client: jwt.PyJWKClient | None = None
+
+    def _get_jwks_client(self) -> jwt.PyJWKClient:
+        if self._jwks_client is None:
+            settings = get_settings()
+            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
+            self._jwks_client = jwt.PyJWKClient(jwks_url)
+        return self._jwks_client
+
+    async def decode_token(self, token: str) -> JWTPayload:
+        """Decode and verify a Supabase JWT."""
+        settings = get_settings()
+        try:
+            try:
+                header = jwt.get_unverified_header(token)
+            except Exception as header_exc:
+                raise jwt.DecodeError("Invalid token format") from header_exc
+
+            alg = header.get("alg")
+
+            if alg == "HS256":
+                payload = jwt.decode(
+                    token,
+                    settings.supabase_jwt_secret,
+                    algorithms=["HS256"],
+                    audience="authenticated",
+                )
+            else:
+                jwks_client = self._get_jwks_client()
+                signing_key = jwks_client.get_signing_key_from_jwt(token)
+                payload = jwt.decode(
+                    token,
+                    signing_key.key,
+                    algorithms=["ES256", "RS256"],
+                    audience="authenticated",
+                )
+            return JWTPayload(**payload)
+        except Exception as exc:
+            logger.warning("JWT validation failed: %s", exc)
+            raise

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import jwt
 import pytest
@@ -19,51 +19,67 @@ from tests.conftest import make_jwt
 
 
 @pytest.mark.asyncio
-async def test_decode_valid_jwt() -> None:
-    """A valid JWT with a known secret decodes successfully."""
+async def test_auth_service_decode_delegates() -> None:
+    """AuthService delegates token decoding to the injected TokenVerifierProtocol."""
     from app.domain.auth.service import AuthService
-    from app.infrastructure.external.jwt_verifier import SupabaseJWTVerifier
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
+    mock_verifier = AsyncMock()
+    mock_payload = JWTPayload(
+        sub="00000000-0000-0000-0000-000000000000",
+        role="authenticated",
+        exp=9999999999,
+        iat=1234567890,
+    )
+    mock_verifier.decode_token.return_value = mock_payload
+
+    service = AuthService(AuthRepository(MagicMock()), mock_verifier)
+    payload = await service.decode_jwt("dummy_token")
+
+    assert payload == mock_payload
+    mock_verifier.decode_token.assert_called_once_with("dummy_token")
+
+
+@pytest.mark.asyncio
+async def test_verifier_valid_jwt() -> None:
+    """SupabaseJWTVerifier decodes a valid JWT successfully."""
+    from app.infrastructure.external.jwt_verifier import SupabaseJWTVerifier
+
     token = make_jwt()
-    service = AuthService(AuthRepository(MagicMock()), SupabaseJWTVerifier())
-    payload = await service.decode_jwt(token)
+    verifier = SupabaseJWTVerifier()
+    payload = await verifier.decode_token(token)
 
     assert isinstance(payload, JWTPayload)
     assert payload.role == "authenticated"
 
 
 @pytest.mark.asyncio
-async def test_decode_expired_jwt_raises_401() -> None:
-    """An expired JWT raises an error."""
-    from app.domain.auth.service import AuthService
+async def test_verifier_expired_jwt_raises() -> None:
+    """SupabaseJWTVerifier raises an error for an expired JWT."""
     from app.infrastructure.external.jwt_verifier import SupabaseJWTVerifier
-    from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt(expired=True)
-    service = AuthService(AuthRepository(MagicMock()), SupabaseJWTVerifier())
+    verifier = SupabaseJWTVerifier()
 
     with pytest.raises(jwt.ExpiredSignatureError):
-        await service.decode_jwt(token)
+        await verifier.decode_token(token)
 
 
 @pytest.mark.asyncio
-async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
-    """An invalid JWT format raises a DecodeError and logs a warning instead of an error."""
+async def test_verifier_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """SupabaseJWTVerifier raises a DecodeError for invalid format and logs a warning."""
     import logging
 
-    from app.domain.auth.service import AuthService
     from app.infrastructure.external.jwt_verifier import SupabaseJWTVerifier
-    from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = "invalid.token.format"
-    service = AuthService(AuthRepository(MagicMock()), SupabaseJWTVerifier())
+    verifier = SupabaseJWTVerifier()
 
     with (
         caplog.at_level(logging.WARNING),
         pytest.raises(jwt.DecodeError, match="Invalid token format"),
     ):
-        await service.decode_jwt(token)
+        await verifier.decode_token(token)
 
     assert any(
         record.levelname == "WARNING" and "JWT validation failed" in record.message

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
 
 import jwt
 import pytest
@@ -26,7 +27,7 @@ async def test_auth_service_decode_delegates() -> None:
 
     mock_verifier = AsyncMock()
     mock_payload = JWTPayload(
-        sub="00000000-0000-0000-0000-000000000000",
+        sub=UUID("00000000-0000-0000-0000-000000000000"),
         role="authenticated",
         exp=9999999999,
         iat=1234567890,
@@ -63,6 +64,29 @@ async def test_verifier_expired_jwt_raises() -> None:
 
     with pytest.raises(jwt.ExpiredSignatureError):
         await verifier.decode_token(token)
+
+
+@pytest.mark.asyncio
+async def test_verifier_unexpected_exception_logs_error(caplog: pytest.LogCaptureFixture) -> None:
+    """SupabaseJWTVerifier handles unexpected Exceptions by logging an error and re-raising."""
+    import logging
+    from unittest.mock import patch
+
+    from app.infrastructure.external.jwt_verifier import SupabaseJWTVerifier
+
+    verifier = SupabaseJWTVerifier()
+
+    with (
+        patch("jwt.get_unverified_header", side_effect=ValueError("Unexpected explosion")),
+        caplog.at_level(logging.ERROR),
+        pytest.raises(ValueError, match="Unexpected explosion"),
+    ):
+        await verifier.decode_token("some.token")
+
+    assert any(
+        record.levelname == "ERROR" and "Unexpected error during JWT validation" in record.message
+        for record in caplog.records
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -22,10 +22,11 @@ from tests.conftest import make_jwt
 async def test_decode_valid_jwt() -> None:
     """A valid JWT with a known secret decodes successfully."""
     from app.domain.auth.service import AuthService
+    from app.infrastructure.external.jwt_verifier import SupabaseJWTVerifier
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt()
-    service = AuthService(AuthRepository(MagicMock()))
+    service = AuthService(AuthRepository(MagicMock()), SupabaseJWTVerifier())
     payload = await service.decode_jwt(token)
 
     assert isinstance(payload, JWTPayload)
@@ -36,10 +37,11 @@ async def test_decode_valid_jwt() -> None:
 async def test_decode_expired_jwt_raises_401() -> None:
     """An expired JWT raises an error."""
     from app.domain.auth.service import AuthService
+    from app.infrastructure.external.jwt_verifier import SupabaseJWTVerifier
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt(expired=True)
-    service = AuthService(AuthRepository(MagicMock()))
+    service = AuthService(AuthRepository(MagicMock()), SupabaseJWTVerifier())
 
     with pytest.raises(jwt.ExpiredSignatureError):
         await service.decode_jwt(token)
@@ -51,10 +53,11 @@ async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureF
     import logging
 
     from app.domain.auth.service import AuthService
+    from app.infrastructure.external.jwt_verifier import SupabaseJWTVerifier
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = "invalid.token.format"
-    service = AuthService(AuthRepository(MagicMock()))
+    service = AuthService(AuthRepository(MagicMock()), SupabaseJWTVerifier())
 
     with (
         caplog.at_level(logging.WARNING),


### PR DESCRIPTION
Extract JWT decoding logic out of `AuthService` (Application layer) and into an injected `TokenVerifierProtocol` implemented by `SupabaseJWTVerifier` (Infrastructure layer) to adhere to Clean Architecture principles.

---
*PR created automatically by Jules for task [337159452169182176](https://jules.google.com/task/337159452169182176) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * JWT verification moved into a reusable verifier component and injected into the authentication service.
  * Real-time (WebSocket) authentication now uses the shared verifier.

* **Tests**
  * Expanded tests to cover token decoding delegation and verifier behavior, including valid, expired, and malformed token cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->