### PR TITLE
Refactor Auth Service to Clean Architecture and Asynchronous Token Verification

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -10,6 +10,7 @@ from app.domain.agents.service import AgentService
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
 from app.domain.memory.service import MemoryService
+from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
 from app.infrastructure.database.supabase import SupabaseClient
 from app.infrastructure.repositories.agent_repo import AgentRepository
 from app.infrastructure.repositories.auth_repo import AuthRepository
@@ -39,6 +40,20 @@ def get_auth_repo(db: SupabaseClient) -> AuthRepository:
 
 
 # ---------------------------------------------------------------------------
+# Verifier factories (Singletons)
+# ---------------------------------------------------------------------------
+
+_jwt_verifier: SupabaseJWTVerifier | None = None
+
+
+def get_jwt_verifier() -> SupabaseJWTVerifier:
+    global _jwt_verifier
+    if _jwt_verifier is None:
+        _jwt_verifier = SupabaseJWTVerifier()
+    return _jwt_verifier
+
+
+# ---------------------------------------------------------------------------
 # Service factories
 # ---------------------------------------------------------------------------
 
@@ -62,5 +77,8 @@ def get_memory_service(
     return MemoryService(repo)
 
 
-def get_auth_service(repo: Annotated[AuthRepository, Depends(get_auth_repo)]) -> AuthService:
-    return AuthService(repo)
+def get_auth_service(
+    repo: Annotated[AuthRepository, Depends(get_auth_repo)],
+    token_verifier: Annotated[SupabaseJWTVerifier, Depends(get_jwt_verifier)],
+) -> AuthService:
+    return AuthService(repo, token_verifier)

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -29,12 +29,10 @@ from uuid import UUID
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
+from app.api.dependencies import get_jwt_verifier
 from app.domain.agents.service import AgentService
-from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
-from app.infrastructure.database.supabase import get_supabase
 from app.infrastructure.repositories.agent_repo import AgentRepository
-from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
 from app.infrastructure.repositories.memory_repo import MemoryRepository
 from app.infrastructure.websocket.manager import chat_hub
@@ -50,10 +48,10 @@ logger = logging.getLogger(__name__)
 
 
 async def _verify_token(token: str) -> UUID | None:
-    """Decode a Supabase JWT by delegating to AuthService.decode_jwt."""
+    """Decode a Supabase JWT by delegating to TokenVerifierProtocol."""
     try:
-        auth_service = AuthService(AuthRepository(get_supabase()))
-        payload = await auth_service.decode_jwt(token)
+        verifier = get_jwt_verifier()
+        payload = await verifier.verify_token(token)
         return payload.sub
     except Exception:
         logger.warning("WS auth rejected: invalid token")

--- a/backend/app/domain/auth/interfaces.py
+++ b/backend/app/domain/auth/interfaces.py
@@ -6,6 +6,7 @@ from typing import Protocol
 from uuid import UUID
 
 from app.domain.auth.entities import Passkey, PasskeyCreate
+from app.domain.auth.schemas import JWTPayload
 
 
 class AuthRepositoryProtocol(Protocol):
@@ -15,16 +16,24 @@ class AuthRepositoryProtocol(Protocol):
         self, user_id: str | UUID, limit: int = 50, cursor: str | None = None
     ) -> tuple[list[Passkey], str | None]:
         """Fetch all registered passkeys for a user with pagination."""
-        ...
+        pass
 
     async def update_sign_count(self, passkey_id: str | UUID, new_count: int) -> None:
         """Update the signature count for a passkey."""
-        ...
+        pass
 
     async def create_passkey(self, input: PasskeyCreate) -> Passkey:
         """Insert a new passkey record."""
-        ...
+        pass
 
     async def delete_passkey(self, passkey_id: str | UUID, user_id: str | UUID) -> bool:
         """Delete a passkey belonging to a user."""
-        ...
+        pass
+
+
+class TokenVerifierProtocol(Protocol):
+    """Protocol for verifying JWT tokens."""
+
+    async def verify_token(self, token: str) -> JWTPayload:
+        """Decode and verify a JWT, returning the parsed payload."""
+        pass

--- a/backend/app/domain/auth/service.py
+++ b/backend/app/domain/auth/service.py
@@ -6,22 +6,19 @@ import logging
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-import jwt
-
-from app.core.config import get_settings
 from app.domain.auth.entities import Passkey
 from app.domain.auth.schemas import JWTPayload
 
 if TYPE_CHECKING:
-    from app.domain.auth.interfaces import AuthRepositoryProtocol
+    from app.domain.auth.interfaces import AuthRepositoryProtocol, TokenVerifierProtocol
 
 logger = logging.getLogger(__name__)
 
 
 class AuthService:
-    def __init__(self, repo: AuthRepositoryProtocol) -> None:
+    def __init__(self, repo: AuthRepositoryProtocol, token_verifier: TokenVerifierProtocol) -> None:
         self.repo = repo
-        self._jwks_client: jwt.PyJWKClient | None = None
+        self.token_verifier = token_verifier
 
     async def list_passkeys(
         self, user_id: str | UUID, limit: int = 50, cursor: str | None = None
@@ -29,44 +26,9 @@ class AuthService:
         """Fetch a paginated list of passkeys for a user."""
         return await self.repo.get_passkeys_by_user(user_id, limit=limit, cursor=cursor)
 
-    def _get_jwks_client(self) -> jwt.PyJWKClient:
-        if self._jwks_client is None:
-            settings = get_settings()
-            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
-            self._jwks_client = jwt.PyJWKClient(jwks_url)
-        return self._jwks_client
-
     async def decode_jwt(self, token: str) -> JWTPayload:
         """Decode and verify a Supabase JWT."""
-        settings = get_settings()
-        try:
-            try:
-                header = jwt.get_unverified_header(token)
-            except Exception as header_exc:
-                raise jwt.DecodeError("Invalid token format") from header_exc
-
-            alg = header.get("alg")
-
-            if alg == "HS256":
-                payload = jwt.decode(
-                    token,
-                    settings.supabase_jwt_secret,
-                    algorithms=["HS256"],
-                    audience="authenticated",
-                )
-            else:
-                jwks_client = self._get_jwks_client()
-                signing_key = jwks_client.get_signing_key_from_jwt(token)
-                payload = jwt.decode(
-                    token,
-                    signing_key.key,
-                    algorithms=["ES256", "RS256"],
-                    audience="authenticated",
-                )
-            return JWTPayload(**payload)
-        except Exception as exc:
-            logger.warning("JWT validation failed: %s", exc)
-            raise
+        return await self.token_verifier.verify_token(token)
 
     # --- WebAuthn / Passkey Logic (Authlib Integration) ---
 

--- a/backend/app/infrastructure/auth/jwt_verifier.py
+++ b/backend/app/infrastructure/auth/jwt_verifier.py
@@ -1,0 +1,68 @@
+"""Infrastructure implementation of the TokenVerifierProtocol."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import jwt
+
+from app.core.config import get_settings
+from app.domain.auth.interfaces import TokenVerifierProtocol
+from app.domain.auth.schemas import JWTPayload
+
+logger = logging.getLogger(__name__)
+
+
+class SupabaseJWTVerifier(TokenVerifierProtocol):
+    """Verifies JWTs issued by Supabase using cached JWKS."""
+
+    def __init__(self) -> None:
+        self._jwks_client: jwt.PyJWKClient | None = None
+
+    def _get_jwks_client(self) -> jwt.PyJWKClient:
+        if self._jwks_client is None:
+            settings = get_settings()
+            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
+            self._jwks_client = jwt.PyJWKClient(jwks_url)
+        return self._jwks_client
+
+    async def verify_token(self, token: str) -> JWTPayload:
+        """Decode and verify a Supabase JWT without blocking the event loop."""
+        settings = get_settings()
+        try:
+            try:
+                # CPU-bound or fast, ok to run synchronously if tiny, but better to wrap decoding.
+                header = jwt.get_unverified_header(token)
+            except Exception as header_exc:
+                raise jwt.DecodeError("Invalid token format") from header_exc
+
+            alg = header.get("alg")
+
+            if alg == "HS256":
+                # CPU bound
+                payload = await asyncio.to_thread(
+                    jwt.decode,
+                    token,
+                    settings.supabase_jwt_secret,
+                    algorithms=["HS256"],
+                    audience="authenticated",
+                )
+            else:
+                jwks_client = self._get_jwks_client()
+                # I/O bound on first fetch, CPU bound on subsequent
+                signing_key = await asyncio.to_thread(
+                    jwks_client.get_signing_key_from_jwt,
+                    token,
+                )
+                payload = await asyncio.to_thread(
+                    jwt.decode,
+                    token,
+                    signing_key.key,
+                    algorithms=["ES256", "RS256"],
+                    audience="authenticated",
+                )
+            return JWTPayload(**payload)
+        except Exception as exc:
+            logger.warning("JWT validation failed: %s", exc)
+            raise

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -9,6 +9,8 @@ import jwt
 import pytest
 
 from app.domain.auth.schemas import JWTPayload
+from app.domain.auth.interfaces import TokenVerifierProtocol
+from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
 from app.infrastructure.database.supabase import get_supabase
 from app.main import app
 
@@ -25,7 +27,7 @@ async def test_decode_valid_jwt() -> None:
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt()
-    service = AuthService(AuthRepository(MagicMock()))
+    service = AuthService(token_verifier=SupabaseJWTVerifier(), repo=AuthRepository(MagicMock()))
     payload = await service.decode_jwt(token)
 
     assert isinstance(payload, JWTPayload)
@@ -39,7 +41,7 @@ async def test_decode_expired_jwt_raises_401() -> None:
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt(expired=True)
-    service = AuthService(AuthRepository(MagicMock()))
+    service = AuthService(token_verifier=SupabaseJWTVerifier(), repo=AuthRepository(MagicMock()))
 
     with pytest.raises(jwt.ExpiredSignatureError):
         await service.decode_jwt(token)
@@ -54,7 +56,7 @@ async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureF
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = "invalid.token.format"
-    service = AuthService(AuthRepository(MagicMock()))
+    service = AuthService(token_verifier=SupabaseJWTVerifier(), repo=AuthRepository(MagicMock()))
 
     with (
         caplog.at_level(logging.WARNING),

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -9,7 +9,6 @@ import jwt
 import pytest
 
 from app.domain.auth.schemas import JWTPayload
-from app.domain.auth.interfaces import TokenVerifierProtocol
 from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
 from app.infrastructure.database.supabase import get_supabase
 from app.main import app


### PR DESCRIPTION
Migrated codebase towards Clean Architecture by active decoupling in the Auth domain.

**Violation Summary:**
- `backend/app/domain/auth/service.py` (`AuthService`) was importing and directly depending on the external `jwt` library and parsing `get_settings()` inside the class. This violated the Layer Contract because Domain and Application layers should not depend on concrete external infrastructure or configurations.

**Architectural Note:**
- Created `TokenVerifierProtocol` in `backend/app/domain/auth/interfaces.py` to invert the dependency.
- Created `SupabaseJWTVerifier` in `backend/app/infrastructure/auth/jwt_verifier.py` to handle the actual `jwt` parsing, JWKS caching, and settings resolution.
- Used `asyncio.to_thread` for CPU-bound `jwt.decode` and synchronous I/O operations from `PyJWKClient` to prevent blocking the FastAPI asynchronous event loop.
- `dependencies.py` was updated to inject this new verifier into `AuthService` as well as provide a module-level singleton function `get_jwt_verifier()` so that `PyJWKClient` can reuse its cache effectively across API and WebSocket requests.

---
*PR created automatically by Jules for task [7203926764551448259](https://jules.google.com/task/7203926764551448259) started by @YKDBontekoe*