### PR TITLE
refactor: Enforce structured AI responses by removing unstructured `chat_completion`

### DIFF
--- a/backend/app/infrastructure/external/openrouter.py
+++ b/backend/app/infrastructure/external/openrouter.py
@@ -21,12 +21,6 @@ if TYPE_CHECKING:
 T = TypeVar("T", bound=BaseModel)
 
 
-class ChatResponse(BaseModel):
-    """Fallback generic Pydantic schema for non-structured chat outputs."""
-
-    message: str
-
-
 class OpenRouterClient:
     def __init__(self, api_key: str):
         # We defer imports to bypass Python 3.13 circular import bugs at startup
@@ -45,11 +39,6 @@ class OpenRouterClient:
             self.openai_client,
             mode=instructor.Mode.OPENROUTER_STRUCTURED_OUTPUTS,
         )
-
-    async def chat_completion(self, messages: list[ChatCompletionMessageParam], model: str) -> str:
-        # Internally enforce strict JSON structured output even for generic strings
-        structured_resp = await self.structured_completion(messages, model, ChatResponse)
-        return structured_resp.message
 
     @retry(
         stop=stop_after_attempt(3),
@@ -129,28 +118,6 @@ def get_openrouter_client() -> OpenRouterClient:
     if _client is None:
         _client = OpenRouterClient(get_settings().openrouter_api_key)
     return _client
-
-
-async def chat_completion(
-    messages: list[ChatCompletionMessageParam], model: str | None = None
-) -> str:
-    client = get_openrouter_client()
-    chosen_model = model or get_settings().default_chat_model
-    try:
-        return await client.chat_completion(messages, chosen_model)
-    except Exception as e:
-        if isinstance(e, asyncio.CancelledError):
-            raise
-        fallback = get_settings().fallback_chat_model
-        if fallback and fallback != chosen_model:
-            logger.warning(
-                "chat_completion failed with model %s, falling back to %s", chosen_model, fallback
-            )
-            try:
-                return await client.chat_completion(messages, fallback)
-            except Exception as fallback_e:
-                raise fallback_e from e
-        raise
 
 
 async def stream_chat(

--- a/backend/tests/test_infrastructure.py
+++ b/backend/tests/test_infrastructure.py
@@ -13,38 +13,6 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_chat_completion_uses_default_model() -> None:
-    mock_client = AsyncMock()
-    mock_client.chat_completion = AsyncMock(return_value="Hello!")
-    with (
-        patch("app.infrastructure.external.openrouter._client", mock_client),
-        patch(
-            "app.infrastructure.external.openrouter.get_settings",
-            return_value=MagicMock(default_chat_model="test-model", openrouter_api_key="k"),
-        ),
-    ):
-        from app.infrastructure.external.openrouter import chat_completion
-
-        result = await chat_completion([{"role": "user", "content": "Hi"}])
-    assert result == "Hello!"
-    mock_client.chat_completion.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_chat_completion_uses_explicit_model() -> None:
-    mock_client = AsyncMock()
-    mock_client.chat_completion = AsyncMock(return_value="World!")
-    with patch("app.infrastructure.external.openrouter._client", mock_client):
-        from app.infrastructure.external.openrouter import chat_completion
-
-        result = await chat_completion([{"role": "user", "content": "Hi"}], model="custom/model")
-    assert result == "World!"
-    mock_client.chat_completion.assert_awaited_once_with(
-        [{"role": "user", "content": "Hi"}], "custom/model"
-    )
-
-
-@pytest.mark.asyncio
 async def test_embed_delegates_to_client() -> None:
     mock_client = AsyncMock()
     mock_client.embed = AsyncMock(return_value=[0.1, 0.2, 0.3])
@@ -87,22 +55,6 @@ async def test_structured_completion_delegates_to_client() -> None:
 # ---------------------------------------------------------------------------
 # OpenRouterClient methods
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_client_chat_completion_delegates_to_structured() -> None:
-    from app.infrastructure.external.openrouter import ChatResponse, OpenRouterClient
-
-    client = OpenRouterClient.__new__(OpenRouterClient)
-    client.structured_completion = AsyncMock(  # type: ignore[method-assign]
-        return_value=ChatResponse(message="hello from structured")
-    )
-
-    result = await client.chat_completion([{"role": "user", "content": "Hi"}], "model")
-    assert result == "hello from structured"
-    client.structured_completion.assert_called_once_with(
-        [{"role": "user", "content": "Hi"}], "model", ChatResponse
-    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_openrouter.py
+++ b/backend/tests/test_openrouter.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel
 
 from app.infrastructure.external.openrouter import (
     OpenRouterClient,
-    chat_completion,
     embed,
     get_openrouter_client,
     structured_completion,
@@ -79,25 +78,6 @@ async def test_embed_success() -> None:
         assert result == [0.1, 0.2]
 
 
-@pytest.mark.asyncio
-async def test_chat_completion_success() -> None:
-    with (
-        patch("openai.AsyncOpenAI"),
-        patch("instructor.from_openai"),
-    ):
-        client = OpenRouterClient("test-key")
-
-        from app.infrastructure.external.openrouter import ChatResponse
-
-        mock_response = ChatResponse(message="hello")
-        cast("Any", client.instructor_client.chat.completions).create = AsyncMock(
-            return_value=mock_response
-        )
-
-        result = await client.chat_completion([{"role": "user", "content": "hi"}], "test-model")
-        assert result == "hello"
-
-
 class DummyModel(BaseModel):
     name: str
 
@@ -135,92 +115,6 @@ async def test_standalone_embed() -> None:
         result = await embed("test text")
         assert result == [0.1, 0.2]
         mock_client.embed.assert_called_once_with("test text", "test-embed-model")
-
-
-@pytest.mark.asyncio
-async def test_standalone_chat_completion_success() -> None:
-    with (
-        patch("app.infrastructure.external.openrouter.get_openrouter_client") as mock_get_client,
-        patch("app.infrastructure.external.openrouter.get_settings") as mock_settings,
-    ):
-        mock_settings.return_value = MagicMock(default_chat_model="default-model")
-        mock_client = MagicMock()
-        mock_client.chat_completion = AsyncMock(return_value="hello")
-        mock_get_client.return_value = mock_client
-
-        result = await chat_completion([{"role": "user", "content": "hi"}])
-        assert result == "hello"
-        mock_client.chat_completion.assert_called_once_with(
-            [{"role": "user", "content": "hi"}], "default-model"
-        )
-
-
-@pytest.mark.asyncio
-async def test_standalone_chat_completion_fallback() -> None:
-    with (
-        patch("app.infrastructure.external.openrouter.get_openrouter_client") as mock_get_client,
-        patch("app.infrastructure.external.openrouter.get_settings") as mock_settings,
-    ):
-        mock_settings.return_value = MagicMock(
-            default_chat_model="default-model", fallback_chat_model="fallback-model"
-        )
-        mock_client = MagicMock()
-
-        # First call fails, second call succeeds
-        mock_client.chat_completion = AsyncMock(
-            side_effect=[Exception("First error"), "fallback-hello"]
-        )
-        mock_get_client.return_value = mock_client
-
-        result = await chat_completion([{"role": "user", "content": "hi"}])
-        assert result == "fallback-hello"
-        assert mock_client.chat_completion.call_count == 2
-
-        # Check that it called with fallback model
-        mock_client.chat_completion.assert_called_with(
-            [{"role": "user", "content": "hi"}], "fallback-model"
-        )
-
-
-@pytest.mark.asyncio
-async def test_standalone_chat_completion_fallback_fails() -> None:
-    with (
-        patch("app.infrastructure.external.openrouter.get_openrouter_client") as mock_get_client,
-        patch("app.infrastructure.external.openrouter.get_settings") as mock_settings,
-    ):
-        mock_settings.return_value = MagicMock(
-            default_chat_model="default-model", fallback_chat_model="fallback-model"
-        )
-        mock_client = MagicMock()
-
-        # Both calls fail
-        mock_client.chat_completion = AsyncMock(
-            side_effect=[Exception("First error"), Exception("Fallback error")]
-        )
-        mock_get_client.return_value = mock_client
-
-        with pytest.raises(Exception, match="Fallback error"):
-            await chat_completion([{"role": "user", "content": "hi"}])
-
-
-@pytest.mark.asyncio
-async def test_standalone_chat_completion_cancelled() -> None:
-    with (
-        patch("app.infrastructure.external.openrouter.get_openrouter_client") as mock_get_client,
-        patch("app.infrastructure.external.openrouter.get_settings") as mock_settings,
-    ):
-        mock_settings.return_value = MagicMock(
-            default_chat_model="default-model", fallback_chat_model="fallback-model"
-        )
-        mock_client = MagicMock()
-
-        mock_client.chat_completion = AsyncMock(side_effect=asyncio.CancelledError())
-        mock_get_client.return_value = mock_client
-
-        with pytest.raises(asyncio.CancelledError):
-            await chat_completion([{"role": "user", "content": "hi"}])
-
-        assert mock_client.chat_completion.call_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR removes the unstructured `chat_completion` method and its generic `ChatResponse` schema from the backend's OpenRouter client logic. 

As part of the LLM contract established by the AI Integration Engineer persona, all API responses must adhere to strict structured outputs utilizing Pydantic or Zod schemas to ensure reliability, avoiding string extraction/regex parsing.

Changes:
- Deleted the generic `ChatResponse` model from `backend/app/infrastructure/external/openrouter.py`.
- Removed `chat_completion` method from `OpenRouterClient` class.
- Removed the module-level standalone `chat_completion` function in `openrouter.py`.
- Cleaned up corresponding test cases in `backend/tests/test_openrouter.py` and `backend/tests/test_infrastructure.py`.

---
*PR created automatically by Jules for task [17222852169416563345](https://jules.google.com/task/17222852169416563345) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed support for unstructured chat completions. Users must migrate to the structured completion API for chat requests.
  * Consolidated chat completion functionality to use structured output patterns exclusively.
  * Updated corresponding test coverage to reflect API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->