### PR TITLE
docs(api): flag undocumented websocket chat hub endpoint

### DIFF
--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -99,6 +99,7 @@ async def _handle_send_message(
 # ---------------------------------------------------------------------------
 # WebSocket endpoint
 # ---------------------------------------------------------------------------
+# DOCS(miru-agent): undocumented endpoint
 @router.websocket("/ws/chat")
 async def websocket_chat_hub(
     websocket: WebSocket,


### PR DESCRIPTION
Add `# DOCS(miru-agent): undocumented endpoint` tag above the websocket chat hub route.

---
*PR created automatically by Jules for task [11224244359446532550](https://jules.google.com/task/11224244359446532550) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation marker to WebSocket endpoint for internal tracking purposes. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->