### PR TITLE
refactor(ui): update HomeDashboardParts to strictly use tokenized Miru Design theme

### DIFF
--- a/frontend/src/components/home/HomeDashboardParts.tsx
+++ b/frontend/src/components/home/HomeDashboardParts.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { StyleProp, View, ViewStyle } from 'react-native';
+import { StyleProp, View, ViewStyle, StyleSheet, Platform } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { AppText } from '@/components/AppText';
 import { ScalePressable } from '@/components/ScalePressable';
 import { Agent, ChatRoom, Task } from '@/core/models';
-import { HOME_COLORS, HOME_SHADOW } from './homeTheme';
 import { relativeTimeFromNow } from './homeUtils';
+import { useTheme } from '@/hooks/useTheme';
+import { theme } from '@/core/theme';
 
 export function HomeSectionHeader({
   title,
@@ -16,21 +17,15 @@ export function HomeSectionHeader({
   actionLabel?: string;
   onAction?: () => void;
 }) {
+  const { C } = useTheme();
   return (
-    <View
-      style={{
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        marginBottom: 12,
-      }}
-    >
-      <AppText variant="h3" style={{ color: HOME_COLORS.text, fontWeight: '700' }}>
+    <View style={styles.sectionHeaderContainer}>
+      <AppText variant="h3" style={{ color: C.text, fontWeight: '700' }}>
         {title}
       </AppText>
       {actionLabel && onAction ? (
         <ScalePressable onPress={onAction}>
-          <AppText variant="bodySm" style={{ color: HOME_COLORS.primary, fontWeight: '700' }}>
+          <AppText variant="bodySm" style={{ color: C.primary, fontWeight: '700' }}>
             {actionLabel}
           </AppText>
         </ScalePressable>
@@ -46,17 +41,14 @@ export function HomeSurfaceCard({
   children: React.ReactNode;
   style?: StyleProp<ViewStyle>;
 }) {
+  const { C } = useTheme();
   return (
     <View
       style={[
+        styles.surfaceCardContainer,
         {
-          backgroundColor: HOME_COLORS.surface,
-          borderRadius: 24,
-          borderWidth: 1,
-          borderColor: HOME_COLORS.border,
-          padding: 16,
-          marginBottom: 14,
-          ...HOME_SHADOW,
+          backgroundColor: C.surface,
+          borderColor: C.border,
         },
         style,
       ]}
@@ -75,34 +67,29 @@ export function HomeActionTile({
   icon: React.ComponentProps<typeof Ionicons>['name'];
   onPress: () => void;
 }) {
+  const { C } = useTheme();
   return (
     <ScalePressable
       onPress={onPress}
-      style={{
-        width: '48.5%',
-        borderWidth: 1,
-        borderColor: HOME_COLORS.border,
-        borderRadius: 18,
-        paddingVertical: 14,
-        paddingHorizontal: 12,
-        backgroundColor: HOME_COLORS.softSurface,
-        marginBottom: 10,
-      }}
+      style={[
+        styles.actionTileContainer,
+        {
+          borderColor: C.border,
+          backgroundColor: C.surfaceMid,
+        },
+      ]}
     >
       <View
-        style={{
-          width: 34,
-          height: 34,
-          borderRadius: 12,
-          backgroundColor: HOME_COLORS.primarySoft,
-          alignItems: 'center',
-          justifyContent: 'center',
-          marginBottom: 8,
-        }}
+        style={[
+          styles.actionTileIconContainer,
+          {
+            backgroundColor: C.primarySurface,
+          },
+        ]}
       >
-        <Ionicons name={icon} size={18} color={HOME_COLORS.primary} />
+        <Ionicons name={icon} size={18} color={C.primary} />
       </View>
-      <AppText variant="bodySm" style={{ color: HOME_COLORS.text, fontWeight: '700' }}>
+      <AppText variant="bodySm" style={{ color: C.text, fontWeight: '700' }}>
         {label}
       </AppText>
     </ScalePressable>
@@ -116,6 +103,7 @@ export function HomeTaskRow({
   task: Task;
   onToggle: () => void;
 }) {
+  const { C } = useTheme();
   const dueDate = task.due_date ? new Date(task.due_date) : null;
   const dueText =
     dueDate && !isNaN(dueDate.getTime())
@@ -125,37 +113,30 @@ export function HomeTaskRow({
   return (
     <ScalePressable
       onPress={onToggle}
-      style={{
-        flexDirection: 'row',
-        alignItems: 'center',
-        borderRadius: 16,
-        backgroundColor: HOME_COLORS.softSurface,
-        paddingHorizontal: 12,
-        paddingVertical: 11,
-        marginBottom: 8,
-      }}
+      style={[
+        styles.taskRowContainer,
+        {
+          backgroundColor: C.surfaceMid,
+        },
+      ]}
     >
       <View
-        style={{
-          width: 24,
-          height: 24,
-          borderRadius: 12,
-          borderWidth: 2,
-          borderColor: task.completed ? HOME_COLORS.primary : '#8FB7A7',
-          backgroundColor: task.completed ? HOME_COLORS.primary : 'transparent',
-          alignItems: 'center',
-          justifyContent: 'center',
-          marginRight: 10,
-        }}
+        style={[
+          styles.taskRowCheckbox,
+          {
+            borderColor: task.completed ? C.primary : C.border,
+            backgroundColor: task.completed ? C.primary : 'transparent',
+          },
+        ]}
       >
-        {task.completed ? <Ionicons name="checkmark" size={14} color="#FFFFFF" /> : null}
+        {task.completed ? <Ionicons name="checkmark" size={14} color={theme.colors.surface.light} /> : null}
       </View>
       <AppText
         variant="bodySm"
         numberOfLines={1}
         style={{
           flex: 1,
-          color: task.completed ? HOME_COLORS.muted : HOME_COLORS.text,
+          color: task.completed ? C.muted : C.text,
           textDecorationLine: task.completed ? 'line-through' : 'none',
           fontWeight: '600',
         }}
@@ -164,14 +145,14 @@ export function HomeTaskRow({
       </AppText>
       {dueText ? (
         <View
-          style={{
-            borderRadius: 12,
-            backgroundColor: HOME_COLORS.accentSoft,
-            paddingHorizontal: 8,
-            paddingVertical: 4,
-          }}
+          style={[
+            styles.taskRowDueBadge,
+            {
+              backgroundColor: C.primarySurface,
+            },
+          ]}
         >
-          <AppText variant="caption" style={{ color: '#9E5817', fontWeight: '700' }}>
+          <AppText variant="caption" style={{ color: C.danger, fontWeight: '700' }}>
             {dueText}
           </AppText>
         </View>
@@ -189,47 +170,42 @@ export function HomeChatRow({
   onPress: () => void;
   t: (key: string, opts?: Record<string, unknown>) => string;
 }) {
+  const { C } = useTheme();
   return (
     <ScalePressable
       onPress={onPress}
-      style={{
-        flexDirection: 'row',
-        alignItems: 'center',
-        paddingHorizontal: 12,
-        paddingVertical: 12,
-        borderRadius: 16,
-        backgroundColor: HOME_COLORS.softSurface,
-        marginBottom: 8,
-      }}
+      style={[
+        styles.chatRowContainer,
+        {
+          backgroundColor: C.surfaceMid,
+        },
+      ]}
     >
       <View
-        style={{
-          width: 34,
-          height: 34,
-          borderRadius: 11,
-          backgroundColor: HOME_COLORS.primarySoft,
-          alignItems: 'center',
-          justifyContent: 'center',
-          marginRight: 10,
-        }}
+        style={[
+          styles.chatRowIconContainer,
+          {
+            backgroundColor: C.primarySurface,
+          },
+        ]}
       >
-        <AppText variant="bodySm" style={{ color: HOME_COLORS.primary, fontWeight: '800' }}>
+        <AppText variant="bodySm" style={{ color: C.primary, fontWeight: '800' }}>
           {room.name[0]?.toUpperCase() ?? '?'}
         </AppText>
       </View>
-      <View style={{ flex: 1, paddingRight: 8 }}>
-        <AppText variant="bodySm" numberOfLines={1} style={{ color: HOME_COLORS.text, fontWeight: '700' }}>
+      <View style={styles.chatRowTextContainer}>
+        <AppText variant="bodySm" numberOfLines={1} style={{ color: C.text, fontWeight: '700' }}>
           {room.name}
         </AppText>
-        <AppText variant="caption" numberOfLines={1} style={{ color: HOME_COLORS.muted }}>
+        <AppText variant="caption" numberOfLines={1} style={{ color: C.muted }}>
           {t('home.actions.tap_to_continue')}
         </AppText>
       </View>
-      <View style={{ alignItems: 'flex-end' }}>
-        <AppText variant="caption" style={{ color: HOME_COLORS.muted, marginBottom: 2 }}>
+      <View style={styles.chatRowMetaContainer}>
+        <AppText variant="caption" style={{ color: C.muted, marginBottom: 2 }}>
           {relativeTimeFromNow(room.updated_at, t)}
         </AppText>
-        <Ionicons name="chevron-forward" size={14} color={HOME_COLORS.muted} />
+        <Ionicons name="chevron-forward" size={14} color={C.muted} />
       </View>
     </ScalePressable>
   );
@@ -242,42 +218,38 @@ export function HomeAgentBadge({
   agent: Agent;
   onPress: () => void;
 }) {
+  const { C } = useTheme();
   return (
     <ScalePressable
       onPress={onPress}
-      style={{
-        borderRadius: 18,
-        borderWidth: 1,
-        borderColor: HOME_COLORS.border,
-        backgroundColor: HOME_COLORS.surface,
-        padding: 10,
-        width: '48.5%',
-        marginBottom: 10,
-      }}
+      style={[
+        styles.agentBadgeContainer,
+        {
+          borderColor: C.border,
+          backgroundColor: C.surface,
+        },
+      ]}
     >
-      <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 6 }}>
+      <View style={styles.agentBadgeHeaderRow}>
         <View
-          style={{
-            width: 30,
-            height: 30,
-            borderRadius: 10,
-            backgroundColor: HOME_COLORS.primarySoft,
-            alignItems: 'center',
-            justifyContent: 'center',
-            marginRight: 8,
-          }}
+          style={[
+            styles.agentBadgeIconContainer,
+            {
+              backgroundColor: C.primarySurface,
+            },
+          ]}
         >
-          <AppText variant="bodySm" style={{ color: HOME_COLORS.primary, fontWeight: '800' }}>
+          <AppText variant="bodySm" style={{ color: C.primary, fontWeight: '800' }}>
             {agent.name?.[0]?.toUpperCase() ?? '?'}
           </AppText>
         </View>
-        <View style={{ flex: 1 }}>
-          <AppText variant="bodySm" numberOfLines={1} style={{ color: HOME_COLORS.text, fontWeight: '700' }}>
+        <View style={styles.agentBadgeTextWrapper}>
+          <AppText variant="bodySm" numberOfLines={1} style={{ color: C.text, fontWeight: '700' }}>
             {agent.name}
           </AppText>
         </View>
       </View>
-      <AppText variant="caption" style={{ color: HOME_COLORS.muted }}>
+      <AppText variant="caption" style={{ color: C.muted }}>
         {agent.message_count} {agent.message_count === 1 ? 'message' : 'messages'}
       </AppText>
     </ScalePressable>
@@ -303,93 +275,73 @@ export function HomeHeroCard({
   onSettingsPress: () => void;
   t: (key: string, opts?: Record<string, unknown>) => string;
 }) {
+  const { C } = useTheme();
   return (
     <View
-      style={{
-        borderRadius: 28,
-        backgroundColor: HOME_COLORS.deep,
-        paddingHorizontal: 18,
-        paddingVertical: 18,
-        marginBottom: 14,
-        overflow: 'hidden',
-        ...HOME_SHADOW,
-      }}
+      style={[
+        styles.heroCardContainer,
+        {
+          backgroundColor: theme.colors.primary.dark,
+        },
+      ]}
     >
       <View
-        style={{
-          position: 'absolute',
-          width: 180,
-          height: 180,
-          borderRadius: 999,
-          backgroundColor: '#2BA98A',
-          opacity: 0.26,
-          top: -90,
-          right: -40,
-        }}
+        style={[
+          styles.heroCardBgCircle1,
+          {
+            backgroundColor: theme.colors.status.success,
+          },
+        ]}
       />
       <View
-        style={{
-          position: 'absolute',
-          width: 120,
-          height: 120,
-          borderRadius: 999,
-          backgroundColor: '#F0B470',
-          opacity: 0.22,
-          bottom: -44,
-          left: -24,
-        }}
+        style={[
+          styles.heroCardBgCircle2,
+          {
+            backgroundColor: theme.colors.status.warning,
+          },
+        ]}
       />
 
-      <View
-        style={{
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          marginBottom: 16,
-        }}
-      >
-        <View style={{ flex: 1, paddingRight: 8 }}>
-          <AppText variant="bodySm" style={{ color: '#CDE9DF', fontWeight: '600' }}>
+      <View style={styles.heroCardHeaderRow}>
+        <View style={styles.heroCardHeaderTextWrapper}>
+          <AppText variant="bodySm" style={{ color: theme.colors.primary.light, fontWeight: '600' }}>
             {greeting}
           </AppText>
-          <AppText variant="h1" numberOfLines={1} style={{ color: '#FFFFFF', fontWeight: '700' }}>
+          <AppText variant="h1" numberOfLines={1} style={{ color: theme.colors.surface.light, fontWeight: '700' }}>
             {firstName}
           </AppText>
-          <AppText variant="caption" style={{ color: '#CDE9DF' }}>
+          <AppText variant="caption" style={{ color: theme.colors.primary.light }}>
             {dateText}
           </AppText>
         </View>
         <ScalePressable
           onPress={onSettingsPress}
-          style={{
-            width: 44,
-            height: 44,
-            borderRadius: 22,
-            backgroundColor: '#2D6A58',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
+          style={[
+            styles.heroCardSettingsBtn,
+            {
+              backgroundColor: C.primary,
+            },
+          ]}
         >
-          <AppText variant="bodySm" style={{ color: '#FFFFFF', fontWeight: '700' }}>
+          <AppText variant="bodySm" style={{ color: theme.colors.surface.light, fontWeight: '700' }}>
             {initials}
           </AppText>
         </ScalePressable>
       </View>
 
-      <View style={{ flexDirection: 'row', gap: 8 }}>
+      <View style={styles.heroCardStatsRow}>
         <View
-          style={{
-            flex: 1,
-            borderRadius: 14,
-            backgroundColor: '#215445',
-            paddingVertical: 10,
-            paddingHorizontal: 10,
-          }}
+          style={[
+            styles.heroCardStatBox,
+            {
+              backgroundColor: C.primarySurface,
+            },
+          ]}
         >
-          <AppText variant="caption" style={{ color: '#CDE9DF', marginBottom: 2 }}>
+          <AppText variant="caption" style={{ color: theme.colors.primary.light, marginBottom: 2 }}>
             {t('home.hero.today_focus', { defaultValue: 'Today focus' })}
           </AppText>
-          <AppText variant="bodySm" style={{ color: '#FFFFFF', fontWeight: '700' }}>
+          <AppText variant="bodySm" style={{ color: theme.colors.surface.light, fontWeight: '700' }}>
             {todayTaskCount > 0
               ? t('home.hero.tasks_due_today', {
                   count: todayTaskCount,
@@ -399,18 +351,17 @@ export function HomeHeroCard({
           </AppText>
         </View>
         <View
-          style={{
-            flex: 1,
-            borderRadius: 14,
-            backgroundColor: '#215445',
-            paddingVertical: 10,
-            paddingHorizontal: 10,
-          }}
+          style={[
+            styles.heroCardStatBox,
+            {
+              backgroundColor: C.primarySurface,
+            },
+          ]}
         >
-          <AppText variant="caption" style={{ color: '#CDE9DF', marginBottom: 2 }}>
+          <AppText variant="caption" style={{ color: theme.colors.primary.light, marginBottom: 2 }}>
             {t('home.hero.completion', { defaultValue: 'Completion' })}
           </AppText>
-          <AppText variant="bodySm" style={{ color: '#FFFFFF', fontWeight: '700' }}>
+          <AppText variant="bodySm" style={{ color: theme.colors.surface.light, fontWeight: '700' }}>
             {completionRate}% {t('home.hero.complete', { defaultValue: 'complete' })}
           </AppText>
         </View>
@@ -418,3 +369,174 @@ export function HomeHeroCard({
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  sectionHeaderContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: theme.spacing.md,
+  },
+  surfaceCardContainer: {
+    borderRadius: theme.borderRadius.xxl,
+    borderWidth: 1,
+    padding: theme.spacing.lg,
+    marginBottom: theme.spacing.lg,
+    ...Platform.select({
+      ios: theme.elevation.sm,
+      android: {
+        elevation: theme.elevation.sm.elevation,
+        shadowColor: 'transparent',
+        shadowOffset: { width: 0, height: 0 },
+        shadowOpacity: 0,
+        shadowRadius: 0,
+      },
+    }) as any,
+  },
+  actionTileContainer: {
+    width: '48.5%',
+    borderWidth: 1,
+    borderRadius: theme.borderRadius.xl,
+    paddingVertical: theme.spacing.md,
+    paddingHorizontal: theme.spacing.md,
+    marginBottom: theme.spacing.md,
+  },
+  actionTileIconContainer: {
+    width: 34,
+    height: 34,
+    borderRadius: theme.borderRadius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: theme.spacing.sm,
+  },
+  taskRowContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: theme.borderRadius.lg,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.md,
+    marginBottom: theme.spacing.sm,
+  },
+  taskRowCheckbox: {
+    width: theme.spacing.xxl,
+    height: theme.spacing.xxl,
+    borderRadius: theme.borderRadius.md,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: theme.spacing.md,
+  },
+  taskRowDueBadge: {
+    borderRadius: theme.borderRadius.md,
+    paddingHorizontal: theme.spacing.sm,
+    paddingVertical: theme.spacing.xs,
+  },
+  chatRowContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.md,
+    borderRadius: theme.borderRadius.lg,
+    marginBottom: theme.spacing.sm,
+  },
+  chatRowIconContainer: {
+    width: 34,
+    height: 34,
+    borderRadius: theme.borderRadius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: theme.spacing.md,
+  },
+  chatRowTextContainer: {
+    flex: 1,
+    paddingRight: theme.spacing.sm,
+  },
+  chatRowMetaContainer: {
+    alignItems: 'flex-end',
+  },
+  agentBadgeContainer: {
+    borderRadius: theme.borderRadius.xl,
+    borderWidth: 1,
+    padding: theme.spacing.md,
+    width: '48.5%',
+    marginBottom: theme.spacing.md,
+  },
+  agentBadgeHeaderRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: theme.spacing.sm,
+  },
+  agentBadgeIconContainer: {
+    width: 30,
+    height: 30,
+    borderRadius: theme.borderRadius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: theme.spacing.sm,
+  },
+  agentBadgeTextWrapper: {
+    flex: 1,
+  },
+  heroCardContainer: {
+    borderRadius: theme.borderRadius.xxl,
+    paddingHorizontal: theme.spacing.lg,
+    paddingVertical: theme.spacing.lg,
+    marginBottom: theme.spacing.md,
+    overflow: 'hidden',
+    ...Platform.select({
+      ios: theme.elevation.lg,
+      android: {
+        elevation: theme.elevation.lg.elevation,
+        shadowColor: 'transparent',
+        shadowOffset: { width: 0, height: 0 },
+        shadowOpacity: 0,
+        shadowRadius: 0,
+      },
+    }) as any,
+  },
+  heroCardBgCircle1: {
+    position: 'absolute',
+    width: 180,
+    height: 180,
+    borderRadius: theme.borderRadius.full,
+    opacity: 0.26,
+    top: -90,
+    right: -40,
+  },
+  heroCardBgCircle2: {
+    position: 'absolute',
+    width: 120,
+    height: 120,
+    borderRadius: theme.borderRadius.full,
+    opacity: 0.22,
+    bottom: -44,
+    left: -24,
+  },
+  heroCardHeaderRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: theme.spacing.lg,
+  },
+  heroCardHeaderTextWrapper: {
+    flex: 1,
+    paddingRight: theme.spacing.sm,
+  },
+  heroCardSettingsBtn: {
+    width: theme.spacing.inputBarButton,
+    height: theme.spacing.inputBarButton,
+    borderRadius: theme.spacing.inputBarButton / 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  heroCardStatsRow: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+  },
+  heroCardStatBox: {
+    flex: 1,
+    borderRadius: theme.borderRadius.lg,
+    paddingVertical: theme.spacing.md,
+    paddingHorizontal: theme.spacing.md,
+  },
+});

--- a/frontend/src/components/home/HomeDashboardParts.tsx
+++ b/frontend/src/components/home/HomeDashboardParts.tsx
@@ -4,7 +4,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { AppText } from '@/components/AppText';
 import { ScalePressable } from '@/components/ScalePressable';
 import { Agent, ChatRoom, Task } from '@/core/models';
-import { relativeTimeFromNow } from './homeUtils';
+import { relativeTimeFromNow } from '@/components/home/homeUtils';
 import { useTheme } from '@/hooks/useTheme';
 import { theme } from '@/core/theme';
 


### PR DESCRIPTION
Refactored `frontend/src/components/home/HomeDashboardParts.tsx` to align completely with the Miru Design System. Replaced hardcoded hex codes, pixel dimensions, and custom home theme constants with standard `theme` values (e.g., `theme.spacing`, `theme.colors.status`, `useTheme()`). All inline layout configurations were properly extracted into a bottom `StyleSheet.create` with appropriate iOS/Android structural `Platform.select` shadow fallbacks.

---
*PR created automatically by Jules for task [16666219690039166010](https://jules.google.com/task/16666219690039166010) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced visual consistency across the home dashboard by implementing unified theme-based styling. Updated all dashboard components including cards, headers, task rows, chat rows, and badges to use consistent colors, spacing, and styling patterns for a more cohesive interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->