### PR TITLE
Harden CrewAI Orchestrator with Structured Outputs

### DIFF
--- a/backend/app/domain/chat/background_service.py
+++ b/backend/app/domain/chat/background_service.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class RoomSummaryResponse(BaseModel):
+class BackgroundRoomSummaryResponse(BaseModel):
     """Structured response model for room summaries."""
 
     summary: str
@@ -174,7 +174,7 @@ class ChatBackgroundService:
             response = await structured_completion(
                 model=model_name,  # Use a fast/cheap model for summarization
                 messages=messages,
-                response_model=RoomSummaryResponse,
+                response_model=BackgroundRoomSummaryResponse,
             )
 
             new_summary = response.summary.strip()

--- a/backend/app/domain/chat/crew_orchestrator.py
+++ b/backend/app/domain/chat/crew_orchestrator.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import crewai
 from crewai import LLM, Crew, Process, Task
+from pydantic import BaseModel, Field
 
 from app.core.config import get_settings
 from app.domain.agent_tools.productivity_tools import (
@@ -48,6 +49,12 @@ if TYPE_CHECKING:
     from app.domain.agents.models import Agent
 
 logger = logging.getLogger(__name__)
+
+
+class CrewTaskOutput(BaseModel):
+    """Structured output expected from the CrewAI task."""
+
+    response: str = Field(description="The response from the agent(s) to the user.")
 
 
 class _OpenRouterLLM(LLM):
@@ -248,6 +255,7 @@ class CrewOrchestrator:
                     locale_instruction=locale_instruction,
                 ),
                 expected_output=MULTI_AGENT_EXPECTED_OUTPUT,
+                output_pydantic=CrewTaskOutput,
             )
             crew = Crew(
                 agents=cast("Any", crew_agents),
@@ -266,6 +274,7 @@ class CrewOrchestrator:
                     locale_instruction=locale_instruction,
                 ),
                 expected_output=SINGLE_AGENT_EXPECTED_OUTPUT,
+                output_pydantic=CrewTaskOutput,
                 agent=crew_agents[0],
             )
             crew = Crew(
@@ -289,4 +298,7 @@ class CrewOrchestrator:
                 logger.warning("Crew kickoff failed on attempt 1, retrying in 2 s…")
                 await asyncio.sleep(2)
 
+        data = getattr(result, "pydantic", None)
+        if data and hasattr(data, "response"):
+            return data.response
         return str(result)

--- a/backend/tests/chat/test_chat_crew.py
+++ b/backend/tests/chat/test_chat_crew.py
@@ -75,7 +75,9 @@ async def test_run_crew_task_has_single_agent(
         mock_crew_agent.role = "Test Agent"
         mock_agent_cls.return_value = mock_crew_agent
         mock_crew_instance = MagicMock()
-        mock_crew_instance.kickoff_async = AsyncMock(return_value="Crew output")
+        mock_result = MagicMock()
+        mock_result.pydantic.response = "Crew output"
+        mock_crew_instance.kickoff_async = AsyncMock(return_value=mock_result)
         mock_crew_cls.return_value = mock_crew_instance
         result = await chat_service.run_crew("hello", user_id, accept_language="es-ES")
         assert result["task_type"] == "general"
@@ -117,10 +119,52 @@ async def test_run_crew_task_has_multiple_agents(
         mock_crew_agent2.role = "Agent 2"
         mock_agent_cls.side_effect = [mock_crew_agent1, mock_crew_agent2]
         mock_crew_instance = MagicMock()
-        mock_crew_instance.kickoff_async = AsyncMock(return_value="Crew output")
+        mock_result = MagicMock()
+        mock_result.pydantic.response = "Crew output"
+        mock_crew_instance.kickoff_async = AsyncMock(return_value=mock_result)
         mock_crew_cls.return_value = mock_crew_instance
         result = await chat_service.run_crew("hello", user_id, accept_language="es-ES")
         assert result["task_type"] == "general"
+
+
+@pytest.mark.asyncio
+async def test_execute_crew_task_fallback_to_str(
+    chat_service: ChatService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    room_agents = [
+        MagicMock(
+            id=uuid4(), name="Agent1", personality="Good", description="desc", agent_integrations=[]
+        )
+    ]
+    user_id = uuid4()
+    user_msg_id = uuid4()
+    mock_llm = MagicMock()
+    monkeypatch.setattr(
+        "app.domain.chat.crew_orchestrator.CrewOrchestrator.get_crew_llm",
+        MagicMock(return_value=mock_llm),
+    )
+    with (
+        patch("app.domain.chat.crew_orchestrator.Task"),
+        patch("app.domain.chat.crew_orchestrator.Crew") as mock_crew_cls,
+        patch("app.domain.chat.crew_orchestrator.crewai.Agent"),
+    ):
+        mock_crew_instance = MagicMock()
+        # Simulate pydantic being None (e.g., if output extraction fails)
+        mock_result = MagicMock()
+        mock_result.pydantic = None
+        mock_result.__str__ = MagicMock(return_value="FallbackString")
+        mock_crew_instance.kickoff_async = AsyncMock(return_value=mock_result)
+        mock_crew_cls.return_value = mock_crew_instance
+
+        result = await CrewOrchestrator.execute_crew_task(
+            typing.cast("list[typing.Any]", room_agents),
+            "Hello",
+            user_id,
+            user_msg_id,
+            MagicMock(),
+            accept_language="ja-JP",
+        )
+        assert result == "FallbackString"
 
 
 @pytest.mark.asyncio
@@ -145,7 +189,9 @@ async def test_execute_crew_task(
         patch("app.domain.chat.crew_orchestrator.crewai.Agent"),
     ):
         mock_crew_instance = MagicMock()
-        mock_crew_instance.kickoff_async = AsyncMock(return_value="Result")
+        mock_result = MagicMock()
+        mock_result.pydantic.response = "Result"
+        mock_crew_instance.kickoff_async = AsyncMock(return_value=mock_result)
         mock_crew_cls.return_value = mock_crew_instance
         result = await CrewOrchestrator.execute_crew_task(
             typing.cast("list[typing.Any]", room_agents),
@@ -183,7 +229,9 @@ async def test_execute_crew_task_multi(
         patch("app.domain.chat.crew_orchestrator.crewai.Agent"),
     ):
         mock_crew_instance = MagicMock()
-        mock_crew_instance.kickoff_async = AsyncMock(return_value="ResultMulti")
+        mock_result = MagicMock()
+        mock_result.pydantic.response = "ResultMulti"
+        mock_crew_instance.kickoff_async = AsyncMock(return_value=mock_result)
         mock_crew_cls.return_value = mock_crew_instance
         result = await CrewOrchestrator.execute_crew_task(
             typing.cast("list[typing.Any]", room_agents),

--- a/backend/tests/test_chat_background_service.py
+++ b/backend/tests/test_chat_background_service.py
@@ -146,12 +146,14 @@ async def test_update_room_summary_background_success(
     mock_room.summary = "old summary"
     background_service.chat_repo.get_room = AsyncMock(return_value=mock_room)
 
-    from app.domain.chat.background_service import RoomSummaryResponse
+    from app.domain.chat.background_service import BackgroundRoomSummaryResponse
 
     with patch(
         "app.infrastructure.external.openrouter.structured_completion", new_callable=AsyncMock
     ) as mock_structured_completion:
-        mock_structured_completion.return_value = RoomSummaryResponse(summary="new updated summary")
+        mock_structured_completion.return_value = BackgroundRoomSummaryResponse(
+            summary="new updated summary"
+        )
 
         await background_service.update_room_summary_background(room_id, history)
 


### PR DESCRIPTION
## Summary
Enforced strict JSON Structured Outputs for CrewAI responses using Pydantic schemas per the "AI Integration Engineer" standard.

## Changes
- Updated `backend/app/domain/chat/crew_orchestrator.py` to use `output_pydantic=CrewTaskOutput` on tasks and safely retrieve `.pydantic.response`.
- Added fallback path in case `.pydantic` fails or the model ignores instruction.
- Renamed `RoomSummaryResponse` to `BackgroundRoomSummaryResponse` inside `background_service.py` so it strictly functions as the structured target, rather than clashing with FastAPI endpoint schema.
- Expanded tests in `backend/tests/chat/test_chat_crew.py` to verify both the `pydantic.response` extraction and the string fallback.

---
*PR created automatically by Jules for task [17501096161622327474](https://jules.google.com/task/17501096161622327474) started by @YKDBontekoe*