### PR TITLE
Refactor: Decouple JWT Verification from Application Layer

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -23,8 +23,10 @@ from app.infrastructure.repositories.memory_repo import MemoryRepository
 
 _jwt_verifier = SupabaseJWTVerifier()
 
+
 def get_jwt_verifier() -> SupabaseJWTVerifier:
     return _jwt_verifier
+
 
 # ---------------------------------------------------------------------------
 # Repository factories
@@ -74,6 +76,6 @@ def get_memory_service(
 
 def get_auth_service(
     repo: Annotated[AuthRepository, Depends(get_auth_repo)],
-    verifier: Annotated[SupabaseJWTVerifier, Depends(get_jwt_verifier)]
+    verifier: Annotated[SupabaseJWTVerifier, Depends(get_jwt_verifier)],
 ) -> AuthService:
     return AuthService(repo, verifier)

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -10,11 +10,21 @@ from app.domain.agents.service import AgentService
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
 from app.domain.memory.service import MemoryService
+from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
 from app.infrastructure.database.supabase import SupabaseClient
 from app.infrastructure.repositories.agent_repo import AgentRepository
 from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
 from app.infrastructure.repositories.memory_repo import MemoryRepository
+
+# ---------------------------------------------------------------------------
+# Singletons
+# ---------------------------------------------------------------------------
+
+_jwt_verifier = SupabaseJWTVerifier()
+
+def get_jwt_verifier() -> SupabaseJWTVerifier:
+    return _jwt_verifier
 
 # ---------------------------------------------------------------------------
 # Repository factories
@@ -62,5 +72,8 @@ def get_memory_service(
     return MemoryService(repo)
 
 
-def get_auth_service(repo: Annotated[AuthRepository, Depends(get_auth_repo)]) -> AuthService:
-    return AuthService(repo)
+def get_auth_service(
+    repo: Annotated[AuthRepository, Depends(get_auth_repo)],
+    verifier: Annotated[SupabaseJWTVerifier, Depends(get_jwt_verifier)]
+) -> AuthService:
+    return AuthService(repo, verifier)

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -25,6 +25,11 @@ _jwt_verifier = SupabaseJWTVerifier()
 
 
 def get_jwt_verifier() -> SupabaseJWTVerifier:
+    """Provide the singleton SupabaseJWTVerifier instance.
+
+    Returns:
+        SupabaseJWTVerifier: A singleton token verifier that manages the PyJWKClient.
+    """
     return _jwt_verifier
 
 
@@ -78,4 +83,13 @@ def get_auth_service(
     repo: Annotated[AuthRepository, Depends(get_auth_repo)],
     verifier: Annotated[SupabaseJWTVerifier, Depends(get_jwt_verifier)],
 ) -> AuthService:
+    """Provide an instance of AuthService.
+
+    Args:
+        repo (AuthRepository): Injected repository for database access.
+        verifier (SupabaseJWTVerifier): Injected verifier for validating tokens.
+
+    Returns:
+        AuthService: An instantiated AuthService ready to process auth requests.
+    """
     return AuthService(repo, verifier)

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -29,6 +29,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
+from app.api.dependencies import get_jwt_verifier
 from app.domain.agents.service import AgentService
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
@@ -52,7 +53,8 @@ logger = logging.getLogger(__name__)
 async def _verify_token(token: str) -> UUID | None:
     """Decode a Supabase JWT by delegating to AuthService.decode_jwt."""
     try:
-        auth_service = AuthService(AuthRepository(get_supabase()))
+        verifier = get_jwt_verifier()
+        auth_service = AuthService(AuthRepository(get_supabase()), verifier)
         payload = await auth_service.decode_jwt(token)
         return payload.sub
     except Exception:

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -31,11 +31,8 @@ from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
 from app.api.dependencies import get_jwt_verifier
 from app.domain.agents.service import AgentService
-from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
-from app.infrastructure.database.supabase import get_supabase
 from app.infrastructure.repositories.agent_repo import AgentRepository
-from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
 from app.infrastructure.repositories.memory_repo import MemoryRepository
 from app.infrastructure.websocket.manager import chat_hub
@@ -51,11 +48,10 @@ logger = logging.getLogger(__name__)
 
 
 async def _verify_token(token: str) -> UUID | None:
-    """Decode a Supabase JWT by delegating to AuthService.decode_jwt."""
+    """Decode a Supabase JWT using the configured token verifier."""
     try:
         verifier = get_jwt_verifier()
-        auth_service = AuthService(AuthRepository(get_supabase()), verifier)
-        payload = await auth_service.decode_jwt(token)
+        payload = await verifier.verify(token)
         return payload.sub
     except Exception:
         logger.warning("WS auth rejected: invalid token")

--- a/backend/app/domain/auth/interfaces.py
+++ b/backend/app/domain/auth/interfaces.py
@@ -10,10 +10,26 @@ from app.domain.auth.schemas import JWTPayload
 
 
 class TokenVerifierProtocol(Protocol):
-    """Protocol for JWT verification."""
+    """Protocol for JWT verification.
+
+    Implementations of this protocol are responsible for decoding and verifying
+    authentication tokens (e.g., extracting claims, verifying signatures, checking expiration).
+    """
 
     async def verify(self, token: str) -> JWTPayload:
-        """Verify and decode a JWT."""
+        """Verify and decode a JWT.
+
+        Args:
+            token (str): The raw JWT string, typically extracted from an Authorization header.
+
+        Returns:
+            JWTPayload: The decoded and validated JWT payload containing user claims.
+
+        Raises:
+            jwt.InvalidTokenError: If the token is structurally invalid or signature verification fails.
+            jwt.ExpiredSignatureError: If the token's expiration time has passed.
+            ValueError: If the token format is fundamentally incorrect.
+        """
         pass
 
 

--- a/backend/app/domain/auth/interfaces.py
+++ b/backend/app/domain/auth/interfaces.py
@@ -6,6 +6,15 @@ from typing import Protocol
 from uuid import UUID
 
 from app.domain.auth.entities import Passkey, PasskeyCreate
+from app.domain.auth.schemas import JWTPayload
+
+
+class TokenVerifierProtocol(Protocol):
+    """Protocol for JWT verification."""
+
+    async def verify(self, token: str) -> JWTPayload:
+        """Verify and decode a JWT."""
+        pass
 
 
 class AuthRepositoryProtocol(Protocol):
@@ -15,16 +24,16 @@ class AuthRepositoryProtocol(Protocol):
         self, user_id: str | UUID, limit: int = 50, cursor: str | None = None
     ) -> tuple[list[Passkey], str | None]:
         """Fetch all registered passkeys for a user with pagination."""
-        ...
+        pass
 
     async def update_sign_count(self, passkey_id: str | UUID, new_count: int) -> None:
         """Update the signature count for a passkey."""
-        ...
+        pass
 
     async def create_passkey(self, input: PasskeyCreate) -> Passkey:
         """Insert a new passkey record."""
-        ...
+        pass
 
     async def delete_passkey(self, passkey_id: str | UUID, user_id: str | UUID) -> bool:
         """Delete a passkey belonging to a user."""
-        ...
+        pass

--- a/backend/app/domain/auth/service.py
+++ b/backend/app/domain/auth/service.py
@@ -6,22 +6,19 @@ import logging
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-import jwt
-
-from app.core.config import get_settings
 from app.domain.auth.entities import Passkey
 from app.domain.auth.schemas import JWTPayload
 
 if TYPE_CHECKING:
-    from app.domain.auth.interfaces import AuthRepositoryProtocol
+    from app.domain.auth.interfaces import AuthRepositoryProtocol, TokenVerifierProtocol
 
 logger = logging.getLogger(__name__)
 
 
 class AuthService:
-    def __init__(self, repo: AuthRepositoryProtocol) -> None:
+    def __init__(self, repo: AuthRepositoryProtocol, token_verifier: TokenVerifierProtocol) -> None:
         self.repo = repo
-        self._jwks_client: jwt.PyJWKClient | None = None
+        self.token_verifier = token_verifier
 
     async def list_passkeys(
         self, user_id: str | UUID, limit: int = 50, cursor: str | None = None
@@ -29,44 +26,9 @@ class AuthService:
         """Fetch a paginated list of passkeys for a user."""
         return await self.repo.get_passkeys_by_user(user_id, limit=limit, cursor=cursor)
 
-    def _get_jwks_client(self) -> jwt.PyJWKClient:
-        if self._jwks_client is None:
-            settings = get_settings()
-            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
-            self._jwks_client = jwt.PyJWKClient(jwks_url)
-        return self._jwks_client
-
     async def decode_jwt(self, token: str) -> JWTPayload:
         """Decode and verify a Supabase JWT."""
-        settings = get_settings()
-        try:
-            try:
-                header = jwt.get_unverified_header(token)
-            except Exception as header_exc:
-                raise jwt.DecodeError("Invalid token format") from header_exc
-
-            alg = header.get("alg")
-
-            if alg == "HS256":
-                payload = jwt.decode(
-                    token,
-                    settings.supabase_jwt_secret,
-                    algorithms=["HS256"],
-                    audience="authenticated",
-                )
-            else:
-                jwks_client = self._get_jwks_client()
-                signing_key = jwks_client.get_signing_key_from_jwt(token)
-                payload = jwt.decode(
-                    token,
-                    signing_key.key,
-                    algorithms=["ES256", "RS256"],
-                    audience="authenticated",
-                )
-            return JWTPayload(**payload)
-        except Exception as exc:
-            logger.warning("JWT validation failed: %s", exc)
-            raise
+        return await self.token_verifier.verify(token)
 
     # --- WebAuthn / Passkey Logic (Authlib Integration) ---
 

--- a/backend/app/infrastructure/auth/jwt_verifier.py
+++ b/backend/app/infrastructure/auth/jwt_verifier.py
@@ -1,0 +1,52 @@
+import asyncio
+
+import jwt
+
+from app.core.config import get_settings
+from app.domain.auth.schemas import JWTPayload
+
+
+class SupabaseJWTVerifier:
+    def __init__(self) -> None:
+        self._jwks_client: jwt.PyJWKClient | None = None
+
+    def _get_jwks_client(self) -> jwt.PyJWKClient:
+        if self._jwks_client is None:
+            settings = get_settings()
+            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
+            self._jwks_client = jwt.PyJWKClient(jwks_url)
+        return self._jwks_client
+
+    async def verify(self, token: str) -> JWTPayload:
+        settings = get_settings()
+        try:
+            try:
+                header = jwt.get_unverified_header(token)
+            except Exception as header_exc:
+                raise jwt.DecodeError("Invalid token format") from header_exc
+
+            alg = header.get("alg")
+
+            if alg == "HS256":
+                payload = jwt.decode(
+                    token,
+                    settings.supabase_jwt_secret,
+                    algorithms=["HS256"],
+                    audience="authenticated",
+                )
+            else:
+                jwks_client = self._get_jwks_client()
+                # Wrap blocking call in to_thread
+                signing_key = await asyncio.to_thread(jwks_client.get_signing_key_from_jwt, token)
+                payload = jwt.decode(
+                    token,
+                    signing_key.key,
+                    algorithms=["ES256", "RS256"],
+                    audience="authenticated",
+                )
+            return JWTPayload(**payload)
+        except Exception as exc:
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.warning("JWT validation failed: %s", exc)
+            raise

--- a/backend/app/infrastructure/auth/jwt_verifier.py
+++ b/backend/app/infrastructure/auth/jwt_verifier.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import asyncio
+import logging
 
 import jwt
 
 from app.core.config import get_settings
 from app.domain.auth.schemas import JWTPayload
+
+logger = logging.getLogger(__name__)
 
 
 class SupabaseJWTVerifier:
@@ -34,7 +39,7 @@ class SupabaseJWTVerifier:
                     algorithms=["HS256"],
                     audience="authenticated",
                 )
-            else:
+            elif alg in ("ES256", "RS256"):
                 jwks_client = self._get_jwks_client()
                 # Wrap blocking call in to_thread
                 signing_key = await asyncio.to_thread(jwks_client.get_signing_key_from_jwt, token)
@@ -44,10 +49,12 @@ class SupabaseJWTVerifier:
                     algorithms=["ES256", "RS256"],
                     audience="authenticated",
                 )
+            else:
+                raise jwt.InvalidAlgorithmError(f"Unsupported algorithm: {alg}")
             return JWTPayload(**payload)
-        except Exception as exc:
-            import logging
-
-            logger = logging.getLogger(__name__)
+        except jwt.PyJWTError as exc:
             logger.warning("JWT validation failed: %s", exc)
+            raise
+        except Exception as exc:
+            logger.exception("JWT validation failed", exc_info=exc)
             raise

--- a/backend/app/infrastructure/auth/jwt_verifier.py
+++ b/backend/app/infrastructure/auth/jwt_verifier.py
@@ -47,6 +47,7 @@ class SupabaseJWTVerifier:
             return JWTPayload(**payload)
         except Exception as exc:
             import logging
+
             logger = logging.getLogger(__name__)
             logger.warning("JWT validation failed: %s", exc)
             raise

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -76,6 +76,90 @@ async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureF
     )
 
 
+@pytest.mark.asyncio
+async def test_decode_jwt_with_jwks_happy_path() -> None:
+    """A valid asymmetric JWT decodes successfully using a mocked JWKS key."""
+    from unittest.mock import patch
+
+    from cryptography.hazmat.primitives import serialization
+
+    # Create an asymmetric keypair using cryptography
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    from app.domain.auth.service import AuthService
+    from app.infrastructure.repositories.auth_repo import AuthRepository
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_key_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+
+    # Create a token signed with the private key
+    headers = {"kid": "mock_kid"}
+    payload = {
+        "sub": "123e4567-e89b-12d3-a456-426614174000",
+        "role": "authenticated",
+        "aud": "authenticated",
+        "exp": 9999999999,
+        "iat": 1516239022,
+    }
+    token = jwt.encode(payload, private_key_pem, algorithm="RS256", headers=headers)
+
+    # Mock the JWK Client to return our public key
+    mock_signing_key = MagicMock()
+    mock_signing_key.key = public_key_pem
+
+    with patch("jwt.PyJWKClient.get_signing_key_from_jwt", return_value=mock_signing_key):
+        verifier = SupabaseJWTVerifier()
+        service = AuthService(AuthRepository(MagicMock()), verifier)
+        decoded = await service.decode_jwt(token)
+
+        assert isinstance(decoded, JWTPayload)
+        assert str(decoded.sub) == payload["sub"]
+        assert decoded.role == "authenticated"
+
+
+@pytest.mark.asyncio
+async def test_decode_jwt_with_jwks_failure(caplog: pytest.LogCaptureFixture) -> None:
+    """An asymmetric JWT failing JWKS verification raises an exception and logs it."""
+    import logging
+    from unittest.mock import patch
+
+    from app.domain.auth.service import AuthService
+    from app.infrastructure.repositories.auth_repo import AuthRepository
+
+    # Create a dummy ES256 token (no valid signature needed since we'll mock the exception)
+    token = jwt.encode({"sub": "test"}, "secret", algorithm="HS256")
+    # Hack the header to look like ES256 to force the JWKS branch
+    header = jwt.utils.base64url_encode(b'{"alg": "ES256", "kid": "bad"}').decode("ascii")
+    token = f"{header}.{token.split('.')[1]}.{token.split('.')[2]}"
+
+    with patch(
+        "jwt.PyJWKClient.get_signing_key_from_jwt",
+        side_effect=jwt.PyJWKClientError("Unable to find a signing key that matches"),
+    ):
+        verifier = SupabaseJWTVerifier()
+        service = AuthService(AuthRepository(MagicMock()), verifier)
+
+        with (
+            caplog.at_level(logging.WARNING),
+            pytest.raises(jwt.PyJWKClientError, match="Unable to find a signing key"),
+        ):
+            await service.decode_jwt(token)
+
+        assert any(
+            record.levelname == "WARNING" and "JWT validation failed" in record.message
+            for record in caplog.records
+        )
+
+
 def test_memories_requires_auth(client: TestClient) -> None:
     """GET /api/v1/memory without a token returns 401."""
     app.dependency_overrides[get_supabase] = lambda: MagicMock()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -9,6 +9,7 @@ import jwt
 import pytest
 
 from app.domain.auth.schemas import JWTPayload
+from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
 from app.infrastructure.database.supabase import get_supabase
 from app.main import app
 
@@ -25,7 +26,8 @@ async def test_decode_valid_jwt() -> None:
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt()
-    service = AuthService(AuthRepository(MagicMock()))
+    verifier = SupabaseJWTVerifier()
+    service = AuthService(AuthRepository(MagicMock()), verifier)
     payload = await service.decode_jwt(token)
 
     assert isinstance(payload, JWTPayload)
@@ -39,7 +41,8 @@ async def test_decode_expired_jwt_raises_401() -> None:
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt(expired=True)
-    service = AuthService(AuthRepository(MagicMock()))
+    verifier = SupabaseJWTVerifier()
+    service = AuthService(AuthRepository(MagicMock()), verifier)
 
     with pytest.raises(jwt.ExpiredSignatureError):
         await service.decode_jwt(token)
@@ -54,7 +57,8 @@ async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureF
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = "invalid.token.format"
-    service = AuthService(AuthRepository(MagicMock()))
+    verifier = SupabaseJWTVerifier()
+    service = AuthService(AuthRepository(MagicMock()), verifier)
 
     with (
         caplog.at_level(logging.WARNING),

--- a/patch_deps.py
+++ b/patch_deps.py
@@ -1,0 +1,41 @@
+with open('backend/app/api/dependencies.py', 'r') as f:
+    content = f.read()
+
+old_get_jwt = '''def get_jwt_verifier() -> SupabaseJWTVerifier:
+    return _jwt_verifier'''
+
+new_get_jwt = '''def get_jwt_verifier() -> SupabaseJWTVerifier:
+    """Provide the singleton SupabaseJWTVerifier instance.
+
+    Returns:
+        SupabaseJWTVerifier: A singleton token verifier that manages the PyJWKClient.
+    """
+    return _jwt_verifier'''
+
+content = content.replace(old_get_jwt, new_get_jwt)
+
+old_get_auth = '''def get_auth_service(
+    repo: Annotated[AuthRepository, Depends(get_auth_repo)],
+    verifier: Annotated[SupabaseJWTVerifier, Depends(get_jwt_verifier)],
+) -> AuthService:
+    return AuthService(repo, verifier)'''
+
+new_get_auth = '''def get_auth_service(
+    repo: Annotated[AuthRepository, Depends(get_auth_repo)],
+    verifier: Annotated[SupabaseJWTVerifier, Depends(get_jwt_verifier)],
+) -> AuthService:
+    """Provide an instance of AuthService.
+
+    Args:
+        repo (AuthRepository): Injected repository for database access.
+        verifier (SupabaseJWTVerifier): Injected verifier for validating tokens.
+
+    Returns:
+        AuthService: An instantiated AuthService ready to process auth requests.
+    """
+    return AuthService(repo, verifier)'''
+
+content = content.replace(old_get_auth, new_get_auth)
+
+with open('backend/app/api/dependencies.py', 'w') as f:
+    f.write(content)

--- a/patch_interfaces.py
+++ b/patch_interfaces.py
@@ -1,0 +1,37 @@
+with open('backend/app/domain/auth/interfaces.py', 'r') as f:
+    content = f.read()
+
+old_protocol = '''class TokenVerifierProtocol(Protocol):
+    """Protocol for JWT verification."""
+
+    async def verify(self, token: str) -> JWTPayload:
+        """Verify and decode a JWT."""
+        pass'''
+
+new_protocol = '''class TokenVerifierProtocol(Protocol):
+    """Protocol for JWT verification.
+
+    Implementations of this protocol are responsible for decoding and verifying
+    authentication tokens (e.g., extracting claims, verifying signatures, checking expiration).
+    """
+
+    async def verify(self, token: str) -> JWTPayload:
+        """Verify and decode a JWT.
+
+        Args:
+            token (str): The raw JWT string, typically extracted from an Authorization header.
+
+        Returns:
+            JWTPayload: The decoded and validated JWT payload containing user claims.
+
+        Raises:
+            jwt.InvalidTokenError: If the token is structurally invalid or signature verification fails.
+            jwt.ExpiredSignatureError: If the token's expiration time has passed.
+            ValueError: If the token format is fundamentally incorrect.
+        """
+        pass'''
+
+content = content.replace(old_protocol, new_protocol)
+
+with open('backend/app/domain/auth/interfaces.py', 'w') as f:
+    f.write(content)

--- a/patch_tests.py
+++ b/patch_tests.py
@@ -1,0 +1,78 @@
+import re
+
+with open('backend/tests/test_auth.py', 'r') as f:
+    content = f.read()
+
+new_tests = '''
+@pytest.mark.asyncio
+async def test_decode_jwt_with_jwks_happy_path() -> None:
+    """A valid asymmetric JWT decodes successfully using a mocked JWKS key."""
+    from app.domain.auth.service import AuthService
+    from app.infrastructure.repositories.auth_repo import AuthRepository
+    from unittest.mock import patch
+
+    # Create an asymmetric keypair
+    private_key_pem = jwt.algorithms.RSAAlgorithm.generate_key(2048)
+    public_key_pem = private_key_pem.public_key()
+
+    # Create a token signed with the private key
+    headers = {"kid": "mock_kid"}
+    payload = {
+        "sub": "123e4567-e89b-12d3-a456-426614174000",
+        "role": "authenticated",
+        "exp": 9999999999,
+        "iat": 1516239022
+    }
+    token = jwt.encode(payload, private_key_pem, algorithm="RS256", headers=headers)
+
+    # Mock the JWK Client to return our public key
+    mock_signing_key = MagicMock()
+    mock_signing_key.key = public_key_pem
+
+    with patch("jwt.PyJWKClient.get_signing_key_from_jwt", return_value=mock_signing_key):
+        verifier = SupabaseJWTVerifier()
+        service = AuthService(AuthRepository(MagicMock()), verifier)
+        decoded = await service.decode_jwt(token)
+
+        assert isinstance(decoded, JWTPayload)
+        assert str(decoded.sub) == payload["sub"]
+        assert decoded.role == "authenticated"
+
+
+@pytest.mark.asyncio
+async def test_decode_jwt_with_jwks_failure(caplog: pytest.LogCaptureFixture) -> None:
+    """An asymmetric JWT failing JWKS verification raises an exception and logs it."""
+    import logging
+    from app.domain.auth.service import AuthService
+    from app.infrastructure.repositories.auth_repo import AuthRepository
+    from unittest.mock import patch
+
+    # Create a dummy ES256 token (no valid signature needed since we'll mock the exception)
+    token = jwt.encode({"sub": "test"}, "secret", algorithm="HS256")
+    # Hack the header to look like ES256 to force the JWKS branch
+    header = jwt.utils.base64url_encode(b'{"alg": "ES256", "kid": "bad"}').decode('ascii')
+    token = f"{header}.{token.split('.')[1]}.{token.split('.')[2]}"
+
+    with patch(
+        "jwt.PyJWKClient.get_signing_key_from_jwt",
+        side_effect=jwt.PyJWKClientError("Unable to find a signing key that matches")
+    ):
+        verifier = SupabaseJWTVerifier()
+        service = AuthService(AuthRepository(MagicMock()), verifier)
+
+        with (
+            caplog.at_level(logging.ERROR),
+            pytest.raises(jwt.PyJWKClientError, match="Unable to find a signing key"),
+        ):
+            await service.decode_jwt(token)
+
+        assert any(
+            record.levelname == "ERROR" and "JWT validation failed" in record.message
+            for record in caplog.records
+        )
+'''
+
+content = content.replace("def test_memories_requires_auth(client: TestClient) -> None:", f"{new_tests}\n\ndef test_memories_requires_auth(client: TestClient) -> None:")
+
+with open('backend/tests/test_auth.py', 'w') as f:
+    f.write(content)

--- a/patch_tests2.py
+++ b/patch_tests2.py
@@ -1,0 +1,50 @@
+import re
+
+with open('backend/tests/test_auth.py', 'r') as f:
+    content = f.read()
+
+old_happy = '''    # Create an asymmetric keypair
+    private_key_pem = jwt.algorithms.RSAAlgorithm.generate_key(2048)
+    public_key_pem = private_key_pem.public_key()
+
+    # Create a token signed with the private key
+    headers = {"kid": "mock_kid"}
+    payload = {
+        "sub": "123e4567-e89b-12d3-a456-426614174000",
+        "role": "authenticated",
+        "exp": 9999999999,
+        "iat": 1516239022
+    }
+    token = jwt.encode(payload, private_key_pem, algorithm="RS256", headers=headers)'''
+
+new_happy = '''    # Create an asymmetric keypair using cryptography
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives import serialization
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption()
+    )
+    public_key_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+
+    # Create a token signed with the private key
+    headers = {"kid": "mock_kid"}
+    payload = {
+        "sub": "123e4567-e89b-12d3-a456-426614174000",
+        "role": "authenticated",
+        "exp": 9999999999,
+        "iat": 1516239022
+    }
+    token = jwt.encode(payload, private_key_pem, algorithm="RS256", headers=headers)'''
+
+content = content.replace(old_happy, new_happy)
+
+with open('backend/tests/test_auth.py', 'w') as f:
+    f.write(content)

--- a/patch_tests3.py
+++ b/patch_tests3.py
@@ -1,0 +1,40 @@
+import re
+
+with open('backend/tests/test_auth.py', 'r') as f:
+    content = f.read()
+
+old_payload = '''    payload = {
+        "sub": "123e4567-e89b-12d3-a456-426614174000",
+        "role": "authenticated",
+        "exp": 9999999999,
+        "iat": 1516239022
+    }'''
+
+new_payload = '''    payload = {
+        "sub": "123e4567-e89b-12d3-a456-426614174000",
+        "role": "authenticated",
+        "aud": "authenticated",
+        "exp": 9999999999,
+        "iat": 1516239022
+    }'''
+
+content = content.replace(old_payload, new_payload)
+
+
+old_failure_assert = '''            assert any(
+                record.levelname == "ERROR" and "JWT validation failed" in record.message
+                for record in caplog.records
+            )'''
+
+new_failure_assert = '''            # The exception handler in jwt_verifier.py is logging it using `logger.exception("JWT validation failed", exc_info=exc)`
+            # The exception type is PyJWKClientError, which inherits from PyJWTError, so it hits the first except block
+            # Let's fix the test to assert on PyJWTError warning
+        assert any(
+            record.levelname == "WARNING" and "JWT validation failed" in record.message
+            for record in caplog.records
+        )'''
+
+content = content.replace(old_failure_assert, new_failure_assert)
+
+with open('backend/tests/test_auth.py', 'w') as f:
+    f.write(content)

--- a/patch_tests4.py
+++ b/patch_tests4.py
@@ -1,0 +1,49 @@
+with open('backend/tests/test_auth.py', 'r') as f:
+    content = f.read()
+
+# Notice that the `caplog.at_level(logging.ERROR)` in the test causes WARNING level logs to be suppressed!
+# We need to change it to `caplog.at_level(logging.WARNING)` because PyJWKClientError is caught by `except jwt.PyJWTError:`
+# and logged as WARNING.
+
+old_failure_block = '''        with patch(
+            "jwt.PyJWKClient.get_signing_key_from_jwt",
+            side_effect=jwt.PyJWKClientError("Unable to find a signing key that matches")
+        ):
+            verifier = SupabaseJWTVerifier()
+            service = AuthService(AuthRepository(MagicMock()), verifier)
+
+            with (
+                caplog.at_level(logging.ERROR),
+                pytest.raises(jwt.PyJWKClientError, match="Unable to find a signing key"),
+            ):
+                await service.decode_jwt(token)
+
+            assert any(
+                record.levelname == "ERROR" and "JWT validation failed" in record.message
+                for record in caplog.records
+            )
+'''
+
+new_failure_block = '''        with patch(
+            "jwt.PyJWKClient.get_signing_key_from_jwt",
+            side_effect=jwt.PyJWKClientError("Unable to find a signing key that matches")
+        ):
+            verifier = SupabaseJWTVerifier()
+            service = AuthService(AuthRepository(MagicMock()), verifier)
+
+            with (
+                caplog.at_level(logging.WARNING),
+                pytest.raises(jwt.PyJWKClientError, match="Unable to find a signing key"),
+            ):
+                await service.decode_jwt(token)
+
+            assert any(
+                record.levelname == "WARNING" and "JWT validation failed" in record.message
+                for record in caplog.records
+            )
+'''
+
+content = content.replace(old_failure_block, new_failure_block)
+
+with open('backend/tests/test_auth.py', 'w') as f:
+    f.write(content)

--- a/patch_tests5.py
+++ b/patch_tests5.py
@@ -1,0 +1,25 @@
+with open('backend/tests/test_auth.py', 'r') as f:
+    content = f.read()
+
+# I see the previous patch failed to replace the string because my old string didn't perfectly match what was in the file, probably due to indentation or comments.
+
+import re
+
+# Use regex to replace the assertion block more robustly
+pattern = r'with \(\s*caplog\.at_level\(logging\.ERROR\),\s*pytest\.raises\(jwt\.PyJWKClientError, match="Unable to find a signing key"\),\s*\):\s*await service\.decode_jwt\(token\)\s*assert any\(\s*record\.levelname == "ERROR" and "JWT validation failed" in record\.message\s*for record in caplog\.records\s*\)'
+
+replacement = '''with (
+            caplog.at_level(logging.WARNING),
+            pytest.raises(jwt.PyJWKClientError, match="Unable to find a signing key"),
+        ):
+            await service.decode_jwt(token)
+
+        assert any(
+            record.levelname == "WARNING" and "JWT validation failed" in record.message
+            for record in caplog.records
+        )'''
+
+content = re.sub(pattern, replacement, content, flags=re.MULTILINE | re.DOTALL)
+
+with open('backend/tests/test_auth.py', 'w') as f:
+    f.write(content)

--- a/patch_verifier.py
+++ b/patch_verifier.py
@@ -1,0 +1,71 @@
+with open('backend/app/infrastructure/auth/jwt_verifier.py', 'r') as f:
+    content = f.read()
+
+# Add __future__ import
+if "from __future__ import annotations" not in content:
+    content = "from __future__ import annotations\n\n" + content
+
+# Fix logging and exception handling
+old_except = '''        except Exception as exc:
+            import logging
+
+            logger = logging.getLogger(__name__)
+            logger.warning("JWT validation failed: %s", exc)
+            raise'''
+
+new_except = '''        except jwt.PyJWTError as exc:
+            logger.warning("JWT validation failed: %s", exc)
+            raise
+        except Exception as exc:
+            logger.exception("JWT validation failed", exc_info=exc)
+            raise'''
+
+content = content.replace(old_except, new_except)
+
+# Fix algorithm check
+old_alg_check = '''            if alg == "HS256":
+                payload = jwt.decode(
+                    token,
+                    settings.supabase_jwt_secret,
+                    algorithms=["HS256"],
+                    audience="authenticated",
+                )
+            else:
+                jwks_client = self._get_jwks_client()
+                # Wrap blocking call in to_thread
+                signing_key = await asyncio.to_thread(jwks_client.get_signing_key_from_jwt, token)
+                payload = jwt.decode(
+                    token,
+                    signing_key.key,
+                    algorithms=["ES256", "RS256"],
+                    audience="authenticated",
+                )'''
+
+new_alg_check = '''            if alg == "HS256":
+                payload = jwt.decode(
+                    token,
+                    settings.supabase_jwt_secret,
+                    algorithms=["HS256"],
+                    audience="authenticated",
+                )
+            elif alg in ("ES256", "RS256"):
+                jwks_client = self._get_jwks_client()
+                # Wrap blocking call in to_thread
+                signing_key = await asyncio.to_thread(jwks_client.get_signing_key_from_jwt, token)
+                payload = jwt.decode(
+                    token,
+                    signing_key.key,
+                    algorithms=["ES256", "RS256"],
+                    audience="authenticated",
+                )
+            else:
+                raise jwt.InvalidAlgorithmError(f"Unsupported algorithm: {alg}")'''
+
+content = content.replace(old_alg_check, new_alg_check)
+
+# Add logger initialization
+if "logger = logging.getLogger(__name__)" not in content:
+    content = content.replace("import jwt\n", "import logging\nimport jwt\n\nlogger = logging.getLogger(__name__)\n")
+
+with open('backend/app/infrastructure/auth/jwt_verifier.py', 'w') as f:
+    f.write(content)

--- a/patch_verifier2.py
+++ b/patch_verifier2.py
@@ -1,0 +1,31 @@
+with open('backend/app/infrastructure/auth/jwt_verifier.py', 'r') as f:
+    content = f.read()
+
+# Fix the import E402
+old_top = '''from __future__ import annotations
+
+import asyncio
+import jwt
+import logging
+
+logger = logging.getLogger(__name__)
+
+from app.core.config import get_settings
+from app.domain.auth.schemas import JWTPayload'''
+
+new_top = '''from __future__ import annotations
+
+import asyncio
+import logging
+
+import jwt
+
+from app.core.config import get_settings
+from app.domain.auth.schemas import JWTPayload
+
+logger = logging.getLogger(__name__)'''
+
+content = content.replace(old_top, new_top)
+
+with open('backend/app/infrastructure/auth/jwt_verifier.py', 'w') as f:
+    f.write(content)

--- a/patch_verifier3.py
+++ b/patch_verifier3.py
@@ -1,0 +1,17 @@
+with open('backend/app/infrastructure/auth/jwt_verifier.py', 'r') as f:
+    content = f.read()
+
+old = '''logger = logging.getLogger(__name__)
+
+from app.core.config import get_settings
+from app.domain.auth.schemas import JWTPayload'''
+
+new = '''from app.core.config import get_settings
+from app.domain.auth.schemas import JWTPayload
+
+logger = logging.getLogger(__name__)'''
+
+content = content.replace(old, new)
+
+with open('backend/app/infrastructure/auth/jwt_verifier.py', 'w') as f:
+    f.write(content)

--- a/patch_ws.py
+++ b/patch_ws.py
@@ -1,0 +1,37 @@
+import re
+
+with open('backend/app/api/v1/websocket.py', 'r') as f:
+    content = f.read()
+
+# Replace _verify_token implementation
+old_verify = '''async def _verify_token(token: str) -> UUID | None:
+    """Decode a Supabase JWT by delegating to AuthService.decode_jwt."""
+    try:
+        verifier = get_jwt_verifier()
+        auth_service = AuthService(AuthRepository(get_supabase()), verifier)
+        payload = await auth_service.decode_jwt(token)
+        return payload.sub
+    except Exception:
+        logger.warning("WS auth rejected: invalid token")
+        return None'''
+
+new_verify = '''async def _verify_token(token: str) -> UUID | None:
+    """Decode a Supabase JWT using the configured token verifier."""
+    try:
+        verifier = get_jwt_verifier()
+        payload = await verifier.verify(token)
+        return payload.sub
+    except Exception:
+        logger.warning("WS auth rejected: invalid token")
+        return None'''
+
+content = content.replace(old_verify, new_verify)
+
+# Remove the unused imports
+content = content.replace('from app.domain.auth.service import AuthService\n', '')
+content = content.replace('from app.infrastructure.repositories.auth_repo import AuthRepository\n', '')
+content = content.replace('from app.infrastructure.database.supabase import get_supabase\n', '')
+
+
+with open('backend/app/api/v1/websocket.py', 'w') as f:
+    f.write(content)


### PR DESCRIPTION
Extracts the `jwt` dependency and `JWKS` fetching logic out of `AuthService` into a new `SupabaseJWTVerifier` implementation. Creates a new `TokenVerifierProtocol` inside `app/domain/auth/interfaces.py` and implements dependency injection across `dependencies.py` and `websocket.py`. Tests are updated and passing.

---
*PR created automatically by Jules for task [15124752989552201467](https://jules.google.com/task/15124752989552201467) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored authentication token verification infrastructure for improved code maintainability and separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->