### PR TITLE
Refactor: Move JWT verification to Infrastructure Layer

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -6,10 +6,13 @@ from typing import Annotated
 
 from fastapi import Depends
 
+from app.core.config import get_settings
 from app.domain.agents.service import AgentService
+from app.domain.auth.interfaces import TokenVerifierProtocol
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
 from app.domain.memory.service import MemoryService
+from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
 from app.infrastructure.database.supabase import SupabaseClient
 from app.infrastructure.repositories.agent_repo import AgentRepository
 from app.infrastructure.repositories.auth_repo import AuthRepository
@@ -38,6 +41,18 @@ def get_auth_repo(db: SupabaseClient) -> AuthRepository:
     return AuthRepository(db)
 
 
+_jwt_verifier: TokenVerifierProtocol | None = None
+
+
+def get_jwt_verifier() -> TokenVerifierProtocol:
+    global _jwt_verifier
+    if _jwt_verifier is None:
+        settings = get_settings()
+        jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
+        _jwt_verifier = SupabaseJWTVerifier(jwks_url=jwks_url, secret=settings.supabase_jwt_secret)
+    return _jwt_verifier
+
+
 # ---------------------------------------------------------------------------
 # Service factories
 # ---------------------------------------------------------------------------
@@ -62,5 +77,8 @@ def get_memory_service(
     return MemoryService(repo)
 
 
-def get_auth_service(repo: Annotated[AuthRepository, Depends(get_auth_repo)]) -> AuthService:
-    return AuthService(repo)
+def get_auth_service(
+    repo: Annotated[AuthRepository, Depends(get_auth_repo)],
+    token_verifier: Annotated[TokenVerifierProtocol, Depends(get_jwt_verifier)],
+) -> AuthService:
+    return AuthService(repo, token_verifier)

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -29,6 +29,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
+from app.api.dependencies import get_jwt_verifier
 from app.domain.agents.service import AgentService
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
@@ -52,7 +53,7 @@ logger = logging.getLogger(__name__)
 async def _verify_token(token: str) -> UUID | None:
     """Decode a Supabase JWT by delegating to AuthService.decode_jwt."""
     try:
-        auth_service = AuthService(AuthRepository(get_supabase()))
+        auth_service = AuthService(AuthRepository(get_supabase()), get_jwt_verifier())
         payload = await auth_service.decode_jwt(token)
         return payload.sub
     except Exception:

--- a/backend/app/domain/auth/interfaces.py
+++ b/backend/app/domain/auth/interfaces.py
@@ -6,6 +6,15 @@ from typing import Protocol
 from uuid import UUID
 
 from app.domain.auth.entities import Passkey, PasskeyCreate
+from app.domain.auth.schemas import JWTPayload
+
+
+class TokenVerifierProtocol(Protocol):
+    """Protocol for JWT Verification."""
+
+    async def verify(self, token: str) -> JWTPayload:
+        """Decode and verify a token."""
+        pass
 
 
 class AuthRepositoryProtocol(Protocol):
@@ -15,16 +24,16 @@ class AuthRepositoryProtocol(Protocol):
         self, user_id: str | UUID, limit: int = 50, cursor: str | None = None
     ) -> tuple[list[Passkey], str | None]:
         """Fetch all registered passkeys for a user with pagination."""
-        ...
+        pass
 
     async def update_sign_count(self, passkey_id: str | UUID, new_count: int) -> None:
         """Update the signature count for a passkey."""
-        ...
+        pass
 
     async def create_passkey(self, input: PasskeyCreate) -> Passkey:
         """Insert a new passkey record."""
-        ...
+        pass
 
     async def delete_passkey(self, passkey_id: str | UUID, user_id: str | UUID) -> bool:
         """Delete a passkey belonging to a user."""
-        ...
+        pass

--- a/backend/app/domain/auth/service.py
+++ b/backend/app/domain/auth/service.py
@@ -6,22 +6,19 @@ import logging
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-import jwt
-
-from app.core.config import get_settings
 from app.domain.auth.entities import Passkey
 from app.domain.auth.schemas import JWTPayload
 
 if TYPE_CHECKING:
-    from app.domain.auth.interfaces import AuthRepositoryProtocol
+    from app.domain.auth.interfaces import AuthRepositoryProtocol, TokenVerifierProtocol
 
 logger = logging.getLogger(__name__)
 
 
 class AuthService:
-    def __init__(self, repo: AuthRepositoryProtocol) -> None:
+    def __init__(self, repo: AuthRepositoryProtocol, token_verifier: TokenVerifierProtocol) -> None:
         self.repo = repo
-        self._jwks_client: jwt.PyJWKClient | None = None
+        self.token_verifier = token_verifier
 
     async def list_passkeys(
         self, user_id: str | UUID, limit: int = 50, cursor: str | None = None
@@ -29,44 +26,9 @@ class AuthService:
         """Fetch a paginated list of passkeys for a user."""
         return await self.repo.get_passkeys_by_user(user_id, limit=limit, cursor=cursor)
 
-    def _get_jwks_client(self) -> jwt.PyJWKClient:
-        if self._jwks_client is None:
-            settings = get_settings()
-            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
-            self._jwks_client = jwt.PyJWKClient(jwks_url)
-        return self._jwks_client
-
     async def decode_jwt(self, token: str) -> JWTPayload:
         """Decode and verify a Supabase JWT."""
-        settings = get_settings()
-        try:
-            try:
-                header = jwt.get_unverified_header(token)
-            except Exception as header_exc:
-                raise jwt.DecodeError("Invalid token format") from header_exc
-
-            alg = header.get("alg")
-
-            if alg == "HS256":
-                payload = jwt.decode(
-                    token,
-                    settings.supabase_jwt_secret,
-                    algorithms=["HS256"],
-                    audience="authenticated",
-                )
-            else:
-                jwks_client = self._get_jwks_client()
-                signing_key = jwks_client.get_signing_key_from_jwt(token)
-                payload = jwt.decode(
-                    token,
-                    signing_key.key,
-                    algorithms=["ES256", "RS256"],
-                    audience="authenticated",
-                )
-            return JWTPayload(**payload)
-        except Exception as exc:
-            logger.warning("JWT validation failed: %s", exc)
-            raise
+        return await self.token_verifier.verify(token)
 
     # --- WebAuthn / Passkey Logic (Authlib Integration) ---
 

--- a/backend/app/infrastructure/auth/jwt_verifier.py
+++ b/backend/app/infrastructure/auth/jwt_verifier.py
@@ -1,0 +1,61 @@
+"""Supabase JWT verification implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import jwt
+
+from app.domain.auth.interfaces import TokenVerifierProtocol
+from app.domain.auth.schemas import JWTPayload
+
+logger = logging.getLogger(__name__)
+
+
+class SupabaseJWTVerifier(TokenVerifierProtocol):
+    """Verifies Supabase JWTs."""
+
+    def __init__(self, jwks_url: str, secret: str) -> None:
+        self._jwks_url = jwks_url
+        self._secret = secret
+        self._jwks_client: jwt.PyJWKClient | None = None
+
+    def _get_jwks_client(self) -> jwt.PyJWKClient:
+        if self._jwks_client is None:
+            self._jwks_client = jwt.PyJWKClient(self._jwks_url)
+        return self._jwks_client
+
+    async def verify(self, token: str) -> JWTPayload:
+        """Decode and verify a Supabase JWT."""
+        try:
+            try:
+                header = jwt.get_unverified_header(token)
+            except Exception as header_exc:
+                raise jwt.DecodeError("Invalid token format") from header_exc
+
+            alg = header.get("alg")
+
+            if alg == "HS256":
+                payload = jwt.decode(
+                    token,
+                    self._secret,
+                    algorithms=["HS256"],
+                    audience="authenticated",
+                )
+            else:
+                jwks_client = self._get_jwks_client()
+                # Run the blocking network call in a separate thread
+                signing_key = await asyncio.to_thread(
+                    jwks_client.get_signing_key_from_jwt, token
+                )
+                payload = jwt.decode(
+                    token,
+                    signing_key.key,
+                    algorithms=["ES256", "RS256"],
+                    audience="authenticated",
+                )
+            return JWTPayload(**payload)
+        except Exception as exc:
+            logger.warning("JWT validation failed: %s", exc)
+            raise

--- a/backend/app/infrastructure/auth/jwt_verifier.py
+++ b/backend/app/infrastructure/auth/jwt_verifier.py
@@ -46,9 +46,7 @@ class SupabaseJWTVerifier(TokenVerifierProtocol):
             else:
                 jwks_client = self._get_jwks_client()
                 # Run the blocking network call in a separate thread
-                signing_key = await asyncio.to_thread(
-                    jwks_client.get_signing_key_from_jwt, token
-                )
+                signing_key = await asyncio.to_thread(jwks_client.get_signing_key_from_jwt, token)
                 payload = jwt.decode(
                     token,
                     signing_key.key,

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -21,11 +21,15 @@ from tests.conftest import make_jwt
 @pytest.mark.asyncio
 async def test_decode_valid_jwt() -> None:
     """A valid JWT with a known secret decodes successfully."""
+    from app.core.config import get_settings
     from app.domain.auth.service import AuthService
+    from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
+    settings = get_settings()
     token = make_jwt()
-    service = AuthService(AuthRepository(MagicMock()))
+    verifier = SupabaseJWTVerifier(jwks_url="", secret=settings.supabase_jwt_secret)
+    service = AuthService(AuthRepository(MagicMock()), verifier)
     payload = await service.decode_jwt(token)
 
     assert isinstance(payload, JWTPayload)
@@ -35,11 +39,15 @@ async def test_decode_valid_jwt() -> None:
 @pytest.mark.asyncio
 async def test_decode_expired_jwt_raises_401() -> None:
     """An expired JWT raises an error."""
+    from app.core.config import get_settings
     from app.domain.auth.service import AuthService
+    from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
+    settings = get_settings()
     token = make_jwt(expired=True)
-    service = AuthService(AuthRepository(MagicMock()))
+    verifier = SupabaseJWTVerifier(jwks_url="", secret=settings.supabase_jwt_secret)
+    service = AuthService(AuthRepository(MagicMock()), verifier)
 
     with pytest.raises(jwt.ExpiredSignatureError):
         await service.decode_jwt(token)
@@ -50,11 +58,15 @@ async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureF
     """An invalid JWT format raises a DecodeError and logs a warning instead of an error."""
     import logging
 
+    from app.core.config import get_settings
     from app.domain.auth.service import AuthService
+    from app.infrastructure.auth.jwt_verifier import SupabaseJWTVerifier
     from app.infrastructure.repositories.auth_repo import AuthRepository
 
+    settings = get_settings()
     token = "invalid.token.format"
-    service = AuthService(AuthRepository(MagicMock()))
+    verifier = SupabaseJWTVerifier(jwks_url="", secret=settings.supabase_jwt_secret)
+    service = AuthService(AuthRepository(MagicMock()), verifier)
 
     with (
         caplog.at_level(logging.WARNING),


### PR DESCRIPTION
Extracted JWT validation logic from `AuthService` (Domain layer) into `SupabaseJWTVerifier` (Infrastructure layer) per Clean Architecture Layer Contract. This enforces active decoupling and dependency inversion, removing framework-specific logic (`pyjwt`, HTTP config handling) from the business domain. The singleton instance is now correctly injected via FastAPI dependencies and reused properly in the WebSocket endpoint.

---
*PR created automatically by Jules for task [15213575294080797162](https://jules.google.com/task/15213575294080797162) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated authentication system JWT token verification with support for multiple encryption algorithms (HS256, ES256, RS256).
  * Improved internal authentication service architecture through enhanced dependency injection and code modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->