### PR TITLE
refactor(backend): decouple jwt verifier from auth service

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -7,6 +7,7 @@ from typing import Annotated
 from fastapi import Depends
 
 from app.domain.agents.service import AgentService
+from app.domain.auth.interfaces import TokenVerifierProtocol
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
 from app.domain.memory.service import MemoryService
@@ -15,6 +16,7 @@ from app.infrastructure.repositories.agent_repo import AgentRepository
 from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
 from app.infrastructure.repositories.memory_repo import MemoryRepository
+from app.infrastructure.security.jwt_verifier import SupabaseJWTVerifier
 
 # ---------------------------------------------------------------------------
 # Repository factories
@@ -36,6 +38,21 @@ def get_memory_repo() -> MemoryRepository:
 def get_auth_repo(db: SupabaseClient) -> AuthRepository:
     # AuthRepository still uses the Supabase client for passkey tables.
     return AuthRepository(db)
+
+
+# ---------------------------------------------------------------------------
+# Security & Auth singletons
+# ---------------------------------------------------------------------------
+
+_jwt_verifier: SupabaseJWTVerifier | None = None
+
+
+def get_jwt_verifier() -> TokenVerifierProtocol:
+    """Return the singleton JWT verifier."""
+    global _jwt_verifier
+    if _jwt_verifier is None:
+        _jwt_verifier = SupabaseJWTVerifier()
+    return _jwt_verifier
 
 
 # ---------------------------------------------------------------------------
@@ -62,5 +79,8 @@ def get_memory_service(
     return MemoryService(repo)
 
 
-def get_auth_service(repo: Annotated[AuthRepository, Depends(get_auth_repo)]) -> AuthService:
-    return AuthService(repo)
+def get_auth_service(
+    repo: Annotated[AuthRepository, Depends(get_auth_repo)],
+    verifier: Annotated[TokenVerifierProtocol, Depends(get_jwt_verifier)],
+) -> AuthService:
+    return AuthService(repo, verifier)

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -29,12 +29,10 @@ from uuid import UUID
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
+from app.api.dependencies import get_jwt_verifier
 from app.domain.agents.service import AgentService
-from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
-from app.infrastructure.database.supabase import get_supabase
 from app.infrastructure.repositories.agent_repo import AgentRepository
-from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
 from app.infrastructure.repositories.memory_repo import MemoryRepository
 from app.infrastructure.websocket.manager import chat_hub
@@ -50,10 +48,10 @@ logger = logging.getLogger(__name__)
 
 
 async def _verify_token(token: str) -> UUID | None:
-    """Decode a Supabase JWT by delegating to AuthService.decode_jwt."""
+    """Decode a Supabase JWT using the injected TokenVerifierProtocol."""
     try:
-        auth_service = AuthService(AuthRepository(get_supabase()))
-        payload = await auth_service.decode_jwt(token)
+        verifier = get_jwt_verifier()
+        payload = await verifier.verify(token)
         return payload.sub
     except Exception:
         logger.warning("WS auth rejected: invalid token")

--- a/backend/app/domain/auth/interfaces.py
+++ b/backend/app/domain/auth/interfaces.py
@@ -6,6 +6,15 @@ from typing import Protocol
 from uuid import UUID
 
 from app.domain.auth.entities import Passkey, PasskeyCreate
+from app.domain.auth.schemas import JWTPayload
+
+
+class TokenVerifierProtocol(Protocol):
+    """Protocol for JWT Verification."""
+
+    async def verify(self, token: str) -> JWTPayload:
+        """Decode and verify a JWT."""
+        pass
 
 
 class AuthRepositoryProtocol(Protocol):

--- a/backend/app/domain/auth/service.py
+++ b/backend/app/domain/auth/service.py
@@ -6,22 +6,19 @@ import logging
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-import jwt
-
-from app.core.config import get_settings
 from app.domain.auth.entities import Passkey
 from app.domain.auth.schemas import JWTPayload
 
 if TYPE_CHECKING:
-    from app.domain.auth.interfaces import AuthRepositoryProtocol
+    from app.domain.auth.interfaces import AuthRepositoryProtocol, TokenVerifierProtocol
 
 logger = logging.getLogger(__name__)
 
 
 class AuthService:
-    def __init__(self, repo: AuthRepositoryProtocol) -> None:
+    def __init__(self, repo: AuthRepositoryProtocol, verifier: TokenVerifierProtocol) -> None:
         self.repo = repo
-        self._jwks_client: jwt.PyJWKClient | None = None
+        self.verifier = verifier
 
     async def list_passkeys(
         self, user_id: str | UUID, limit: int = 50, cursor: str | None = None
@@ -29,44 +26,9 @@ class AuthService:
         """Fetch a paginated list of passkeys for a user."""
         return await self.repo.get_passkeys_by_user(user_id, limit=limit, cursor=cursor)
 
-    def _get_jwks_client(self) -> jwt.PyJWKClient:
-        if self._jwks_client is None:
-            settings = get_settings()
-            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
-            self._jwks_client = jwt.PyJWKClient(jwks_url)
-        return self._jwks_client
-
     async def decode_jwt(self, token: str) -> JWTPayload:
         """Decode and verify a Supabase JWT."""
-        settings = get_settings()
-        try:
-            try:
-                header = jwt.get_unverified_header(token)
-            except Exception as header_exc:
-                raise jwt.DecodeError("Invalid token format") from header_exc
-
-            alg = header.get("alg")
-
-            if alg == "HS256":
-                payload = jwt.decode(
-                    token,
-                    settings.supabase_jwt_secret,
-                    algorithms=["HS256"],
-                    audience="authenticated",
-                )
-            else:
-                jwks_client = self._get_jwks_client()
-                signing_key = jwks_client.get_signing_key_from_jwt(token)
-                payload = jwt.decode(
-                    token,
-                    signing_key.key,
-                    algorithms=["ES256", "RS256"],
-                    audience="authenticated",
-                )
-            return JWTPayload(**payload)
-        except Exception as exc:
-            logger.warning("JWT validation failed: %s", exc)
-            raise
+        return await self.verifier.verify(token)
 
     # --- WebAuthn / Passkey Logic (Authlib Integration) ---
 

--- a/backend/app/infrastructure/security/jwt_verifier.py
+++ b/backend/app/infrastructure/security/jwt_verifier.py
@@ -1,0 +1,58 @@
+"""JWT Verifier implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import jwt
+
+from app.core.config import get_settings
+from app.domain.auth.schemas import JWTPayload
+
+logger = logging.getLogger(__name__)
+
+
+class SupabaseJWTVerifier:
+    def __init__(self) -> None:
+        self._jwks_client: jwt.PyJWKClient | None = None
+
+    def _get_jwks_client(self) -> jwt.PyJWKClient:
+        if self._jwks_client is None:
+            settings = get_settings()
+            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
+            self._jwks_client = jwt.PyJWKClient(jwks_url)
+        return self._jwks_client
+
+    async def verify(self, token: str) -> JWTPayload:
+        """Decode and verify a Supabase JWT."""
+        settings = get_settings()
+        try:
+            try:
+                header = jwt.get_unverified_header(token)
+            except Exception as header_exc:
+                raise jwt.DecodeError("Invalid token format") from header_exc
+
+            alg = header.get("alg")
+
+            if alg == "HS256":
+                payload = jwt.decode(
+                    token,
+                    settings.supabase_jwt_secret,
+                    algorithms=["HS256"],
+                    audience="authenticated",
+                )
+            else:
+                jwks_client = self._get_jwks_client()
+                # Wrap blocking call in asyncio.to_thread
+                signing_key = await asyncio.to_thread(jwks_client.get_signing_key_from_jwt, token)
+                payload = jwt.decode(
+                    token,
+                    signing_key.key,
+                    algorithms=["ES256", "RS256"],
+                    audience="authenticated",
+                )
+            return JWTPayload(**payload)
+        except Exception as exc:
+            logger.warning("JWT validation failed: %s", exc)
+            raise

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -26,6 +26,7 @@ async def test_decode_valid_jwt() -> None:
 
     token = make_jwt()
     from app.infrastructure.security.jwt_verifier import SupabaseJWTVerifier
+
     verifier = SupabaseJWTVerifier()
     service = AuthService(AuthRepository(MagicMock()), verifier)
     payload = await service.decode_jwt(token)
@@ -42,6 +43,7 @@ async def test_decode_expired_jwt_raises_401() -> None:
 
     token = make_jwt(expired=True)
     from app.infrastructure.security.jwt_verifier import SupabaseJWTVerifier
+
     verifier = SupabaseJWTVerifier()
     service = AuthService(AuthRepository(MagicMock()), verifier)
 
@@ -59,6 +61,7 @@ async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureF
 
     token = "invalid.token.format"
     from app.infrastructure.security.jwt_verifier import SupabaseJWTVerifier
+
     verifier = SupabaseJWTVerifier()
     service = AuthService(AuthRepository(MagicMock()), verifier)
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -25,7 +25,9 @@ async def test_decode_valid_jwt() -> None:
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt()
-    service = AuthService(AuthRepository(MagicMock()))
+    from app.infrastructure.security.jwt_verifier import SupabaseJWTVerifier
+    verifier = SupabaseJWTVerifier()
+    service = AuthService(AuthRepository(MagicMock()), verifier)
     payload = await service.decode_jwt(token)
 
     assert isinstance(payload, JWTPayload)
@@ -39,7 +41,9 @@ async def test_decode_expired_jwt_raises_401() -> None:
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = make_jwt(expired=True)
-    service = AuthService(AuthRepository(MagicMock()))
+    from app.infrastructure.security.jwt_verifier import SupabaseJWTVerifier
+    verifier = SupabaseJWTVerifier()
+    service = AuthService(AuthRepository(MagicMock()), verifier)
 
     with pytest.raises(jwt.ExpiredSignatureError):
         await service.decode_jwt(token)
@@ -54,7 +58,9 @@ async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureF
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
     token = "invalid.token.format"
-    service = AuthService(AuthRepository(MagicMock()))
+    from app.infrastructure.security.jwt_verifier import SupabaseJWTVerifier
+    verifier = SupabaseJWTVerifier()
+    service = AuthService(AuthRepository(MagicMock()), verifier)
 
     with (
         caplog.at_level(logging.WARNING),


### PR DESCRIPTION
This refactor addresses violations of the Layer Contract by decoupling infrastructure logic (PyJWKClient/JWT decoding over HTTP) from the domain/application layer (`AuthService`). The JWT verification is now hidden behind a `TokenVerifierProtocol` and injected into the domain logic. Additionally, this fixes an event loop blocking issue and an implicit PyJWKClient cache churn bug in the WebSocket route.

---
*PR created automatically by Jules for task [5418252592373068585](https://jules.google.com/task/5418252592373068585) started by @YKDBontekoe*