### PR TITLE
fix(productivity): use get_or_none for update_event to prevent unhandled 500s

### DIFF
--- a/backend/app/infrastructure/repositories/productivity_repo.py
+++ b/backend/app/infrastructure/repositories/productivity_repo.py
@@ -241,11 +241,13 @@ class ProductivityRepository(IProductivityRepository):
 
     async def update_event(
         self, user_id: UUID, event_id: UUID, valid_keys: dict
-    ) -> CalendarEventEntity:
+    ) -> CalendarEventEntity | None:
         async with handle_db_errors("update calendar event"):
-            event = await CalendarEvent.get(id=event_id, user_id=user_id).prefetch_related(
+            event = await CalendarEvent.get_or_none(id=event_id, user_id=user_id).prefetch_related(
                 "agent", "origin_message"
             )
+            if not event:
+                return None
             for field, value in valid_keys.items():
                 setattr(event, field, value)
             await event.save(update_fields=list(valid_keys.keys()))

--- a/backend/tests/productivity/test_use_cases_manage.py
+++ b/backend/tests/productivity/test_use_cases_manage.py
@@ -1,11 +1,24 @@
-import pytest
 import uuid
-from unittest.mock import AsyncMock, MagicMock
-from app.domain.productivity.use_cases.manage_productivity import ManageProductivityUseCase, TaskNotFoundError, NoteNotFoundError, CalendarEventNotFoundError, InvalidTimeRangeError
-from app.domain.productivity.schemas import TaskUpdate, NoteUpdate, CalendarEventUpdate
-from app.domain.productivity.interfaces.repository import IProductivityRepository
-from app.domain.productivity.schemas import CalendarEventCreate
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.domain.productivity.interfaces.repository import IProductivityRepository
+from app.domain.productivity.schemas import (
+    CalendarEventCreate,
+    CalendarEventUpdate,
+    NoteUpdate,
+    TaskUpdate,
+)
+from app.domain.productivity.use_cases.manage_productivity import (
+    CalendarEventNotFoundError,
+    InvalidTimeRangeError,
+    ManageProductivityUseCase,
+    NoteNotFoundError,
+    TaskNotFoundError,
+)
+
 
 @pytest.fixture
 def mock_repo():
@@ -33,6 +46,7 @@ def mock_repo():
 
     return repo
 
+
 @pytest.mark.asyncio
 async def test_manage_productivity_not_found_on_update(mock_repo):
     use_case = ManageProductivityUseCase(mock_repo)
@@ -47,6 +61,17 @@ async def test_manage_productivity_not_found_on_update(mock_repo):
     with pytest.raises(CalendarEventNotFoundError):
         await use_case.update_event(user_id, uuid.uuid4(), CalendarEventUpdate(title="New"))
 
+    # Test update with no valid fields returns the original entity
+    task_res = await use_case.update_task(user_id, uuid.uuid4(), TaskUpdate())
+    assert task_res == mock_repo.get_task.return_value
+
+    note_res = await use_case.update_note(user_id, uuid.uuid4(), NoteUpdate())
+    assert note_res == mock_repo.get_note.return_value
+
+    event_res = await use_case.update_event(user_id, uuid.uuid4(), CalendarEventUpdate())
+    assert event_res == mock_repo.get_event.return_value
+
+
 @pytest.mark.asyncio
 async def test_create_event_invalid_time(mock_repo):
     use_case = ManageProductivityUseCase(mock_repo)
@@ -57,3 +82,20 @@ async def test_create_event_invalid_time(mock_repo):
     event_data.end_time = now - timedelta(hours=1)
     with pytest.raises(InvalidTimeRangeError):
         await use_case.create_event(user_id, event_data)
+
+
+@pytest.mark.asyncio
+async def test_update_event_invalid_time(mock_repo):
+    use_case = ManageProductivityUseCase(mock_repo)
+    user_id = uuid.uuid4()
+    now = datetime.now(UTC)
+
+    mock_event = MagicMock()
+    mock_event.start_time = now
+    mock_event.end_time = now + timedelta(hours=1)
+    mock_repo.get_event = AsyncMock(return_value=mock_event)
+
+    with pytest.raises(InvalidTimeRangeError):
+        await use_case.update_event(
+            user_id, uuid.uuid4(), CalendarEventUpdate(end_time=now - timedelta(hours=1))
+        )

--- a/backend/tests/productivity/test_use_cases_manage.py
+++ b/backend/tests/productivity/test_use_cases_manage.py
@@ -1,0 +1,59 @@
+import pytest
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+from app.domain.productivity.use_cases.manage_productivity import ManageProductivityUseCase, TaskNotFoundError, NoteNotFoundError, CalendarEventNotFoundError, InvalidTimeRangeError
+from app.domain.productivity.schemas import TaskUpdate, NoteUpdate, CalendarEventUpdate
+from app.domain.productivity.interfaces.repository import IProductivityRepository
+from app.domain.productivity.schemas import CalendarEventCreate
+from datetime import UTC, datetime, timedelta
+
+@pytest.fixture
+def mock_repo():
+    repo = MagicMock(spec=IProductivityRepository)
+    repo.update_task = AsyncMock(return_value=None)
+    repo.update_note = AsyncMock(return_value=None)
+    repo.update_event = AsyncMock(return_value=None)
+
+    mock_task = MagicMock()
+    mock_task.title = "Task"
+    mock_task.is_completed = False
+    repo.get_task = AsyncMock(return_value=mock_task)
+
+    mock_note = MagicMock()
+    mock_note.title = "Note"
+    mock_note.content = "Content"
+    mock_note.is_pinned = False
+    repo.get_note = AsyncMock(return_value=mock_note)
+
+    now = datetime.now(UTC)
+    mock_event = MagicMock()
+    mock_event.start_time = now
+    mock_event.end_time = now + timedelta(hours=1)
+    repo.get_event = AsyncMock(return_value=mock_event)
+
+    return repo
+
+@pytest.mark.asyncio
+async def test_manage_productivity_not_found_on_update(mock_repo):
+    use_case = ManageProductivityUseCase(mock_repo)
+    user_id = uuid.uuid4()
+
+    with pytest.raises(TaskNotFoundError):
+        await use_case.update_task(user_id, uuid.uuid4(), TaskUpdate(title="New"))
+
+    with pytest.raises(NoteNotFoundError):
+        await use_case.update_note(user_id, uuid.uuid4(), NoteUpdate(title="New"))
+
+    with pytest.raises(CalendarEventNotFoundError):
+        await use_case.update_event(user_id, uuid.uuid4(), CalendarEventUpdate(title="New"))
+
+@pytest.mark.asyncio
+async def test_create_event_invalid_time(mock_repo):
+    use_case = ManageProductivityUseCase(mock_repo)
+    user_id = uuid.uuid4()
+    now = datetime.now(UTC)
+    event_data = MagicMock(spec=CalendarEventCreate)
+    event_data.start_time = now
+    event_data.end_time = now - timedelta(hours=1)
+    with pytest.raises(InvalidTimeRangeError):
+        await use_case.create_event(user_id, event_data)


### PR DESCRIPTION
Replaced `.get()` with `.get_or_none()` in `ProductivityRepository.update_event` to gracefully handle cases where a calendar event does not exist or does not belong to the user. This prevents Tortoise ORM `DoesNotExist` exceptions from bubbling up as unhandled 500 Internal Server Errors, allowing the upstream use case to correctly raise a `CalendarEventNotFoundError` and return a 404 response.

The `user_id` parameter is retained in the query to maintain strict ownership checks (AuthZ/IDOR prevention). Return type hints were updated accordingly.

---
*PR created automatically by Jules for task [3027405527452425887](https://jules.google.com/task/3027405527452425887) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved event retrieval robustness in the calendar system to handle missing events gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->