### PR TITLE
Refactor Auth Domain to Decouple JWT Verification

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from typing import Annotated
 
+import jwt
 from fastapi import Depends
 
 from app.domain.agents.service import AgentService
+from app.domain.auth.interfaces import TokenVerifierProtocol
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
 from app.domain.memory.service import MemoryService
@@ -15,6 +17,9 @@ from app.infrastructure.repositories.agent_repo import AgentRepository
 from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
 from app.infrastructure.repositories.memory_repo import MemoryRepository
+
+# Module-level singleton to ensure internal caches are reused
+_jwks_client: jwt.PyJWKClient | None = None
 
 # ---------------------------------------------------------------------------
 # Repository factories
@@ -36,6 +41,25 @@ def get_memory_repo() -> MemoryRepository:
 def get_auth_repo(db: SupabaseClient) -> AuthRepository:
     # AuthRepository still uses the Supabase client for passkey tables.
     return AuthRepository(db)
+
+
+# ---------------------------------------------------------------------------
+# Infrastructure factories
+# ---------------------------------------------------------------------------
+
+
+def get_token_verifier() -> TokenVerifierProtocol:
+    from app.core.security.auth import SupabaseJWTVerifier
+
+    global _jwks_client
+    if _jwks_client is None:
+        from app.core.config import get_settings
+
+        settings = get_settings()
+        jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
+        _jwks_client = jwt.PyJWKClient(jwks_url)
+
+    return SupabaseJWTVerifier(jwks_client=_jwks_client)
 
 
 # ---------------------------------------------------------------------------
@@ -62,5 +86,7 @@ def get_memory_service(
     return MemoryService(repo)
 
 
-def get_auth_service(repo: Annotated[AuthRepository, Depends(get_auth_repo)]) -> AuthService:
-    return AuthService(repo)
+def get_auth_service(
+    repo: Annotated[AuthRepository, Depends(get_auth_repo)],
+) -> AuthService:
+    return AuthService(repo=repo)

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -27,6 +27,7 @@ import json
 import logging
 from uuid import UUID
 
+import jwt
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
 from app.api.dependencies import get_token_verifier
@@ -51,7 +52,7 @@ async def _verify_token(token: str) -> UUID | None:
         verifier = get_token_verifier()
         payload = await verifier.verify_token(token)
         return payload.sub
-    except Exception:
+    except jwt.PyJWTError:
         logger.warning("WS auth rejected: invalid token")
         return None
 

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -29,12 +29,10 @@ from uuid import UUID
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
+from app.api.dependencies import get_token_verifier
 from app.domain.agents.service import AgentService
-from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
-from app.infrastructure.database.supabase import get_supabase
 from app.infrastructure.repositories.agent_repo import AgentRepository
-from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
 from app.infrastructure.repositories.memory_repo import MemoryRepository
 from app.infrastructure.websocket.manager import chat_hub
@@ -43,17 +41,15 @@ router = APIRouter(tags=["WebSocket"])
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# JWT authentication — delegates to AuthService so algorithm/claims handling
-# stays centralised; uses a query-param token because WS upgrades cannot carry
-# a custom Authorization header from most clients.
+# JWT authentication
 # ---------------------------------------------------------------------------
 
 
 async def _verify_token(token: str) -> UUID | None:
-    """Decode a Supabase JWT by delegating to AuthService.decode_jwt."""
+    """Decode a Supabase JWT by delegating to SupabaseJWTVerifier."""
     try:
-        auth_service = AuthService(AuthRepository(get_supabase()))
-        payload = await auth_service.decode_jwt(token)
+        verifier = get_token_verifier()
+        payload = await verifier.verify_token(token)
         return payload.sub
     except Exception:
         logger.warning("WS auth rejected: invalid token")

--- a/backend/app/core/security/auth.py
+++ b/backend/app/core/security/auth.py
@@ -39,9 +39,7 @@ class SupabaseJWTVerifier:
         try:
             try:
                 header = jwt.get_unverified_header(token)
-            except (jwt.DecodeError, Exception) as header_exc:
-                if not isinstance(header_exc, jwt.DecodeError):
-                    logger.warning("JWT validation failed: %s", header_exc)
+            except jwt.DecodeError as header_exc:
                 raise jwt.DecodeError("Invalid token format") from header_exc
 
             alg = header.get("alg")
@@ -63,17 +61,8 @@ class SupabaseJWTVerifier:
                     audience="authenticated",
                 )
             return JWTPayload(**payload)
-        except jwt.ExpiredSignatureError:
-            logger.warning("JWT validation failed: Signature expired")
-            raise
-        except jwt.DecodeError:
-            logger.warning("JWT validation failed: Decode error")
-            raise
-        except jwt.InvalidTokenError as exc:
+        except (jwt.ExpiredSignatureError, jwt.DecodeError, jwt.InvalidTokenError, jwt.PyJWKClientError) as exc:
             logger.warning("JWT validation failed: %s", exc)
-            raise
-        except jwt.PyJWKClientError as exc:
-            logger.warning("JWT JWKS validation failed: %s", exc)
             raise
 
 
@@ -84,11 +73,18 @@ async def get_current_user(
     """FastAPI dependency that validates the Bearer token and returns the user UUID."""
     try:
         payload = await token_verifier.verify_token(credentials.credentials)
-    except Exception:
+    except jwt.PyJWTError:
         raise_api_error(
             status_code=status.HTTP_401_UNAUTHORIZED,
             error="invalid_authentication_token",
             message="Invalid authentication token.",
+        )
+    except Exception:
+        logger.exception("Unexpected error during token verification")
+        raise_api_error(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            error="internal_server_error",
+            message="An unexpected error occurred during authentication.",
         )
 
     # payload is now a JWTPayload model, use attribute access

--- a/backend/app/core/security/auth.py
+++ b/backend/app/core/security/auth.py
@@ -61,7 +61,12 @@ class SupabaseJWTVerifier:
                     audience="authenticated",
                 )
             return JWTPayload(**payload)
-        except (jwt.ExpiredSignatureError, jwt.DecodeError, jwt.InvalidTokenError, jwt.PyJWKClientError) as exc:
+        except (
+            jwt.ExpiredSignatureError,
+            jwt.DecodeError,
+            jwt.InvalidTokenError,
+            jwt.PyJWKClientError,
+        ) as exc:
             logger.warning("JWT validation failed: %s", exc)
             raise
 

--- a/backend/app/core/security/auth.py
+++ b/backend/app/core/security/auth.py
@@ -2,27 +2,88 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated
 from uuid import UUID
 
+import jwt
 from fastapi import Depends, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
-from app.api.dependencies import get_auth_service
+from app.api.dependencies import get_token_verifier
 from app.api.errors import raise_api_error
-from app.domain.auth.service import AuthService  # noqa: TCH001
+from app.core.config import get_settings
+from app.domain.auth.interfaces import TokenVerifierProtocol
+from app.domain.auth.schemas import JWTPayload
+
+logger = logging.getLogger(__name__)
 
 # HTTPBearer extracts the Bearer token from the Authorization header.
 _bearer = HTTPBearer(auto_error=True)
 
 
+class SupabaseJWTVerifier:
+    def __init__(self, jwks_client: jwt.PyJWKClient | None = None) -> None:
+        self._jwks_client = jwks_client
+
+    def _get_jwks_client(self) -> jwt.PyJWKClient:
+        if self._jwks_client is None:
+            settings = get_settings()
+            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
+            self._jwks_client = jwt.PyJWKClient(jwks_url)
+        return self._jwks_client
+
+    async def verify_token(self, token: str) -> JWTPayload:
+        """Decode and verify a Supabase JWT."""
+        settings = get_settings()
+        try:
+            try:
+                header = jwt.get_unverified_header(token)
+            except (jwt.DecodeError, Exception) as header_exc:
+                if not isinstance(header_exc, jwt.DecodeError):
+                    logger.warning("JWT validation failed: %s", header_exc)
+                raise jwt.DecodeError("Invalid token format") from header_exc
+
+            alg = header.get("alg")
+
+            if alg == "HS256":
+                payload = jwt.decode(
+                    token,
+                    settings.supabase_jwt_secret,
+                    algorithms=["HS256"],
+                    audience="authenticated",
+                )
+            else:
+                jwks_client = self._get_jwks_client()
+                signing_key = jwks_client.get_signing_key_from_jwt(token)
+                payload = jwt.decode(
+                    token,
+                    signing_key.key,
+                    algorithms=["ES256", "RS256"],
+                    audience="authenticated",
+                )
+            return JWTPayload(**payload)
+        except jwt.ExpiredSignatureError:
+            logger.warning("JWT validation failed: Signature expired")
+            raise
+        except jwt.DecodeError:
+            logger.warning("JWT validation failed: Decode error")
+            raise
+        except jwt.InvalidTokenError as exc:
+            logger.warning("JWT validation failed: %s", exc)
+            raise
+        except jwt.PyJWKClientError as exc:
+            logger.warning("JWT JWKS validation failed: %s", exc)
+            raise
+
+
 async def get_current_user(
     credentials: Annotated[HTTPAuthorizationCredentials, Depends(_bearer)],
-    auth_service: Annotated[AuthService, Depends(get_auth_service)],
+    token_verifier: Annotated[TokenVerifierProtocol, Depends(get_token_verifier)],
 ) -> UUID:
     """FastAPI dependency that validates the Bearer token and returns the user UUID."""
     try:
-        payload = await auth_service.decode_jwt(credentials.credentials)
+        payload = await token_verifier.verify_token(credentials.credentials)
     except Exception:
         raise_api_error(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/app/domain/auth/interfaces.py
+++ b/backend/app/domain/auth/interfaces.py
@@ -6,6 +6,7 @@ from typing import Protocol
 from uuid import UUID
 
 from app.domain.auth.entities import Passkey, PasskeyCreate
+from app.domain.auth.schemas import JWTPayload
 
 
 class AuthRepositoryProtocol(Protocol):
@@ -15,16 +16,24 @@ class AuthRepositoryProtocol(Protocol):
         self, user_id: str | UUID, limit: int = 50, cursor: str | None = None
     ) -> tuple[list[Passkey], str | None]:
         """Fetch all registered passkeys for a user with pagination."""
-        ...
+        pass
 
     async def update_sign_count(self, passkey_id: str | UUID, new_count: int) -> None:
         """Update the signature count for a passkey."""
-        ...
+        pass
 
     async def create_passkey(self, input: PasskeyCreate) -> Passkey:
         """Insert a new passkey record."""
-        ...
+        pass
 
     async def delete_passkey(self, passkey_id: str | UUID, user_id: str | UUID) -> bool:
         """Delete a passkey belonging to a user."""
-        ...
+        pass
+
+
+class TokenVerifierProtocol(Protocol):
+    """Protocol for verifying authentication tokens."""
+
+    async def verify_token(self, token: str) -> JWTPayload:
+        """Verify an authentication token and return its payload."""
+        pass

--- a/backend/app/domain/auth/interfaces.py
+++ b/backend/app/domain/auth/interfaces.py
@@ -16,19 +16,19 @@ class AuthRepositoryProtocol(Protocol):
         self, user_id: str | UUID, limit: int = 50, cursor: str | None = None
     ) -> tuple[list[Passkey], str | None]:
         """Fetch all registered passkeys for a user with pagination."""
-        pass
+        ...
 
     async def update_sign_count(self, passkey_id: str | UUID, new_count: int) -> None:
         """Update the signature count for a passkey."""
-        pass
+        ...
 
     async def create_passkey(self, input: PasskeyCreate) -> Passkey:
         """Insert a new passkey record."""
-        pass
+        ...
 
     async def delete_passkey(self, passkey_id: str | UUID, user_id: str | UUID) -> bool:
         """Delete a passkey belonging to a user."""
-        pass
+        ...
 
 
 class TokenVerifierProtocol(Protocol):
@@ -36,4 +36,4 @@ class TokenVerifierProtocol(Protocol):
 
     async def verify_token(self, token: str) -> JWTPayload:
         """Verify an authentication token and return its payload."""
-        pass
+        ...

--- a/backend/app/domain/auth/service.py
+++ b/backend/app/domain/auth/service.py
@@ -6,11 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-import jwt
-
-from app.core.config import get_settings
 from app.domain.auth.entities import Passkey
-from app.domain.auth.schemas import JWTPayload
 
 if TYPE_CHECKING:
     from app.domain.auth.interfaces import AuthRepositoryProtocol
@@ -21,52 +17,12 @@ logger = logging.getLogger(__name__)
 class AuthService:
     def __init__(self, repo: AuthRepositoryProtocol) -> None:
         self.repo = repo
-        self._jwks_client: jwt.PyJWKClient | None = None
 
     async def list_passkeys(
         self, user_id: str | UUID, limit: int = 50, cursor: str | None = None
     ) -> tuple[list[Passkey], str | None]:
         """Fetch a paginated list of passkeys for a user."""
         return await self.repo.get_passkeys_by_user(user_id, limit=limit, cursor=cursor)
-
-    def _get_jwks_client(self) -> jwt.PyJWKClient:
-        if self._jwks_client is None:
-            settings = get_settings()
-            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
-            self._jwks_client = jwt.PyJWKClient(jwks_url)
-        return self._jwks_client
-
-    async def decode_jwt(self, token: str) -> JWTPayload:
-        """Decode and verify a Supabase JWT."""
-        settings = get_settings()
-        try:
-            try:
-                header = jwt.get_unverified_header(token)
-            except Exception as header_exc:
-                raise jwt.DecodeError("Invalid token format") from header_exc
-
-            alg = header.get("alg")
-
-            if alg == "HS256":
-                payload = jwt.decode(
-                    token,
-                    settings.supabase_jwt_secret,
-                    algorithms=["HS256"],
-                    audience="authenticated",
-                )
-            else:
-                jwks_client = self._get_jwks_client()
-                signing_key = jwks_client.get_signing_key_from_jwt(token)
-                payload = jwt.decode(
-                    token,
-                    signing_key.key,
-                    algorithms=["ES256", "RS256"],
-                    audience="authenticated",
-                )
-            return JWTPayload(**payload)
-        except Exception as exc:
-            logger.warning("JWT validation failed: %s", exc)
-            raise
 
     # --- WebAuthn / Passkey Logic (Authlib Integration) ---
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -129,9 +129,7 @@ async def test_decode_jwt_jwks_error(caplog: pytest.LogCaptureFixture) -> None:
     ):
         await verifier.verify_token(token)
 
-    assert any(
-        "JWT validation failed: jwks failure" in record.message for record in caplog.records
-    )
+    assert any("JWT validation failed: jwks failure" in record.message for record in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -170,3 +168,48 @@ def test_invalid_token_returns_401(client: TestClient) -> None:
         assert response.status_code == 401
     finally:
         app.dependency_overrides = {}
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_unexpected_error(caplog: pytest.LogCaptureFixture) -> None:
+    """get_current_user raises 500 APIError on non-JWT exception."""
+    verifier = MagicMock()
+    verifier.verify_token.side_effect = Exception("database down")
+
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="bad_token")
+
+    with caplog.at_level(logging.ERROR), pytest.raises(HTTPException) as exc_info:
+        await get_current_user(credentials=creds, token_verifier=verifier)
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail["error"] == "internal_server_error"
+    assert any(
+        "Unexpected error during token verification" in record.message for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_success() -> None:
+    """get_current_user successfully extracts user_id on valid token."""
+    verifier = MagicMock()
+
+    now = int(time.time())
+    fake_payload = JWTPayload(
+        sub="11111111-1111-1111-1111-111111111111",
+        role="authenticated",
+        iat=now,
+        exp=now + 3600,
+        iss="supabase",
+        aud="authenticated",
+    )
+
+    import asyncio
+
+    future = asyncio.Future()
+    future.set_result(fake_payload)
+    verifier.verify_token.return_value = future
+
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="good_token")
+
+    user_id = await get_current_user(credentials=creds, token_verifier=verifier)
+    assert str(user_id) == "11111111-1111-1111-1111-111111111111"

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -71,9 +71,10 @@ async def test_decode_es256_jwt_via_jwks() -> None:
     """An ES256 JWT uses PyJWKClient to fetch signing key."""
     token = make_jwt()
 
-    with patch("jwt.get_unverified_header", return_value={"alg": "ES256"}), \
-         patch("jwt.PyJWKClient.get_signing_key_from_jwt") as mock_get_key:
-
+    with (
+        patch("jwt.get_unverified_header", return_value={"alg": "ES256"}),
+        patch("jwt.PyJWKClient.get_signing_key_from_jwt") as mock_get_key,
+    ):
         mock_key = MagicMock()
         mock_key.key = "fake_key"
         mock_get_key.return_value = mock_key
@@ -85,7 +86,7 @@ async def test_decode_es256_jwt_via_jwks() -> None:
             "iat": now,
             "exp": now + 3600,
             "iss": "supabase",
-            "aud": "authenticated"
+            "aud": "authenticated",
         }
         with patch("jwt.decode", return_value=fake_payload):
             verifier = SupabaseJWTVerifier()
@@ -101,9 +102,11 @@ async def test_decode_jwt_invalid_token_error(caplog: pytest.LogCaptureFixture) 
     token = make_jwt()
     verifier = SupabaseJWTVerifier()
 
-    with patch("jwt.decode", side_effect=jwt.InvalidTokenError("bad token")), \
-         caplog.at_level(logging.WARNING), \
-         pytest.raises(jwt.InvalidTokenError):
+    with (
+        patch("jwt.decode", side_effect=jwt.InvalidTokenError("bad token")),
+        caplog.at_level(logging.WARNING),
+        pytest.raises(jwt.InvalidTokenError),
+    ):
         await verifier.verify_token(token)
 
     assert any("JWT validation failed: bad token" in record.message for record in caplog.records)
@@ -115,13 +118,20 @@ async def test_decode_jwt_jwks_error(caplog: pytest.LogCaptureFixture) -> None:
     token = make_jwt()
     verifier = SupabaseJWTVerifier()
 
-    with patch("jwt.get_unverified_header", return_value={"alg": "ES256"}), \
-         patch("jwt.PyJWKClient.get_signing_key_from_jwt", side_effect=jwt.PyJWKClientError("jwks failure")), \
-         caplog.at_level(logging.WARNING), \
-         pytest.raises(jwt.PyJWKClientError):
+    with (
+        patch("jwt.get_unverified_header", return_value={"alg": "ES256"}),
+        patch(
+            "jwt.PyJWKClient.get_signing_key_from_jwt",
+            side_effect=jwt.PyJWKClientError("jwks failure"),
+        ),
+        caplog.at_level(logging.WARNING),
+        pytest.raises(jwt.PyJWKClientError),
+    ):
         await verifier.verify_token(token)
 
-    assert any("JWT JWKS validation failed: jwks failure" in record.message for record in caplog.records)
+    assert any(
+        "JWT validation failed: jwks failure" in record.message for record in caplog.records
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -21,12 +21,11 @@ from tests.conftest import make_jwt
 @pytest.mark.asyncio
 async def test_decode_valid_jwt() -> None:
     """A valid JWT with a known secret decodes successfully."""
-    from app.domain.auth.service import AuthService
-    from app.infrastructure.repositories.auth_repo import AuthRepository
+    from app.core.security.auth import SupabaseJWTVerifier
 
     token = make_jwt()
-    service = AuthService(AuthRepository(MagicMock()))
-    payload = await service.decode_jwt(token)
+    verifier = SupabaseJWTVerifier()
+    payload = await verifier.verify_token(token)
 
     assert isinstance(payload, JWTPayload)
     assert payload.role == "authenticated"
@@ -35,14 +34,13 @@ async def test_decode_valid_jwt() -> None:
 @pytest.mark.asyncio
 async def test_decode_expired_jwt_raises_401() -> None:
     """An expired JWT raises an error."""
-    from app.domain.auth.service import AuthService
-    from app.infrastructure.repositories.auth_repo import AuthRepository
+    from app.core.security.auth import SupabaseJWTVerifier
 
     token = make_jwt(expired=True)
-    service = AuthService(AuthRepository(MagicMock()))
+    verifier = SupabaseJWTVerifier()
 
     with pytest.raises(jwt.ExpiredSignatureError):
-        await service.decode_jwt(token)
+        await verifier.verify_token(token)
 
 
 @pytest.mark.asyncio
@@ -50,17 +48,16 @@ async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureF
     """An invalid JWT format raises a DecodeError and logs a warning instead of an error."""
     import logging
 
-    from app.domain.auth.service import AuthService
-    from app.infrastructure.repositories.auth_repo import AuthRepository
+    from app.core.security.auth import SupabaseJWTVerifier
 
     token = "invalid.token.format"
-    service = AuthService(AuthRepository(MagicMock()))
+    verifier = SupabaseJWTVerifier()
 
     with (
         caplog.at_level(logging.WARNING),
         pytest.raises(jwt.DecodeError, match="Invalid token format"),
     ):
-        await service.decode_jwt(token)
+        await verifier.verify_token(token)
 
     assert any(
         record.levelname == "WARNING" and "JWT validation failed" in record.message

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import logging
+import time
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import jwt
 import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
 
+from app.core.security.auth import SupabaseJWTVerifier, get_current_user
 from app.domain.auth.schemas import JWTPayload
 from app.infrastructure.database.supabase import get_supabase
 from app.main import app
@@ -21,8 +26,6 @@ from tests.conftest import make_jwt
 @pytest.mark.asyncio
 async def test_decode_valid_jwt() -> None:
     """A valid JWT with a known secret decodes successfully."""
-    from app.core.security.auth import SupabaseJWTVerifier
-
     token = make_jwt()
     verifier = SupabaseJWTVerifier()
     payload = await verifier.verify_token(token)
@@ -34,8 +37,6 @@ async def test_decode_valid_jwt() -> None:
 @pytest.mark.asyncio
 async def test_decode_expired_jwt_raises_401() -> None:
     """An expired JWT raises an error."""
-    from app.core.security.auth import SupabaseJWTVerifier
-
     token = make_jwt(expired=True)
     verifier = SupabaseJWTVerifier()
 
@@ -46,10 +47,6 @@ async def test_decode_expired_jwt_raises_401() -> None:
 @pytest.mark.asyncio
 async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
     """An invalid JWT format raises a DecodeError and logs a warning instead of an error."""
-    import logging
-
-    from app.core.security.auth import SupabaseJWTVerifier
-
     token = "invalid.token.format"
     verifier = SupabaseJWTVerifier()
 
@@ -67,6 +64,79 @@ async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureF
         record.levelname == "ERROR" and "JWT validation failed" in record.message
         for record in caplog.records
     )
+
+
+@pytest.mark.asyncio
+async def test_decode_es256_jwt_via_jwks() -> None:
+    """An ES256 JWT uses PyJWKClient to fetch signing key."""
+    token = make_jwt()
+
+    with patch("jwt.get_unverified_header", return_value={"alg": "ES256"}), \
+         patch("jwt.PyJWKClient.get_signing_key_from_jwt") as mock_get_key:
+
+        mock_key = MagicMock()
+        mock_key.key = "fake_key"
+        mock_get_key.return_value = mock_key
+
+        now = int(time.time())
+        fake_payload = {
+            "sub": "11111111-1111-1111-1111-111111111111",
+            "role": "authenticated",
+            "iat": now,
+            "exp": now + 3600,
+            "iss": "supabase",
+            "aud": "authenticated"
+        }
+        with patch("jwt.decode", return_value=fake_payload):
+            verifier = SupabaseJWTVerifier()
+            payload = await verifier.verify_token(token)
+
+            assert isinstance(payload, JWTPayload)
+            assert str(payload.sub) == "11111111-1111-1111-1111-111111111111"
+
+
+@pytest.mark.asyncio
+async def test_decode_jwt_invalid_token_error(caplog: pytest.LogCaptureFixture) -> None:
+    """jwt.InvalidTokenError is caught and logged."""
+    token = make_jwt()
+    verifier = SupabaseJWTVerifier()
+
+    with patch("jwt.decode", side_effect=jwt.InvalidTokenError("bad token")), \
+         caplog.at_level(logging.WARNING), \
+         pytest.raises(jwt.InvalidTokenError):
+        await verifier.verify_token(token)
+
+    assert any("JWT validation failed: bad token" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_decode_jwt_jwks_error(caplog: pytest.LogCaptureFixture) -> None:
+    """jwt.PyJWKClientError is caught and logged."""
+    token = make_jwt()
+    verifier = SupabaseJWTVerifier()
+
+    with patch("jwt.get_unverified_header", return_value={"alg": "ES256"}), \
+         patch("jwt.PyJWKClient.get_signing_key_from_jwt", side_effect=jwt.PyJWKClientError("jwks failure")), \
+         caplog.at_level(logging.WARNING), \
+         pytest.raises(jwt.PyJWKClientError):
+        await verifier.verify_token(token)
+
+    assert any("JWT JWKS validation failed: jwks failure" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_invalid_token() -> None:
+    """get_current_user raises HTTPException on verification failure."""
+    verifier = MagicMock()
+    verifier.verify_token.side_effect = jwt.InvalidTokenError()
+
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="bad_token")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(credentials=creds, token_verifier=verifier)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail["error"] == "invalid_authentication_token"
 
 
 def test_memories_requires_auth(client: TestClient) -> None:

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -1,0 +1,120 @@
+"""Tests for auth routes."""
+
+from __future__ import annotations
+
+import datetime
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.api.dependencies import get_auth_service
+from app.core.security.auth import get_current_user
+from app.domain.auth.entities import Passkey
+from app.main import app
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def override_auth(client: TestClient):
+    user_id = uuid4()
+    app.dependency_overrides[get_current_user] = lambda: user_id
+    mock_service = MagicMock()
+    app.dependency_overrides[get_auth_service] = lambda: mock_service
+    yield client, mock_service, user_id
+    app.dependency_overrides.pop(get_current_user, None)
+    app.dependency_overrides.pop(get_auth_service, None)
+
+
+def test_get_registration_options(override_auth):
+    client, mock_service, user_id = override_auth
+    response = client.post("/api/v1/auth/passkey/register/options", json={})
+    assert response.status_code == 200
+    assert response.json()["challenge"] == "dummy_challenge"
+
+
+def test_verify_registration(override_auth):
+    client, mock_service, user_id = override_auth
+    # Make sure verify_registration resolves
+    import asyncio
+
+    future = asyncio.Future()
+    future.set_result(None)
+    mock_service.verify_registration.return_value = future
+
+    response = client.post(
+        "/api/v1/auth/passkey/register/verify", json={"challenge_id": "ch", "credential": "cred"}
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_get_login_options(override_auth):
+    client, mock_service, user_id = override_auth
+    response = client.post("/api/v1/auth/passkey/login/options", json={"email": "test@test.com"})
+    assert response.status_code == 200
+    assert response.json()["challenge"] == "dummy_challenge"
+
+
+def test_verify_login(override_auth):
+    client, mock_service, user_id = override_auth
+    response = client.post(
+        "/api/v1/auth/passkey/login/verify", json={"credential": "c", "challenge_id": "c"}
+    )
+    assert response.status_code == 200
+    assert response.json()["access_token"] == "dummy_access_token"
+
+
+def test_list_passkeys(override_auth):
+    client, mock_service, user_id = override_auth
+
+    import asyncio
+
+    future = asyncio.Future()
+    mock_passkey = Passkey(
+        id=uuid4(),
+        user_id=user_id,
+        credential_id="cred",
+        public_key="pub",
+        sign_count=0,
+        device_name="test",
+        created_at=datetime.datetime.now(),
+        last_used_at=datetime.datetime.now(),
+    )
+    future.set_result(([mock_passkey], "next"))
+    mock_service.list_passkeys.return_value = future
+
+    response = client.get("/api/v1/auth/passkey/list")
+    assert response.status_code == 200
+    assert response.json()["next_cursor"] == "next"
+    assert len(response.json()["passkeys"]) == 1
+
+
+def test_delete_passkey_success(override_auth):
+    client, mock_service, user_id = override_auth
+
+    import asyncio
+
+    future = asyncio.Future()
+    future.set_result(True)
+    mock_service.delete_passkey.return_value = future
+
+    response = client.delete("/api/v1/auth/passkey/test_id")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_delete_passkey_not_found(override_auth):
+    client, mock_service, user_id = override_auth
+
+    import asyncio
+
+    future = asyncio.Future()
+    future.set_result(False)
+    mock_service.delete_passkey.return_value = future
+
+    response = client.delete("/api/v1/auth/passkey/test_id")
+    assert response.status_code == 404

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -1,0 +1,52 @@
+"""Tests for auth service."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.domain.auth.entities import Passkey
+from app.domain.auth.service import AuthService
+
+
+@pytest.mark.asyncio
+async def test_auth_service_list_passkeys():
+    repo = AsyncMock()
+    user_id = uuid4()
+    mock_passkeys = [
+        Passkey(
+            id=uuid4(), user_id=user_id, credential_id="cred_id", public_key="pub_key", sign_count=0
+        )
+    ]
+    repo.get_passkeys_by_user.return_value = (mock_passkeys, "next_cursor")
+
+    service = AuthService(repo)
+    passkeys, cursor = await service.list_passkeys(user_id, limit=10, cursor="cursor")
+
+    assert passkeys == mock_passkeys
+    assert cursor == "next_cursor"
+    repo.get_passkeys_by_user.assert_called_once_with(user_id, limit=10, cursor="cursor")
+
+
+@pytest.mark.asyncio
+async def test_auth_service_delete_passkey():
+    repo = AsyncMock()
+    user_id = uuid4()
+    passkey_id = str(uuid4())
+    repo.delete_passkey.return_value = True
+
+    service = AuthService(repo)
+    result = await service.delete_passkey(passkey_id, user_id)
+
+    assert result is True
+    repo.delete_passkey.assert_called_once_with(passkey_id, user_id)
+
+
+@pytest.mark.asyncio
+async def test_auth_service_verify_registration():
+    repo = AsyncMock()
+    service = AuthService(repo)
+    result = await service.verify_registration("challenge", "json")
+    assert result is None

--- a/fix_mock.py
+++ b/fix_mock.py
@@ -1,7 +1,0 @@
-with open("backend/tests/test_auth.py", "r") as f:
-    code = f.read()
-
-code = code.replace("verifier.verify_token.return_value = fake_payload", "verifier.verify_token.return_value = fake_payload\n    import asyncio\n    future = asyncio.Future()\n    future.set_result(fake_payload)\n    verifier.verify_token.return_value = future")
-
-with open("backend/tests/test_auth.py", "w") as f:
-    f.write(code)

--- a/fix_mock.py
+++ b/fix_mock.py
@@ -1,0 +1,7 @@
+with open("backend/tests/test_auth.py", "r") as f:
+    code = f.read()
+
+code = code.replace("verifier.verify_token.return_value = fake_payload", "verifier.verify_token.return_value = fake_payload\n    import asyncio\n    future = asyncio.Future()\n    future.set_result(fake_payload)\n    verifier.verify_token.return_value = future")
+
+with open("backend/tests/test_auth.py", "w") as f:
+    f.write(code)


### PR DESCRIPTION
**Debt Identified**: `AuthService` handled both business logic (managing passkeys) and infrastructure concerns (fetching external JWKS keys, decoding JWTs). It also contained bare `except Exception:` blocks for `pyjwt` decoding.

**Refactored Code**: 
- Extracted JWT logic into `SupabaseJWTVerifier`.
- Created `TokenVerifierProtocol` and updated `dependencies.py` to inject it as a singleton.
- Hardened exception handling by catching specific `jwt` errors.
- Updated `AuthService` and tests to remove the old implementation and rely on the decoupled protocol.

**Structural Note**: This refactoring implements the SOLID principles (SRP and DIP) by separating authentication infrastructure from the core auth domain logic. It prevents `AuthService` from being a "God Class" and makes testing the JWT verifier fully isolated.

---
*PR created automatically by Jules for task [13356851463287625576](https://jules.google.com/task/13356851463287625576) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured JWT token verification system to use a dedicated token verifier component.
  * Updated WebSocket authentication to utilize the new verification mechanism.
  * Clarified authentication repository interfaces with explicit method contracts.

* **Tests**
  * Updated authentication tests to validate the new token verification implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->