### PR TITLE
Refactor: Extract JWT verification to Clean Architecture Infrastructure

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -10,11 +10,22 @@ from app.domain.agents.service import AgentService
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
 from app.domain.memory.service import MemoryService
+from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
 from app.infrastructure.database.supabase import SupabaseClient
 from app.infrastructure.repositories.agent_repo import AgentRepository
 from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
 from app.infrastructure.repositories.memory_repo import MemoryRepository
+
+# Module-level singleton for token verifier to preserve internal caches (e.g. JWKS)
+_token_verifier: SupabaseJWTVerifier | None = None
+
+
+def get_token_verifier() -> SupabaseJWTVerifier:
+    global _token_verifier
+    if _token_verifier is None:
+        _token_verifier = SupabaseJWTVerifier()
+    return _token_verifier
 
 # ---------------------------------------------------------------------------
 # Repository factories
@@ -62,5 +73,8 @@ def get_memory_service(
     return MemoryService(repo)
 
 
-def get_auth_service(repo: Annotated[AuthRepository, Depends(get_auth_repo)]) -> AuthService:
-    return AuthService(repo)
+def get_auth_service(
+    repo: Annotated[AuthRepository, Depends(get_auth_repo)],
+    verifier: Annotated[SupabaseJWTVerifier, Depends(get_token_verifier)],
+) -> AuthService:
+    return AuthService(repo, verifier)

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -27,6 +27,7 @@ def get_token_verifier() -> SupabaseJWTVerifier:
         _token_verifier = SupabaseJWTVerifier()
     return _token_verifier
 
+
 # ---------------------------------------------------------------------------
 # Repository factories
 # ---------------------------------------------------------------------------

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -29,6 +29,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
+from app.api.dependencies import get_token_verifier
 from app.domain.agents.service import AgentService
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
@@ -52,7 +53,7 @@ logger = logging.getLogger(__name__)
 async def _verify_token(token: str) -> UUID | None:
     """Decode a Supabase JWT by delegating to AuthService.decode_jwt."""
     try:
-        auth_service = AuthService(AuthRepository(get_supabase()))
+        auth_service = AuthService(AuthRepository(get_supabase()), get_token_verifier())
         payload = await auth_service.decode_jwt(token)
         return payload.sub
     except Exception:

--- a/backend/app/domain/auth/interfaces.py
+++ b/backend/app/domain/auth/interfaces.py
@@ -6,6 +6,15 @@ from typing import Protocol
 from uuid import UUID
 
 from app.domain.auth.entities import Passkey, PasskeyCreate
+from app.domain.auth.schemas import JWTPayload
+
+
+class TokenVerifierProtocol(Protocol):
+    """Protocol for JWT token verification."""
+
+    async def verify_token(self, token: str) -> JWTPayload:
+        """Verify a JWT and return its payload."""
+        pass
 
 
 class AuthRepositoryProtocol(Protocol):

--- a/backend/app/domain/auth/service.py
+++ b/backend/app/domain/auth/service.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class AuthService:
-    def __init__(self, repo: "AuthRepositoryProtocol", verifier: "TokenVerifierProtocol") -> None:
+    def __init__(self, repo: AuthRepositoryProtocol, verifier: TokenVerifierProtocol) -> None:
         self.repo = repo
         self.verifier = verifier
 

--- a/backend/app/domain/auth/service.py
+++ b/backend/app/domain/auth/service.py
@@ -6,22 +6,19 @@ import logging
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-import jwt
-
-from app.core.config import get_settings
 from app.domain.auth.entities import Passkey
 from app.domain.auth.schemas import JWTPayload
 
 if TYPE_CHECKING:
-    from app.domain.auth.interfaces import AuthRepositoryProtocol
+    from app.domain.auth.interfaces import AuthRepositoryProtocol, TokenVerifierProtocol
 
 logger = logging.getLogger(__name__)
 
 
 class AuthService:
-    def __init__(self, repo: AuthRepositoryProtocol) -> None:
+    def __init__(self, repo: "AuthRepositoryProtocol", verifier: "TokenVerifierProtocol") -> None:
         self.repo = repo
-        self._jwks_client: jwt.PyJWKClient | None = None
+        self.verifier = verifier
 
     async def list_passkeys(
         self, user_id: str | UUID, limit: int = 50, cursor: str | None = None
@@ -29,44 +26,9 @@ class AuthService:
         """Fetch a paginated list of passkeys for a user."""
         return await self.repo.get_passkeys_by_user(user_id, limit=limit, cursor=cursor)
 
-    def _get_jwks_client(self) -> jwt.PyJWKClient:
-        if self._jwks_client is None:
-            settings = get_settings()
-            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
-            self._jwks_client = jwt.PyJWKClient(jwks_url)
-        return self._jwks_client
-
     async def decode_jwt(self, token: str) -> JWTPayload:
-        """Decode and verify a Supabase JWT."""
-        settings = get_settings()
-        try:
-            try:
-                header = jwt.get_unverified_header(token)
-            except Exception as header_exc:
-                raise jwt.DecodeError("Invalid token format") from header_exc
-
-            alg = header.get("alg")
-
-            if alg == "HS256":
-                payload = jwt.decode(
-                    token,
-                    settings.supabase_jwt_secret,
-                    algorithms=["HS256"],
-                    audience="authenticated",
-                )
-            else:
-                jwks_client = self._get_jwks_client()
-                signing_key = jwks_client.get_signing_key_from_jwt(token)
-                payload = jwt.decode(
-                    token,
-                    signing_key.key,
-                    algorithms=["ES256", "RS256"],
-                    audience="authenticated",
-                )
-            return JWTPayload(**payload)
-        except Exception as exc:
-            logger.warning("JWT validation failed: %s", exc)
-            raise
+        """Decode and verify a Supabase JWT using the injected verifier."""
+        return await self.verifier.verify_token(token)
 
     # --- WebAuthn / Passkey Logic (Authlib Integration) ---
 

--- a/backend/app/infrastructure/auth/jwt_verifier.py
+++ b/backend/app/infrastructure/auth/jwt_verifier.py
@@ -32,7 +32,7 @@ class SupabaseJWTVerifier(TokenVerifierProtocol):
         try:
             try:
                 header = jwt.get_unverified_header(token)
-            except Exception as header_exc:
+            except (jwt.DecodeError, ValueError) as header_exc:
                 raise jwt.DecodeError("Invalid token format") from header_exc
 
             alg = header.get("alg")
@@ -54,6 +54,6 @@ class SupabaseJWTVerifier(TokenVerifierProtocol):
                     audience="authenticated",
                 )
             return JWTPayload(**payload)
-        except Exception as exc:
+        except (jwt.InvalidTokenError, jwt.PyJWKClientError) as exc:
             logger.warning("JWT validation failed: %s", exc)
             raise

--- a/backend/app/infrastructure/auth/jwt_verifier.py
+++ b/backend/app/infrastructure/auth/jwt_verifier.py
@@ -1,0 +1,59 @@
+"""JWT verification infrastructure."""
+
+from __future__ import annotations
+
+import logging
+
+import jwt
+
+from app.core.config import get_settings
+from app.domain.auth.interfaces import TokenVerifierProtocol
+from app.domain.auth.schemas import JWTPayload
+
+logger = logging.getLogger(__name__)
+
+
+class SupabaseJWTVerifier(TokenVerifierProtocol):
+    """Implementation of TokenVerifierProtocol using Supabase JWKS."""
+
+    def __init__(self) -> None:
+        self._jwks_client: jwt.PyJWKClient | None = None
+
+    def _get_jwks_client(self) -> jwt.PyJWKClient:
+        if self._jwks_client is None:
+            settings = get_settings()
+            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
+            self._jwks_client = jwt.PyJWKClient(jwks_url)
+        return self._jwks_client
+
+    async def verify_token(self, token: str) -> JWTPayload:
+        """Decode and verify a Supabase JWT."""
+        settings = get_settings()
+        try:
+            try:
+                header = jwt.get_unverified_header(token)
+            except Exception as header_exc:
+                raise jwt.DecodeError("Invalid token format") from header_exc
+
+            alg = header.get("alg")
+
+            if alg == "HS256":
+                payload = jwt.decode(
+                    token,
+                    settings.supabase_jwt_secret,
+                    algorithms=["HS256"],
+                    audience="authenticated",
+                )
+            else:
+                jwks_client = self._get_jwks_client()
+                signing_key = jwks_client.get_signing_key_from_jwt(token)
+                payload = jwt.decode(
+                    token,
+                    signing_key.key,
+                    algorithms=["ES256", "RS256"],
+                    audience="authenticated",
+                )
+            return JWTPayload(**payload)
+        except Exception as exc:
+            logger.warning("JWT validation failed: %s", exc)
+            raise

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -23,9 +23,10 @@ async def test_decode_valid_jwt() -> None:
     """A valid JWT with a known secret decodes successfully."""
     from app.domain.auth.service import AuthService
     from app.infrastructure.repositories.auth_repo import AuthRepository
+    from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
 
     token = make_jwt()
-    service = AuthService(AuthRepository(MagicMock()))
+    service = AuthService(AuthRepository(MagicMock()), SupabaseJWTVerifier())
     payload = await service.decode_jwt(token)
 
     assert isinstance(payload, JWTPayload)
@@ -37,9 +38,10 @@ async def test_decode_expired_jwt_raises_401() -> None:
     """An expired JWT raises an error."""
     from app.domain.auth.service import AuthService
     from app.infrastructure.repositories.auth_repo import AuthRepository
+    from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
 
     token = make_jwt(expired=True)
-    service = AuthService(AuthRepository(MagicMock()))
+    service = AuthService(AuthRepository(MagicMock()), SupabaseJWTVerifier())
 
     with pytest.raises(jwt.ExpiredSignatureError):
         await service.decode_jwt(token)
@@ -52,9 +54,10 @@ async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureF
 
     from app.domain.auth.service import AuthService
     from app.infrastructure.repositories.auth_repo import AuthRepository
+    from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
 
     token = "invalid.token.format"
-    service = AuthService(AuthRepository(MagicMock()))
+    service = AuthService(AuthRepository(MagicMock()), SupabaseJWTVerifier())
 
     with (
         caplog.at_level(logging.WARNING),

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -22,8 +22,8 @@ from tests.conftest import make_jwt
 async def test_decode_valid_jwt() -> None:
     """A valid JWT with a known secret decodes successfully."""
     from app.domain.auth.service import AuthService
-    from app.infrastructure.repositories.auth_repo import AuthRepository
     from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
+    from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt()
     service = AuthService(AuthRepository(MagicMock()), SupabaseJWTVerifier())
@@ -37,8 +37,8 @@ async def test_decode_valid_jwt() -> None:
 async def test_decode_expired_jwt_raises_401() -> None:
     """An expired JWT raises an error."""
     from app.domain.auth.service import AuthService
-    from app.infrastructure.repositories.auth_repo import AuthRepository
     from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
+    from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt(expired=True)
     service = AuthService(AuthRepository(MagicMock()), SupabaseJWTVerifier())
@@ -53,8 +53,8 @@ async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureF
     import logging
 
     from app.domain.auth.service import AuthService
-    from app.infrastructure.repositories.auth_repo import AuthRepository
     from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
+    from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = "invalid.token.format"
     service = AuthService(AuthRepository(MagicMock()), SupabaseJWTVerifier())


### PR DESCRIPTION
This pull request extracts the concrete JWT verification logic (specifically using `jwt.PyJWKClient`) from `AuthService` into a new infrastructure class, `SupabaseJWTVerifier`. It introduces a new interface `TokenVerifierProtocol` into the domain layer to adhere strictly to Clean Architecture principles. The `AuthService` now utilizes constructor injection for the token verifier. Additionally, a new singleton dependency `get_token_verifier` is introduced to ensure JWKS caches are maintained across the application lifecycle. Tests and WebSocket router instantiations have been updated to reflect these dependency changes.

---
*PR created automatically by Jules for task [15277261941135524087](https://jules.google.com/task/15277261941135524087) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored JWT token verification to use dependency injection with request-level caching. Verification logic is now delegated to a dedicated service, improving maintainability and enabling reuse of cached cryptographic credentials across requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->