### PR TITLE
fix: handle db errors gracefully in update_event

### DIFF
--- a/backend/app/infrastructure/repositories/productivity_repo.py
+++ b/backend/app/infrastructure/repositories/productivity_repo.py
@@ -241,11 +241,13 @@ class ProductivityRepository(IProductivityRepository):
 
     async def update_event(
         self, user_id: UUID, event_id: UUID, valid_keys: dict
-    ) -> CalendarEventEntity:
+    ) -> CalendarEventEntity | None:
         async with handle_db_errors("update calendar event"):
-            event = await CalendarEvent.get(id=event_id, user_id=user_id).prefetch_related(
+            event = await CalendarEvent.get_or_none(id=event_id, user_id=user_id).prefetch_related(
                 "agent", "origin_message"
             )
+            if not event:
+                return None
             for field, value in valid_keys.items():
                 setattr(event, field, value)
             await event.save(update_fields=list(valid_keys.keys()))

--- a/backend/tests/productivity/test_productivity_repo_update_event.py
+++ b/backend/tests/productivity/test_productivity_repo_update_event.py
@@ -1,0 +1,9 @@
+import uuid
+import pytest
+from app.infrastructure.repositories.productivity_repo import ProductivityRepository
+
+@pytest.mark.asyncio
+async def test_update_event_returns_none(initialize_tortoise):
+    repo = ProductivityRepository()
+    result = await repo.update_event(uuid.uuid4(), uuid.uuid4(), {"title": "Test"})
+    assert result is None

--- a/backend/tests/productivity/test_productivity_repo_update_event.py
+++ b/backend/tests/productivity/test_productivity_repo_update_event.py
@@ -1,6 +1,9 @@
 import uuid
+
 import pytest
+
 from app.infrastructure.repositories.productivity_repo import ProductivityRepository
+
 
 @pytest.mark.asyncio
 async def test_update_event_returns_none(initialize_tortoise):

--- a/backend/tests/productivity/test_productivity_repo_update_task_note.py
+++ b/backend/tests/productivity/test_productivity_repo_update_task_note.py
@@ -1,0 +1,15 @@
+import uuid
+import pytest
+from app.infrastructure.repositories.productivity_repo import ProductivityRepository
+
+@pytest.mark.asyncio
+async def test_update_task_returns_none(initialize_tortoise):
+    repo = ProductivityRepository()
+    result = await repo.update_task(uuid.uuid4(), uuid.uuid4(), {"title": "Test"})
+    assert result is None
+
+@pytest.mark.asyncio
+async def test_update_note_returns_none(initialize_tortoise):
+    repo = ProductivityRepository()
+    result = await repo.update_note(uuid.uuid4(), uuid.uuid4(), {"title": "Test"})
+    assert result is None


### PR DESCRIPTION
Refactored `update_event` repository implementation to use `get_or_none()` to neutralize an unhandled ORM 500 internal server error during lookups. This properly leverages the application layer's `if not updated_event: raise ...NotFoundError()` check.

---
*PR created automatically by Jules for task [9549896763336887726](https://jules.google.com/task/9549896763336887726) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved event retrieval performance by optimizing database queries with related data prefetching.
  * Enhanced error handling for missing event scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->