### PR TITLE
refactor: decouple JWT verification into TokenVerifierProtocol

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -8,6 +8,7 @@ from fastapi import Depends
 
 from app.core.security.jwt_verifier import SupabaseJWTVerifier
 from app.domain.agents.service import AgentService
+from app.domain.auth.interfaces import TokenVerifierProtocol
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
 from app.domain.memory.service import MemoryService
@@ -66,7 +67,7 @@ def get_memory_service(
 _jwt_verifier: SupabaseJWTVerifier | None = None
 
 
-def get_jwt_verifier() -> SupabaseJWTVerifier:
+def get_jwt_verifier() -> TokenVerifierProtocol:
     global _jwt_verifier
     if _jwt_verifier is None:
         _jwt_verifier = SupabaseJWTVerifier()
@@ -75,6 +76,6 @@ def get_jwt_verifier() -> SupabaseJWTVerifier:
 
 def get_auth_service(
     repo: Annotated[AuthRepository, Depends(get_auth_repo)],
-    token_verifier: Annotated[SupabaseJWTVerifier, Depends(get_jwt_verifier)],
+    token_verifier: Annotated[TokenVerifierProtocol, Depends(get_jwt_verifier)],
 ) -> AuthService:
     return AuthService(repo, token_verifier)

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -6,6 +6,7 @@ from typing import Annotated
 
 from fastapi import Depends
 
+from app.core.security.jwt_verifier import SupabaseJWTVerifier
 from app.domain.agents.service import AgentService
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
@@ -62,5 +63,18 @@ def get_memory_service(
     return MemoryService(repo)
 
 
-def get_auth_service(repo: Annotated[AuthRepository, Depends(get_auth_repo)]) -> AuthService:
-    return AuthService(repo)
+_jwt_verifier: SupabaseJWTVerifier | None = None
+
+
+def get_jwt_verifier() -> SupabaseJWTVerifier:
+    global _jwt_verifier
+    if _jwt_verifier is None:
+        _jwt_verifier = SupabaseJWTVerifier()
+    return _jwt_verifier
+
+
+def get_auth_service(
+    repo: Annotated[AuthRepository, Depends(get_auth_repo)],
+    token_verifier: Annotated[SupabaseJWTVerifier, Depends(get_jwt_verifier)],
+) -> AuthService:
+    return AuthService(repo, token_verifier)

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -28,10 +28,12 @@ import logging
 from uuid import UUID
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
+from fastapi.security import HTTPAuthorizationCredentials
 
-from app.api.dependencies import get_jwt_verifier
+from app.core.security.auth import get_current_user
 from app.domain.agents.service import AgentService
 from app.domain.chat.service import ChatService
+from app.infrastructure.database.supabase import get_supabase
 from app.infrastructure.repositories.agent_repo import AgentRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
 from app.infrastructure.repositories.memory_repo import MemoryRepository
@@ -48,11 +50,14 @@ logger = logging.getLogger(__name__)
 
 
 async def _verify_token(token: str) -> UUID | None:
-    """Decode a Supabase JWT by delegating to the application's JWT verifier."""
+    """Decode a Supabase JWT by delegating to the central auth entrypoint."""
     try:
-        verifier = get_jwt_verifier()
-        payload = await verifier.verify_token(token)
-        return payload.sub
+        from app.api.dependencies import get_auth_repo, get_jwt_verifier
+        from app.domain.auth.service import AuthService
+
+        auth_service = AuthService(get_auth_repo(get_supabase()), get_jwt_verifier())
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+        return await get_current_user(credentials, auth_service)
     except Exception:
         logger.warning("WS auth rejected: invalid token")
         return None

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -29,12 +29,10 @@ from uuid import UUID
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
+from app.api.dependencies import get_jwt_verifier
 from app.domain.agents.service import AgentService
-from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
-from app.infrastructure.database.supabase import get_supabase
 from app.infrastructure.repositories.agent_repo import AgentRepository
-from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
 from app.infrastructure.repositories.memory_repo import MemoryRepository
 from app.infrastructure.websocket.manager import chat_hub
@@ -50,10 +48,10 @@ logger = logging.getLogger(__name__)
 
 
 async def _verify_token(token: str) -> UUID | None:
-    """Decode a Supabase JWT by delegating to AuthService.decode_jwt."""
+    """Decode a Supabase JWT by delegating to the application's JWT verifier."""
     try:
-        auth_service = AuthService(AuthRepository(get_supabase()))
-        payload = await auth_service.decode_jwt(token)
+        verifier = get_jwt_verifier()
+        payload = await verifier.verify_token(token)
         return payload.sub
     except Exception:
         logger.warning("WS auth rejected: invalid token")

--- a/backend/app/core/security/jwt_verifier.py
+++ b/backend/app/core/security/jwt_verifier.py
@@ -56,6 +56,9 @@ class SupabaseJWTVerifier:
                     audience="authenticated",
                 )
             return JWTPayload(**payload)
-        except Exception as exc:
+        except jwt.PyJWTError as exc:
             logger.warning("JWT validation failed: %s", exc)
+            raise
+        except Exception as exc:
+            logger.exception("Unexpected JWT verifier error while validating token: %s", exc)
             raise

--- a/backend/app/core/security/jwt_verifier.py
+++ b/backend/app/core/security/jwt_verifier.py
@@ -1,0 +1,61 @@
+"""JWT token verification implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import jwt
+
+from app.core.config import get_settings
+from app.domain.auth.schemas import JWTPayload
+
+logger = logging.getLogger(__name__)
+
+
+class SupabaseJWTVerifier:
+    """Verifies Supabase JWTs, caching the JWKS client for performance."""
+
+    def __init__(self) -> None:
+        self._jwks_client: jwt.PyJWKClient | None = None
+
+    def _get_jwks_client(self) -> jwt.PyJWKClient:
+        """Get or initialize the PyJWKClient lazily."""
+        if self._jwks_client is None:
+            settings = get_settings()
+            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
+            self._jwks_client = jwt.PyJWKClient(jwks_url)
+        return self._jwks_client
+
+    async def verify_token(self, token: str) -> JWTPayload:
+        """Decode and verify a Supabase JWT."""
+        settings = get_settings()
+        try:
+            try:
+                header = jwt.get_unverified_header(token)
+            except Exception as header_exc:
+                raise jwt.DecodeError("Invalid token format") from header_exc
+
+            alg = header.get("alg")
+
+            if alg == "HS256":
+                payload = jwt.decode(
+                    token,
+                    settings.supabase_jwt_secret,
+                    algorithms=["HS256"],
+                    audience="authenticated",
+                )
+            else:
+                jwks_client = self._get_jwks_client()
+                # Run the blocking network/cache-check in a thread pool
+                signing_key = await asyncio.to_thread(jwks_client.get_signing_key_from_jwt, token)
+                payload = jwt.decode(
+                    token,
+                    signing_key.key,
+                    algorithms=["ES256", "RS256"],
+                    audience="authenticated",
+                )
+            return JWTPayload(**payload)
+        except Exception as exc:
+            logger.warning("JWT validation failed: %s", exc)
+            raise

--- a/backend/app/domain/auth/interfaces.py
+++ b/backend/app/domain/auth/interfaces.py
@@ -6,6 +6,7 @@ from typing import Protocol
 from uuid import UUID
 
 from app.domain.auth.entities import Passkey, PasskeyCreate
+from app.domain.auth.schemas import JWTPayload
 
 
 class AuthRepositoryProtocol(Protocol):
@@ -28,3 +29,11 @@ class AuthRepositoryProtocol(Protocol):
     async def delete_passkey(self, passkey_id: str | UUID, user_id: str | UUID) -> bool:
         """Delete a passkey belonging to a user."""
         ...
+
+
+class TokenVerifierProtocol(Protocol):
+    """Protocol for validating JWT tokens."""
+
+    async def verify_token(self, token: str) -> JWTPayload:
+        """Decode and verify a token, returning the structured payload."""
+        pass

--- a/backend/app/domain/auth/service.py
+++ b/backend/app/domain/auth/service.py
@@ -6,22 +6,19 @@ import logging
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-import jwt
-
-from app.core.config import get_settings
 from app.domain.auth.entities import Passkey
 from app.domain.auth.schemas import JWTPayload
 
 if TYPE_CHECKING:
-    from app.domain.auth.interfaces import AuthRepositoryProtocol
+    from app.domain.auth.interfaces import AuthRepositoryProtocol, TokenVerifierProtocol
 
 logger = logging.getLogger(__name__)
 
 
 class AuthService:
-    def __init__(self, repo: AuthRepositoryProtocol) -> None:
+    def __init__(self, repo: AuthRepositoryProtocol, token_verifier: TokenVerifierProtocol) -> None:
         self.repo = repo
-        self._jwks_client: jwt.PyJWKClient | None = None
+        self.token_verifier = token_verifier
 
     async def list_passkeys(
         self, user_id: str | UUID, limit: int = 50, cursor: str | None = None
@@ -29,44 +26,9 @@ class AuthService:
         """Fetch a paginated list of passkeys for a user."""
         return await self.repo.get_passkeys_by_user(user_id, limit=limit, cursor=cursor)
 
-    def _get_jwks_client(self) -> jwt.PyJWKClient:
-        if self._jwks_client is None:
-            settings = get_settings()
-            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
-            self._jwks_client = jwt.PyJWKClient(jwks_url)
-        return self._jwks_client
-
     async def decode_jwt(self, token: str) -> JWTPayload:
         """Decode and verify a Supabase JWT."""
-        settings = get_settings()
-        try:
-            try:
-                header = jwt.get_unverified_header(token)
-            except Exception as header_exc:
-                raise jwt.DecodeError("Invalid token format") from header_exc
-
-            alg = header.get("alg")
-
-            if alg == "HS256":
-                payload = jwt.decode(
-                    token,
-                    settings.supabase_jwt_secret,
-                    algorithms=["HS256"],
-                    audience="authenticated",
-                )
-            else:
-                jwks_client = self._get_jwks_client()
-                signing_key = jwks_client.get_signing_key_from_jwt(token)
-                payload = jwt.decode(
-                    token,
-                    signing_key.key,
-                    algorithms=["ES256", "RS256"],
-                    audience="authenticated",
-                )
-            return JWTPayload(**payload)
-        except Exception as exc:
-            logger.warning("JWT validation failed: %s", exc)
-            raise
+        return await self.token_verifier.verify_token(token)
 
     # --- WebAuthn / Passkey Logic (Authlib Integration) ---
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -25,7 +25,10 @@ async def test_decode_valid_jwt() -> None:
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt()
-    service = AuthService(AuthRepository(MagicMock()))
+    from app.core.security.jwt_verifier import SupabaseJWTVerifier
+
+    verifier = SupabaseJWTVerifier()
+    service = AuthService(AuthRepository(MagicMock()), verifier)
     payload = await service.decode_jwt(token)
 
     assert isinstance(payload, JWTPayload)
@@ -39,7 +42,10 @@ async def test_decode_expired_jwt_raises_401() -> None:
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt(expired=True)
-    service = AuthService(AuthRepository(MagicMock()))
+    from app.core.security.jwt_verifier import SupabaseJWTVerifier
+
+    verifier = SupabaseJWTVerifier()
+    service = AuthService(AuthRepository(MagicMock()), verifier)
 
     with pytest.raises(jwt.ExpiredSignatureError):
         await service.decode_jwt(token)
@@ -54,7 +60,10 @@ async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureF
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = "invalid.token.format"
-    service = AuthService(AuthRepository(MagicMock()))
+    from app.core.security.jwt_verifier import SupabaseJWTVerifier
+
+    verifier = SupabaseJWTVerifier()
+    service = AuthService(AuthRepository(MagicMock()), verifier)
 
     with (
         caplog.at_level(logging.WARNING),

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
+import base64
+import json
+import uuid
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import jwt
 import pytest
 
+from app.core.security.jwt_verifier import SupabaseJWTVerifier
 from app.domain.auth.schemas import JWTPayload
+from app.domain.auth.service import AuthService
 from app.infrastructure.database.supabase import get_supabase
+from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.main import app
 
 if TYPE_CHECKING:
@@ -21,11 +27,8 @@ from tests.conftest import make_jwt
 @pytest.mark.asyncio
 async def test_decode_valid_jwt() -> None:
     """A valid JWT with a known secret decodes successfully."""
-    from app.domain.auth.service import AuthService
-    from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt()
-    from app.core.security.jwt_verifier import SupabaseJWTVerifier
 
     verifier = SupabaseJWTVerifier()
     service = AuthService(AuthRepository(MagicMock()), verifier)
@@ -38,11 +41,8 @@ async def test_decode_valid_jwt() -> None:
 @pytest.mark.asyncio
 async def test_decode_expired_jwt_raises_401() -> None:
     """An expired JWT raises an error."""
-    from app.domain.auth.service import AuthService
-    from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt(expired=True)
-    from app.core.security.jwt_verifier import SupabaseJWTVerifier
 
     verifier = SupabaseJWTVerifier()
     service = AuthService(AuthRepository(MagicMock()), verifier)
@@ -56,11 +56,7 @@ async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureF
     """An invalid JWT format raises a DecodeError and logs a warning instead of an error."""
     import logging
 
-    from app.domain.auth.service import AuthService
-    from app.infrastructure.repositories.auth_repo import AuthRepository
-
     token = "invalid.token.format"
-    from app.core.security.jwt_verifier import SupabaseJWTVerifier
 
     verifier = SupabaseJWTVerifier()
     service = AuthService(AuthRepository(MagicMock()), verifier)
@@ -102,3 +98,111 @@ def test_invalid_token_returns_401(client: TestClient) -> None:
         assert response.status_code == 401
     finally:
         app.dependency_overrides = {}
+
+
+@pytest.mark.asyncio
+async def test_decode_rs256_valid_jwt() -> None:
+    """An RS256 token is verified successfully using the JWKS client branch."""
+
+    # Create an RS256 token (we'll just use a dummy key and mock decode)
+    header_b64 = (
+        base64.urlsafe_b64encode(json.dumps({"alg": "RS256", "typ": "JWT"}).encode())
+        .decode()
+        .rstrip("=")
+    )
+    payload_b64 = (
+        base64.urlsafe_b64encode(
+            json.dumps(
+                {
+                    "sub": "user_id",
+                    "role": "authenticated",
+                    "aud": "authenticated",
+                    "iss": "supabase",
+                    "exp": 1999999999,
+                    "iat": 1,
+                }
+            ).encode()
+        )
+        .decode()
+        .rstrip("=")
+    )
+    token = f"{header_b64}.{payload_b64}.c2lnbmF0dXJl"
+
+    verifier = SupabaseJWTVerifier()
+    service = AuthService(AuthRepository(MagicMock()), verifier)
+
+    with patch("jwt.PyJWKClient") as mock_jwk_client_class:
+        mock_jwks_client_instance = MagicMock()
+        mock_jwks_client_instance.get_signing_key_from_jwt.return_value = MagicMock(
+            key="public_key"
+        )
+        mock_jwk_client_class.return_value = mock_jwks_client_instance
+
+        with patch("asyncio.to_thread") as mock_to_thread:
+            # We mock to_thread to immediately return the result of get_signing_key_from_jwt
+            mock_to_thread.return_value = mock_jwks_client_instance.get_signing_key_from_jwt(token)
+
+            with patch("jwt.decode") as mock_jwt_decode:
+                mock_jwt_decode.return_value = {
+                    "sub": str(uuid.uuid4()),
+                    "role": "authenticated",
+                    "aud": "authenticated",
+                    "iss": "supabase",
+                    "exp": 1999999999,
+                    "iat": 1,
+                }
+
+                payload = await service.decode_jwt(token)
+
+                assert isinstance(payload, JWTPayload)
+                pass
+
+
+@pytest.mark.asyncio
+async def test_decode_rs256_invalid_jwt_raises_error() -> None:
+    """An RS256 token fails verification using the JWKS client branch when an error is raised."""
+    import jwt
+
+    # Create an RS256 token (we'll just use a dummy key and mock decode)
+    header_b64 = (
+        base64.urlsafe_b64encode(json.dumps({"alg": "RS256", "typ": "JWT"}).encode())
+        .decode()
+        .rstrip("=")
+    )
+    payload_b64 = (
+        base64.urlsafe_b64encode(
+            json.dumps(
+                {
+                    "sub": "user_id",
+                    "role": "authenticated",
+                    "aud": "authenticated",
+                    "iss": "supabase",
+                    "exp": 1999999999,
+                    "iat": 1,
+                }
+            ).encode()
+        )
+        .decode()
+        .rstrip("=")
+    )
+    token = f"{header_b64}.{payload_b64}.c2lnbmF0dXJl"
+
+    verifier = SupabaseJWTVerifier()
+    service = AuthService(AuthRepository(MagicMock()), verifier)
+
+    with patch("jwt.PyJWKClient") as mock_jwk_client_class:
+        mock_jwks_client_instance = MagicMock()
+        mock_jwks_client_instance.get_signing_key_from_jwt.side_effect = jwt.PyJWKClientError(
+            "Unable to fetch JWKS"
+        )
+        mock_jwk_client_class.return_value = mock_jwks_client_instance
+
+        with patch("asyncio.to_thread") as mock_to_thread:
+            # Re-raise the exception from the mock
+            async def mock_coro(*args, **kwargs):
+                raise jwt.PyJWKClientError("Unable to fetch JWKS")
+
+            mock_to_thread.side_effect = mock_coro
+
+            with pytest.raises(jwt.PyJWKClientError):
+                await service.decode_jwt(token)


### PR DESCRIPTION
This refactor decouples the JWT token verification logic from `AuthService` in accordance with the "Architect" and "Refactoring Engineer" persona directives. It introduces `TokenVerifierProtocol` to define the interface and `SupabaseJWTVerifier` for the concrete implementation. `PyJWKClient` is now appropriately cached via a module-level singleton in `dependencies.py` accessed via `get_jwt_verifier()`. The `get_signing_key_from_jwt` call, which is a blocking network cache lookup, has been hardened by wrapping it in `asyncio.to_thread` to prevent stalling the FastAPI event loop. Relevant unit tests and dependent modules like `websocket.py` have been updated and all tests passed.

---
*PR created automatically by Jules for task [5035296218774850341](https://jules.google.com/task/5035296218774850341) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved authentication handling by centralizing JWT token verification logic, ensuring consistent token validation across all application endpoints and WebSocket connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->