### PR TITLE
Refactor `ChatInlineBanner` to use design tokens and modular stylesheet

### DIFF
--- a/frontend/src/components/chat/ChatInlineBanner.tsx
+++ b/frontend/src/components/chat/ChatInlineBanner.tsx
@@ -9,7 +9,7 @@ interface ChatInlineBannerProps {
   tone?: 'error' | 'success' | 'info';
 }
 
-export function ChatInlineBanner({ text, tone = 'info' }: ChatInlineBannerProps) {
+export const ChatInlineBanner = ({ text, tone = 'info' }: ChatInlineBannerProps) => {
   const { C } = useTheme();
 
   const getToneColors = () => {
@@ -35,7 +35,7 @@ export function ChatInlineBanner({ text, tone = 'info' }: ChatInlineBannerProps)
       </AppText>
     </View>
   );
-}
+};
 
 const styles = StyleSheet.create({
   container: {

--- a/frontend/src/components/chat/ChatInlineBanner.tsx
+++ b/frontend/src/components/chat/ChatInlineBanner.tsx
@@ -1,34 +1,60 @@
 import React from 'react';
-import { View } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { AppText } from '@/components/AppText';
+import { useTheme } from '@/hooks/useTheme';
+import { theme } from '@/core/theme';
 
 interface ChatInlineBannerProps {
   text: string;
   tone?: 'error' | 'success' | 'info';
 }
 
-const TONE_CLASSES = {
-  error: {
-    box: 'border-[#B23A3A66] bg-[#B23A3A1F]',
-    text: 'text-[#B23A3A]',
-  },
-  success: {
-    box: 'border-[#147D6466] bg-[#147D641F]',
-    text: 'text-[#147D64]',
-  },
-  info: {
-    box: 'border-[#5A746766] bg-[#5A74671F]',
-    text: 'text-[#5A7467]',
-  },
-} as const;
-
 export function ChatInlineBanner({ text, tone = 'info' }: ChatInlineBannerProps) {
-  const toneClass = TONE_CLASSES[tone];
+  const { C } = useTheme();
+
+  const getToneColors = () => {
+    switch (tone) {
+      case 'error':
+        return { color: C.danger, bg: C.dangerSurface };
+      case 'success':
+        return { color: C.success, bg: C.successSurface };
+      case 'info':
+      default:
+        return { color: C.muted, bg: C.surfaceHigh };
+    }
+  };
+
+  const { color, bg } = getToneColors();
+
   return (
-    <View className={`mx-3 mb-2 rounded-xl border px-2.5 py-2 ${toneClass.box}`}>
-      <AppText variant="caption" className={`font-bold ${toneClass.text}`}>
+    <View style={styles.container}>
+      <View style={[StyleSheet.absoluteFill, styles.bgLayer, { backgroundColor: bg }]} />
+      <View style={[styles.borderLayer, { borderColor: color, opacity: 0.4 }]} />
+      <AppText variant="caption" style={[styles.text, { color }]}>
         {text}
       </AppText>
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: theme.spacing.md,
+    marginBottom: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.bubblePaddingV,
+    paddingVertical: theme.spacing.sm,
+    borderRadius: theme.borderRadius.md,
+    overflow: 'hidden',
+  },
+  bgLayer: {
+    borderRadius: theme.borderRadius.md,
+  },
+  borderLayer: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: theme.borderRadius.md,
+    borderWidth: 1,
+  },
+  text: {
+    fontWeight: 'bold',
+  },
+});


### PR DESCRIPTION
Refactored `ChatInlineBanner` to adhere to "The Polish Loop" and "Premium Standard" for the React Native application. Removed all raw hex codes and inline string concatenation in favor of pure semantic design tokens via the `useTheme()` hook. Utilized `StyleSheet.absoluteFillObject` to build out solid background layers with properly separated opacity configurations, mitigating previous issues with missing rendering logic from pure CSS strings.

---
*PR created automatically by Jules for task [6794442201707899359](https://jules.google.com/task/6794442201707899359) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal styling architecture for the chat inline banner component to improve consistency with the app's design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->