### PR TITLE
Security: Prevent 500 error in update_event with get_or_none

### DIFF
--- a/backend/app/infrastructure/repositories/productivity_repo.py
+++ b/backend/app/infrastructure/repositories/productivity_repo.py
@@ -241,11 +241,13 @@ class ProductivityRepository(IProductivityRepository):
 
     async def update_event(
         self, user_id: UUID, event_id: UUID, valid_keys: dict
-    ) -> CalendarEventEntity:
+    ) -> CalendarEventEntity | None:
         async with handle_db_errors("update calendar event"):
-            event = await CalendarEvent.get(id=event_id, user_id=user_id).prefetch_related(
+            event = await CalendarEvent.get_or_none(id=event_id, user_id=user_id).prefetch_related(
                 "agent", "origin_message"
             )
+            if not event:
+                return None
             for field, value in valid_keys.items():
                 setattr(event, field, value)
             await event.save(update_fields=list(valid_keys.keys()))

--- a/backend/tests/productivity/test_events.py
+++ b/backend/tests/productivity/test_events.py
@@ -109,6 +109,32 @@ async def test_update_event(async_client, mock_user_id, override_get_current_use
 
 
 @pytest.mark.asyncio
+async def test_update_event_internal_none(
+    async_client, mock_user_id, override_get_current_user, monkeypatch
+):
+    """Test that if the repository unexpectedly returns None on update, the use case handles it."""
+    from datetime import UTC, datetime, timedelta
+
+    now = datetime.now(UTC)
+    event = await CalendarEvent.create(
+        user_id=mock_user_id, title="Event 1", start_time=now, end_time=now + timedelta(hours=1)
+    )
+
+    # Mock the repo to return None for update_event
+    from app.infrastructure.repositories.productivity_repo import ProductivityRepository
+
+    async def mock_update_event(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(ProductivityRepository, "update_event", mock_update_event)
+
+    response = await async_client.patch(
+        f"/api/v1/productivity/events/{event.id}", json={"title": "Updated Event"}
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_delete_event(async_client, mock_user_id, override_get_current_user):
     from datetime import UTC, datetime, timedelta
 


### PR DESCRIPTION
Addresses a potential data leakage / 500 error bug when attempting to update calendar events that do not exist or are not owned by the user.

---
*PR created automatically by Jules for task [4230929990968051366](https://jules.google.com/task/4230929990968051366) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar event update handling: The system now gracefully manages scenarios where a calendar event is no longer available, resulting in more stable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->