### PR TITLE
docs(agents): update CodeRabbit scope to reflect ai-approved label logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ The following AI agents actively monitor and modify the Miru codebase. Their act
 **Trigger Conditions:**
 - Automatically invoked when the "PR Checks and Linting" CI workflow completes successfully on a PR branch.
 - Retries automatically every 30 minutes via a queue processor if rate-limited (label `coderabbit:queued`).
-**Scope:** Reviews all modified files in a PR. Posts actionable comments. When 0 actionable comments are found, it triggers the `ai-approved` label.
+**Scope:** Reviews all modified files in a PR. Posts actionable comments. When 0 actionable comments are found, it triggers the `ai-approved` label without adding `ready-to-merge`, as human approval is still required.
 
 ## Project Structure
 


### PR DESCRIPTION
- Updated `AGENTS.md` CodeRabbit documentation to match `.github/workflows/ai-agents.yml` behavior.
- Clarified that `ai-approved` label does not add `ready-to-merge` since human review is still needed.
- Ran backend and frontend tests to ensure no regressions.

---
*PR created automatically by Jules for task [2035143472855741045](https://jules.google.com/task/2035143472855741045) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Clarified the workflow behavior when pull requests have no actionable review comments, specifying which labels are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->