### PR TITLE
Refactor: Isolate JWT Verification in Infrastructure

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -20,6 +20,12 @@ from app.infrastructure.repositories.memory_repo import MemoryRepository
 # Module-level singleton to reuse the internal JWKS cache
 _jwt_verifier = SupabaseJWTVerifier()
 
+
+def get_jwt_verifier() -> SupabaseJWTVerifier:
+    """Returns the module-level JWT verifier singleton."""
+    return _jwt_verifier
+
+
 # ---------------------------------------------------------------------------
 # Repository factories
 # ---------------------------------------------------------------------------

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -10,11 +10,15 @@ from app.domain.agents.service import AgentService
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
 from app.domain.memory.service import MemoryService
+from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
 from app.infrastructure.database.supabase import SupabaseClient
 from app.infrastructure.repositories.agent_repo import AgentRepository
 from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
 from app.infrastructure.repositories.memory_repo import MemoryRepository
+
+# Module-level singleton to reuse the internal JWKS cache
+_jwt_verifier = SupabaseJWTVerifier()
 
 # ---------------------------------------------------------------------------
 # Repository factories
@@ -63,4 +67,4 @@ def get_memory_service(
 
 
 def get_auth_service(repo: Annotated[AuthRepository, Depends(get_auth_repo)]) -> AuthService:
-    return AuthService(repo)
+    return AuthService(repo, token_verifier=_jwt_verifier)

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -29,6 +29,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
+from app.api.dependencies import _jwt_verifier
 from app.domain.agents.service import AgentService
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
@@ -52,7 +53,7 @@ logger = logging.getLogger(__name__)
 async def _verify_token(token: str) -> UUID | None:
     """Decode a Supabase JWT by delegating to AuthService.decode_jwt."""
     try:
-        auth_service = AuthService(AuthRepository(get_supabase()))
+        auth_service = AuthService(AuthRepository(get_supabase()), token_verifier=_jwt_verifier)
         payload = await auth_service.decode_jwt(token)
         return payload.sub
     except Exception:

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -29,7 +29,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
-from app.api.dependencies import _jwt_verifier
+from app.api.dependencies import get_jwt_verifier
 from app.domain.agents.service import AgentService
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
@@ -53,7 +53,9 @@ logger = logging.getLogger(__name__)
 async def _verify_token(token: str) -> UUID | None:
     """Decode a Supabase JWT by delegating to AuthService.decode_jwt."""
     try:
-        auth_service = AuthService(AuthRepository(get_supabase()), token_verifier=_jwt_verifier)
+        auth_service = AuthService(
+            AuthRepository(get_supabase()), token_verifier=get_jwt_verifier()
+        )
         payload = await auth_service.decode_jwt(token)
         return payload.sub
     except Exception:

--- a/backend/app/domain/auth/interfaces.py
+++ b/backend/app/domain/auth/interfaces.py
@@ -6,6 +6,15 @@ from typing import Protocol
 from uuid import UUID
 
 from app.domain.auth.entities import Passkey, PasskeyCreate
+from app.domain.auth.schemas import JWTPayload
+
+
+class TokenVerifierProtocol(Protocol):
+    """Protocol for verifying tokens."""
+
+    async def verify_token(self, token: str) -> JWTPayload:
+        """Verify a token and return its payload."""
+        pass
 
 
 class AuthRepositoryProtocol(Protocol):

--- a/backend/app/domain/auth/service.py
+++ b/backend/app/domain/auth/service.py
@@ -6,22 +6,21 @@ import logging
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-import jwt
-
-from app.core.config import get_settings
 from app.domain.auth.entities import Passkey
 from app.domain.auth.schemas import JWTPayload
 
 if TYPE_CHECKING:
-    from app.domain.auth.interfaces import AuthRepositoryProtocol
+    from app.domain.auth.interfaces import AuthRepositoryProtocol, TokenVerifierProtocol
 
 logger = logging.getLogger(__name__)
 
 
 class AuthService:
-    def __init__(self, repo: AuthRepositoryProtocol) -> None:
+    def __init__(
+        self, repo: AuthRepositoryProtocol, token_verifier: TokenVerifierProtocol
+    ) -> None:
         self.repo = repo
-        self._jwks_client: jwt.PyJWKClient | None = None
+        self.token_verifier = token_verifier
 
     async def list_passkeys(
         self, user_id: str | UUID, limit: int = 50, cursor: str | None = None
@@ -29,44 +28,9 @@ class AuthService:
         """Fetch a paginated list of passkeys for a user."""
         return await self.repo.get_passkeys_by_user(user_id, limit=limit, cursor=cursor)
 
-    def _get_jwks_client(self) -> jwt.PyJWKClient:
-        if self._jwks_client is None:
-            settings = get_settings()
-            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
-            self._jwks_client = jwt.PyJWKClient(jwks_url)
-        return self._jwks_client
-
     async def decode_jwt(self, token: str) -> JWTPayload:
         """Decode and verify a Supabase JWT."""
-        settings = get_settings()
-        try:
-            try:
-                header = jwt.get_unverified_header(token)
-            except Exception as header_exc:
-                raise jwt.DecodeError("Invalid token format") from header_exc
-
-            alg = header.get("alg")
-
-            if alg == "HS256":
-                payload = jwt.decode(
-                    token,
-                    settings.supabase_jwt_secret,
-                    algorithms=["HS256"],
-                    audience="authenticated",
-                )
-            else:
-                jwks_client = self._get_jwks_client()
-                signing_key = jwks_client.get_signing_key_from_jwt(token)
-                payload = jwt.decode(
-                    token,
-                    signing_key.key,
-                    algorithms=["ES256", "RS256"],
-                    audience="authenticated",
-                )
-            return JWTPayload(**payload)
-        except Exception as exc:
-            logger.warning("JWT validation failed: %s", exc)
-            raise
+        return await self.token_verifier.verify_token(token)
 
     # --- WebAuthn / Passkey Logic (Authlib Integration) ---
 

--- a/backend/app/domain/auth/service.py
+++ b/backend/app/domain/auth/service.py
@@ -16,9 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class AuthService:
-    def __init__(
-        self, repo: AuthRepositoryProtocol, token_verifier: TokenVerifierProtocol
-    ) -> None:
+    def __init__(self, repo: AuthRepositoryProtocol, token_verifier: TokenVerifierProtocol) -> None:
         self.repo = repo
         self.token_verifier = token_verifier
 

--- a/backend/app/infrastructure/auth/jwt_verifier.py
+++ b/backend/app/infrastructure/auth/jwt_verifier.py
@@ -1,0 +1,59 @@
+"""Supabase JWT Verifier."""
+
+from __future__ import annotations
+
+import logging
+
+import jwt
+
+from app.core.config import get_settings
+from app.domain.auth.interfaces import TokenVerifierProtocol
+from app.domain.auth.schemas import JWTPayload
+
+logger = logging.getLogger(__name__)
+
+
+class SupabaseJWTVerifier(TokenVerifierProtocol):
+    """Verifies Supabase JWTs."""
+
+    def __init__(self) -> None:
+        self._jwks_client: jwt.PyJWKClient | None = None
+
+    def _get_jwks_client(self) -> jwt.PyJWKClient:
+        if self._jwks_client is None:
+            settings = get_settings()
+            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
+            self._jwks_client = jwt.PyJWKClient(jwks_url)
+        return self._jwks_client
+
+    async def verify_token(self, token: str) -> JWTPayload:
+        """Decode and verify a Supabase JWT."""
+        settings = get_settings()
+        try:
+            try:
+                header = jwt.get_unverified_header(token)
+            except Exception as header_exc:
+                raise jwt.DecodeError("Invalid token format") from header_exc
+
+            alg = header.get("alg")
+
+            if alg == "HS256":
+                payload = jwt.decode(
+                    token,
+                    settings.supabase_jwt_secret,
+                    algorithms=["HS256"],
+                    audience="authenticated",
+                )
+            else:
+                jwks_client = self._get_jwks_client()
+                signing_key = jwks_client.get_signing_key_from_jwt(token)
+                payload = jwt.decode(
+                    token,
+                    signing_key.key,
+                    algorithms=["ES256", "RS256"],
+                    audience="authenticated",
+                )
+            return JWTPayload(**payload)
+        except Exception as exc:
+            logger.warning("JWT validation failed: %s", exc)
+            raise

--- a/backend/app/infrastructure/auth/jwt_verifier.py
+++ b/backend/app/infrastructure/auth/jwt_verifier.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import jwt
@@ -46,7 +47,7 @@ class SupabaseJWTVerifier(TokenVerifierProtocol):
                 )
             else:
                 jwks_client = self._get_jwks_client()
-                signing_key = jwks_client.get_signing_key_from_jwt(token)
+                signing_key = await asyncio.to_thread(jwks_client.get_signing_key_from_jwt, token)
                 payload = jwt.decode(
                     token,
                     signing_key.key,

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -22,10 +22,11 @@ from tests.conftest import make_jwt
 async def test_decode_valid_jwt() -> None:
     """A valid JWT with a known secret decodes successfully."""
     from app.domain.auth.service import AuthService
+    from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt()
-    service = AuthService(AuthRepository(MagicMock()))
+    service = AuthService(AuthRepository(MagicMock()), token_verifier=SupabaseJWTVerifier())
     payload = await service.decode_jwt(token)
 
     assert isinstance(payload, JWTPayload)
@@ -36,10 +37,11 @@ async def test_decode_valid_jwt() -> None:
 async def test_decode_expired_jwt_raises_401() -> None:
     """An expired JWT raises an error."""
     from app.domain.auth.service import AuthService
+    from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt(expired=True)
-    service = AuthService(AuthRepository(MagicMock()))
+    service = AuthService(AuthRepository(MagicMock()), token_verifier=SupabaseJWTVerifier())
 
     with pytest.raises(jwt.ExpiredSignatureError):
         await service.decode_jwt(token)
@@ -51,10 +53,11 @@ async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureF
     import logging
 
     from app.domain.auth.service import AuthService
+    from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = "invalid.token.format"
-    service = AuthService(AuthRepository(MagicMock()))
+    service = AuthService(AuthRepository(MagicMock()), token_verifier=SupabaseJWTVerifier())
 
     with (
         caplog.at_level(logging.WARNING),


### PR DESCRIPTION
Extracts concrete JWT validation (`PyJWKClient` and the `jwt` lib) out of the domain-level `AuthService` and places it behind a `TokenVerifierProtocol` implemented by the infrastructure-level `SupabaseJWTVerifier`. This strictly aligns the Auth Domain with Clean Architecture constraints (eliminating third-party framework/network-fetching code from Use Cases). Dependency Injection is updated in `app.api.dependencies` (to ensure the JWKS cache continues to be reused as a module-level singleton), and `tests/test_auth.py` and `app/api/v1/websocket.py` are updated accordingly. All tests pass locally.

---
*PR created automatically by Jules for task [4323525548470794672](https://jules.google.com/task/4323525548470794672) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal authentication verification architecture by separating JWT verification logic from the authentication service, improving code maintainability and testability while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->