### PR TITLE
refactor: Enforce structured LLM outputs using Pydantic instead of regex

### DIFF
--- a/backend/app/domain/chat/background_service.py
+++ b/backend/app/domain/chat/background_service.py
@@ -67,11 +67,11 @@ class ChatBackgroundService:
         room_id: UUID,
         user_message: str,
         responded_agents: list[Agent],
-        result_text: str,
+        transcript: Any,
         agent_names: list[str],
     ) -> None:
         """Embed and store the conversation turn as memories for future retrieval."""
-        from app.domain.chat.websocket_broadcaster import ChatWebSocketBroadcaster
+        from app.domain.chat.dtos import ChatTranscript
         from app.domain.memory.models import Memory
         from app.infrastructure.external.openrouter import embed
 
@@ -91,7 +91,9 @@ class ChatBackgroundService:
 
             # Store each agent response segment individually
             agent_by_name = {a.name.lower(): a for a in responded_agents}
-            segments = ChatWebSocketBroadcaster.parse_transcript(result_text, agent_names)
+            if not isinstance(transcript, ChatTranscript):
+                return
+            segments = [(resp.agent_name, resp.message) for resp in transcript.responses]
             for agent_name, content in segments:
                 matched = (
                     agent_by_name.get(agent_name.lower())

--- a/backend/app/domain/chat/crew_orchestrator.py
+++ b/backend/app/domain/chat/crew_orchestrator.py
@@ -21,13 +21,12 @@ from app.domain.agent_tools.productivity_tools import (
     UpdateEventTool,
     UpdateTaskTool,
 )
+from app.domain.chat.dtos import ChatTranscript
 from app.domain.chat.language import resolve_language
 from app.domain.chat.prompts import (
     HISTORY_PREFIX,
     MEMORY_PREFIX,
-    MULTI_AGENT_EXPECTED_OUTPUT,
     MULTI_AGENT_PROMPT,
-    SINGLE_AGENT_EXPECTED_OUTPUT,
     SINGLE_AGENT_PROMPT,
     SUMMARY_PREFIX,
 )
@@ -197,7 +196,7 @@ class CrewOrchestrator:
         conversation_history: list[dict] | None = None,
         memory_context: str | None = None,
         room_summary: str | None = None,
-    ) -> str:
+    ) -> ChatTranscript:
         """Build and execute the CrewAI task.
 
         ``conversation_history`` is a list of ``{"role": "user"|"agent", "name": str,
@@ -247,7 +246,7 @@ class CrewOrchestrator:
                     user_message=user_message,
                     locale_instruction=locale_instruction,
                 ),
-                expected_output=MULTI_AGENT_EXPECTED_OUTPUT,
+                output_pydantic=ChatTranscript,
             )
             crew = Crew(
                 agents=cast("Any", crew_agents),
@@ -265,7 +264,7 @@ class CrewOrchestrator:
                     user_message=user_message,
                     locale_instruction=locale_instruction,
                 ),
-                expected_output=SINGLE_AGENT_EXPECTED_OUTPUT,
+                output_pydantic=ChatTranscript,
                 agent=crew_agents[0],
             )
             crew = Crew(
@@ -289,4 +288,4 @@ class CrewOrchestrator:
                 logger.warning("Crew kickoff failed on attempt 1, retrying in 2 s…")
                 await asyncio.sleep(2)
 
-        return str(result)
+        return cast(ChatTranscript, result.pydantic if result else None)

--- a/backend/app/domain/chat/dtos.py
+++ b/backend/app/domain/chat/dtos.py
@@ -68,3 +68,10 @@ class MessageUpdate(BaseModel):
         if not v.strip():
             raise ValueError("content must not be blank or whitespace only")
         return v.strip()
+
+class AgentResponseSegment(BaseModel):
+    agent_name: str
+    message: str
+
+class ChatTranscript(BaseModel):
+    responses: list[AgentResponseSegment]

--- a/backend/app/domain/chat/prompts.py
+++ b/backend/app/domain/chat/prompts.py
@@ -31,8 +31,7 @@ MULTI_AGENT_PROMPT = (
     "(tasks/notes/events) and propose a concrete plan. "
     "Before creating, updating, or deleting tasks/notes/events, confirm intent briefly unless "
     "the user explicitly asked you to perform the action now. "
-    "Return a transcript of only the agents who actually responded, "
-    "formatted as 'AgentName: message' with one blank line between agents.{locale_instruction}"
+    "Return the exact JSON structure matching ChatTranscript containing ONLY the agents who actually responded.{locale_instruction}"
 )
 
 SINGLE_AGENT_PROMPT = (
@@ -43,13 +42,6 @@ SINGLE_AGENT_PROMPT = (
     "Respond naturally and helpfully as yourself. "
     "When relevant, be proactive about planning and converting intent into tasks/notes/events. "
     "Confirm before write actions unless the user explicitly requested immediate execution. "
-    "Do not introduce yourself or list your capabilities — just answer directly.{locale_instruction}"
+    "Do not introduce yourself or list your capabilities — just answer directly. "
+    "Return the exact JSON structure matching ChatTranscript with your response.{locale_instruction}"
 )
-
-MULTI_AGENT_EXPECTED_OUTPUT = (
-    "A chat transcript with only the relevant agents responding. "
-    "Format: 'AgentName: message' with one blank line between agents. "
-    "Agents should be concise and natural, not self-promotional."
-)
-
-SINGLE_AGENT_EXPECTED_OUTPUT = "A direct, helpful response to the user's message."

--- a/backend/app/domain/chat/service.py
+++ b/backend/app/domain/chat/service.py
@@ -266,7 +266,8 @@ class ChatService:
             accept_language=accept_language,
         )
 
-        return {"task_type": "general", "result": result}
+        result_text = "\n\n".join(f"{resp.agent_name}: {resp.message}" for resp in result.responses)
+        return {"task_type": "general", "result": result_text}
 
     @staticmethod
     def _build_history(
@@ -358,7 +359,7 @@ class ChatService:
             room = await self.chat_repo.get_room(room_id)
             room_summary = room.summary if room else None
 
-            result_text = await CrewOrchestrator.execute_crew_task(
+            transcript = await CrewOrchestrator.execute_crew_task(
                 room_agents=room_agents,
                 user_message=user_message,
                 user_id=user_id,
@@ -372,7 +373,7 @@ class ChatService:
 
             # 6. Persist + broadcast — returns only the agents that actually responded.
             responded_agents = await self.ws_broadcaster.persist_and_broadcast_agent_response(
-                room_id, room_agents, result_text, agent_names
+                room_id, room_agents, transcript, agent_names
             )
 
             await chat_hub.broadcast_to_room(
@@ -390,7 +391,8 @@ class ChatService:
 
             # 7. Fire background tasks: mood update, affinity, and memory storage.
             history_text = CrewOrchestrator.format_history(conversation_history)
-            recent_context = f"{history_text}\nUser: {user_message}\n{result_text}".strip()
+            transcript_text = "\n\n".join(f"{r.agent_name}: {r.message}" for r in transcript.responses)
+            recent_context = f"{history_text}\nUser: {user_message}\n{transcript_text}".strip()
 
             for agent in responded_agents:
                 asyncio.create_task(  # noqa: RUF006
@@ -402,7 +404,7 @@ class ChatService:
 
             asyncio.create_task(  # noqa: RUF006
                 self.bg_service.store_memories_background(
-                    user_id, room_id, user_message, responded_agents, result_text, agent_names
+                    user_id, room_id, user_message, responded_agents, transcript, agent_names
                 )
             )
 

--- a/backend/app/domain/chat/websocket_broadcaster.py
+++ b/backend/app/domain/chat/websocket_broadcaster.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
+from app.domain.chat.dtos import ChatTranscript
 from app.domain.chat.entities import ChatMessageEntity
 
 if TYPE_CHECKING:
@@ -134,52 +135,11 @@ class ChatWebSocketBroadcaster:
 
         return _step_callback
 
-    @staticmethod
-    def parse_transcript(result_text: str, agent_names: list[str]) -> list[tuple[str, str]]:
-        """Parse a multi-agent transcript into (agent_name, message) pairs.
-
-        Expected format: 'AgentName: message\\n\\nOtherAgent: message'
-        Falls back to a single unnamed entry when the format cannot be parsed.
-        """
-        if not agent_names or len(agent_names) == 1:
-            return [("", result_text.strip())]
-
-        # Build a set of known names (case-insensitive) for matching
-        name_set = {n.lower() for n in agent_names}
-        segments: list[tuple[str, str]] = []
-        current_name = ""
-        current_lines: list[str] = []
-
-        for line in result_text.splitlines():
-            # Detect "AgentName: ..." prefix
-            colon_pos = line.find(":")
-            if colon_pos > 0:
-                candidate = line[:colon_pos].strip()
-                if candidate.lower() in name_set:
-                    # Save previous segment
-                    if current_lines or current_name:
-                        segments.append((current_name, "\n".join(current_lines).strip()))
-                    current_name = candidate
-                    current_lines = [line[colon_pos + 1 :].strip()]
-                    continue
-            current_lines.append(line)
-
-        if current_lines or current_name:
-            segments.append((current_name, "\n".join(current_lines).strip()))
-
-        # Drop empty segments
-        segments = [(n, m) for n, m in segments if m]
-        return (
-            segments
-            if segments
-            else ([] if not result_text.strip() else [("", result_text.strip())])
-        )
-
     async def persist_and_broadcast_agent_response(
         self,
         room_id: UUID,
         room_agents: list[Agent],
-        result_text: str,
+        transcript: ChatTranscript,
         agent_names: list[str],
     ) -> list[Agent]:
         """Save the agent response(s) and broadcast to room.
@@ -195,7 +155,7 @@ class ChatWebSocketBroadcaster:
         from app.infrastructure.websocket.manager import chat_hub  # noqa: PLC0415
 
         agent_by_name = {a.name.lower(): a for a in room_agents}
-        segments = self.parse_transcript(result_text, agent_names)
+        segments = [(resp.agent_name, resp.message) for resp in transcript.responses]
 
         responded: list[Agent] = []
 


### PR DESCRIPTION
Harden the bridge between the codebase and the LLM by removing raw string processing and regex parsing, completely replacing them with strict Pydantic structures (`ChatTranscript`, `AgentResponseSegment`) fed to `crew.kickoff_async` via `output_pydantic`. This implements structured output across the Chat Service, the CrewAI Orchestrator, the Background Tasks, and the WebSocket Broadcaster.

---
*PR created automatically by Jules for task [11553965647757056005](https://jules.google.com/task/11553965647757056005) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal chat transcript processing to use structured data formats instead of raw text, enabling more reliable handling of multi-agent conversations.
  * Enhanced memory persistence from chat interactions for better conversation context retention.
  * Simplified agent response extraction and broadcast logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->