### PR TITLE
feat: strict JSON schemas for all AI responses

### DIFF
--- a/backend/app/domain/chat/background_service.py
+++ b/backend/app/domain/chat/background_service.py
@@ -67,11 +67,10 @@ class ChatBackgroundService:
         room_id: UUID,
         user_message: str,
         responded_agents: list[Agent],
-        result_text: str,
+        result: Any,
         agent_names: list[str],
     ) -> None:
         """Embed and store the conversation turn as memories for future retrieval."""
-        from app.domain.chat.websocket_broadcaster import ChatWebSocketBroadcaster
         from app.domain.memory.models import Memory
         from app.infrastructure.external.openrouter import embed
 
@@ -91,8 +90,9 @@ class ChatBackgroundService:
 
             # Store each agent response segment individually
             agent_by_name = {a.name.lower(): a for a in responded_agents}
-            segments = ChatWebSocketBroadcaster.parse_transcript(result_text, agent_names)
-            for agent_name, content in segments:
+            for agent_msg in result.messages:
+                agent_name = agent_msg.agent_name
+                content = agent_msg.content
                 matched = (
                     agent_by_name.get(agent_name.lower())
                     if agent_name

--- a/backend/app/domain/chat/crew_orchestrator.py
+++ b/backend/app/domain/chat/crew_orchestrator.py
@@ -21,6 +21,7 @@ from app.domain.agent_tools.productivity_tools import (
     UpdateEventTool,
     UpdateTaskTool,
 )
+from app.domain.chat.dtos import RoomChatResponse
 from app.domain.chat.language import resolve_language
 from app.domain.chat.prompts import (
     HISTORY_PREFIX,
@@ -197,7 +198,7 @@ class CrewOrchestrator:
         conversation_history: list[dict] | None = None,
         memory_context: str | None = None,
         room_summary: str | None = None,
-    ) -> str:
+    ) -> RoomChatResponse:
         """Build and execute the CrewAI task.
 
         ``conversation_history`` is a list of ``{"role": "user"|"agent", "name": str,
@@ -248,6 +249,7 @@ class CrewOrchestrator:
                     locale_instruction=locale_instruction,
                 ),
                 expected_output=MULTI_AGENT_EXPECTED_OUTPUT,
+                output_pydantic=RoomChatResponse,
             )
             crew = Crew(
                 agents=cast("Any", crew_agents),
@@ -266,6 +268,7 @@ class CrewOrchestrator:
                     locale_instruction=locale_instruction,
                 ),
                 expected_output=SINGLE_AGENT_EXPECTED_OUTPUT,
+                output_pydantic=RoomChatResponse,
                 agent=crew_agents[0],
             )
             crew = Crew(
@@ -289,4 +292,7 @@ class CrewOrchestrator:
                 logger.warning("Crew kickoff failed on attempt 1, retrying in 2 s…")
                 await asyncio.sleep(2)
 
-        return str(result)
+        if not result or not result.pydantic:
+            raise ValueError("Failed to obtain structured response from CrewAI task")
+
+        return result.pydantic

--- a/backend/app/domain/chat/crew_orchestrator.py
+++ b/backend/app/domain/chat/crew_orchestrator.py
@@ -279,7 +279,7 @@ class CrewOrchestrator:
             )
 
         # Retry once on transient failures (e.g. output-parsing errors from the LLM).
-        result = None
+        result: Any = None
         for attempt in (0, 1):
             try:
                 result = await crew.kickoff_async()

--- a/backend/app/domain/chat/dtos.py
+++ b/backend/app/domain/chat/dtos.py
@@ -53,6 +53,17 @@ class ChatMessageResponse(BaseModel):
     created_at: datetime
 
 
+class AgentMessage(BaseModel):
+    agent_name: str = Field(..., description="The name of the agent responding")
+    content: str = Field(..., description="The content of the agent's response")
+
+
+class RoomChatResponse(BaseModel):
+    messages: list[AgentMessage] = Field(
+        ..., description="The ordered list of messages sent by agents in response to the user"
+    )
+
+
 class ChatRequest(BaseModel):
     message: str | None = None
     content: str | None = None

--- a/backend/app/domain/chat/prompts.py
+++ b/backend/app/domain/chat/prompts.py
@@ -31,8 +31,7 @@ MULTI_AGENT_PROMPT = (
     "(tasks/notes/events) and propose a concrete plan. "
     "Before creating, updating, or deleting tasks/notes/events, confirm intent briefly unless "
     "the user explicitly asked you to perform the action now. "
-    "Return a transcript of only the agents who actually responded, "
-    "formatted as 'AgentName: message' with one blank line between agents.{locale_instruction}"
+    "Return a structured list of messages containing only the agents who actually responded.{locale_instruction}"
 )
 
 SINGLE_AGENT_PROMPT = (
@@ -47,9 +46,8 @@ SINGLE_AGENT_PROMPT = (
 )
 
 MULTI_AGENT_EXPECTED_OUTPUT = (
-    "A chat transcript with only the relevant agents responding. "
-    "Format: 'AgentName: message' with one blank line between agents. "
+    "A structured response containing only the relevant agents responding. "
     "Agents should be concise and natural, not self-promotional."
 )
 
-SINGLE_AGENT_EXPECTED_OUTPUT = "A direct, helpful response to the user's message."
+SINGLE_AGENT_EXPECTED_OUTPUT = "A direct, helpful structured response to the user's message."

--- a/backend/app/domain/chat/service.py
+++ b/backend/app/domain/chat/service.py
@@ -266,7 +266,9 @@ class ChatService:
             accept_language=accept_language,
         )
 
-        return {"task_type": "general", "result": result}
+        result_text = "\n".join(f"{m.agent_name}: {m.content}" for m in result.messages)
+
+        return {"task_type": "general", "result": result_text}
 
     @staticmethod
     def _build_history(
@@ -358,7 +360,7 @@ class ChatService:
             room = await self.chat_repo.get_room(room_id)
             room_summary = room.summary if room else None
 
-            result_text = await CrewOrchestrator.execute_crew_task(
+            result = await CrewOrchestrator.execute_crew_task(
                 room_agents=room_agents,
                 user_message=user_message,
                 user_id=user_id,
@@ -372,7 +374,7 @@ class ChatService:
 
             # 6. Persist + broadcast — returns only the agents that actually responded.
             responded_agents = await self.ws_broadcaster.persist_and_broadcast_agent_response(
-                room_id, room_agents, result_text, agent_names
+                room_id, room_agents, result, agent_names
             )
 
             await chat_hub.broadcast_to_room(
@@ -390,6 +392,7 @@ class ChatService:
 
             # 7. Fire background tasks: mood update, affinity, and memory storage.
             history_text = CrewOrchestrator.format_history(conversation_history)
+            result_text = "\n".join(f"{m.agent_name}: {m.content}" for m in result.messages)
             recent_context = f"{history_text}\nUser: {user_message}\n{result_text}".strip()
 
             for agent in responded_agents:
@@ -402,7 +405,7 @@ class ChatService:
 
             asyncio.create_task(  # noqa: RUF006
                 self.bg_service.store_memories_background(
-                    user_id, room_id, user_message, responded_agents, result_text, agent_names
+                    user_id, room_id, user_message, responded_agents, result, agent_names
                 )
             )
 

--- a/backend/app/domain/chat/websocket_broadcaster.py
+++ b/backend/app/domain/chat/websocket_broadcaster.py
@@ -134,58 +134,17 @@ class ChatWebSocketBroadcaster:
 
         return _step_callback
 
-    @staticmethod
-    def parse_transcript(result_text: str, agent_names: list[str]) -> list[tuple[str, str]]:
-        """Parse a multi-agent transcript into (agent_name, message) pairs.
-
-        Expected format: 'AgentName: message\\n\\nOtherAgent: message'
-        Falls back to a single unnamed entry when the format cannot be parsed.
-        """
-        if not agent_names or len(agent_names) == 1:
-            return [("", result_text.strip())]
-
-        # Build a set of known names (case-insensitive) for matching
-        name_set = {n.lower() for n in agent_names}
-        segments: list[tuple[str, str]] = []
-        current_name = ""
-        current_lines: list[str] = []
-
-        for line in result_text.splitlines():
-            # Detect "AgentName: ..." prefix
-            colon_pos = line.find(":")
-            if colon_pos > 0:
-                candidate = line[:colon_pos].strip()
-                if candidate.lower() in name_set:
-                    # Save previous segment
-                    if current_lines or current_name:
-                        segments.append((current_name, "\n".join(current_lines).strip()))
-                    current_name = candidate
-                    current_lines = [line[colon_pos + 1 :].strip()]
-                    continue
-            current_lines.append(line)
-
-        if current_lines or current_name:
-            segments.append((current_name, "\n".join(current_lines).strip()))
-
-        # Drop empty segments
-        segments = [(n, m) for n, m in segments if m]
-        return (
-            segments
-            if segments
-            else ([] if not result_text.strip() else [("", result_text.strip())])
-        )
-
     async def persist_and_broadcast_agent_response(
         self,
         room_id: UUID,
         room_agents: list[Agent],
-        result_text: str,
+        result: Any,
         agent_names: list[str],
     ) -> list[Agent]:
         """Save the agent response(s) and broadcast to room.
 
-        For multi-agent rooms the transcript is split into individual per-agent
-        messages so each agent's reply appears in its own bubble.
+        For multi-agent rooms the response is a structured object containing
+        individual per-agent messages so each agent's reply appears in its own bubble.
 
         Returns the list of agents who actually produced a response segment so
         that the caller can run per-agent post-processing (mood, affinity, etc.).
@@ -195,12 +154,14 @@ class ChatWebSocketBroadcaster:
         from app.infrastructure.websocket.manager import chat_hub  # noqa: PLC0415
 
         agent_by_name = {a.name.lower(): a for a in room_agents}
-        segments = self.parse_transcript(result_text, agent_names)
 
         responded: list[Agent] = []
 
         # Persist and broadcast each segment as a separate message
-        for agent_name, content in segments:
+        for agent_msg in result.messages:
+            agent_name = agent_msg.agent_name
+            content = agent_msg.content
+
             matched_agent = agent_by_name.get(agent_name.lower())
             # Single-agent fallback: attribute the message to the only agent in the room.
             effective_agent = matched_agent or (room_agents[0] if len(room_agents) == 1 else None)

--- a/backend/tests/chat/test_chat_crew.py
+++ b/backend/tests/chat/test_chat_crew.py
@@ -75,7 +75,15 @@ async def test_run_crew_task_has_single_agent(
         mock_crew_agent.role = "Test Agent"
         mock_agent_cls.return_value = mock_crew_agent
         mock_crew_instance = MagicMock()
-        mock_crew_instance.kickoff_async = AsyncMock(return_value="Crew output")
+
+        from app.domain.chat.dtos import AgentMessage, RoomChatResponse
+
+        mock_output = MagicMock()
+        mock_output.pydantic = RoomChatResponse(
+            messages=[AgentMessage(agent_name="Test Agent", content="Crew output")]
+        )
+
+        mock_crew_instance.kickoff_async = AsyncMock(return_value=mock_output)
         mock_crew_cls.return_value = mock_crew_instance
         result = await chat_service.run_crew("hello", user_id, accept_language="es-ES")
         assert result["task_type"] == "general"
@@ -117,7 +125,15 @@ async def test_run_crew_task_has_multiple_agents(
         mock_crew_agent2.role = "Agent 2"
         mock_agent_cls.side_effect = [mock_crew_agent1, mock_crew_agent2]
         mock_crew_instance = MagicMock()
-        mock_crew_instance.kickoff_async = AsyncMock(return_value="Crew output")
+
+        from app.domain.chat.dtos import AgentMessage, RoomChatResponse
+
+        mock_output = MagicMock()
+        mock_output.pydantic = RoomChatResponse(
+            messages=[AgentMessage(agent_name="Agent 1", content="Crew output")]
+        )
+
+        mock_crew_instance.kickoff_async = AsyncMock(return_value=mock_output)
         mock_crew_cls.return_value = mock_crew_instance
         result = await chat_service.run_crew("hello", user_id, accept_language="es-ES")
         assert result["task_type"] == "general"
@@ -145,7 +161,14 @@ async def test_execute_crew_task(
         patch("app.domain.chat.crew_orchestrator.crewai.Agent"),
     ):
         mock_crew_instance = MagicMock()
-        mock_crew_instance.kickoff_async = AsyncMock(return_value="Result")
+
+        from app.domain.chat.dtos import AgentMessage, RoomChatResponse
+
+        mock_output = MagicMock()
+        expected = RoomChatResponse(messages=[AgentMessage(agent_name="Agent1", content="Result")])
+        mock_output.pydantic = expected
+
+        mock_crew_instance.kickoff_async = AsyncMock(return_value=mock_output)
         mock_crew_cls.return_value = mock_crew_instance
         result = await CrewOrchestrator.execute_crew_task(
             typing.cast("list[typing.Any]", room_agents),
@@ -155,7 +178,7 @@ async def test_execute_crew_task(
             MagicMock(),
             accept_language="ja-JP",
         )
-        assert result == "Result"
+        assert result == expected
 
 
 @pytest.mark.asyncio
@@ -183,7 +206,16 @@ async def test_execute_crew_task_multi(
         patch("app.domain.chat.crew_orchestrator.crewai.Agent"),
     ):
         mock_crew_instance = MagicMock()
-        mock_crew_instance.kickoff_async = AsyncMock(return_value="ResultMulti")
+
+        from app.domain.chat.dtos import AgentMessage, RoomChatResponse
+
+        mock_output = MagicMock()
+        expected = RoomChatResponse(
+            messages=[AgentMessage(agent_name="Agent1", content="ResultMulti")]
+        )
+        mock_output.pydantic = expected
+
+        mock_crew_instance.kickoff_async = AsyncMock(return_value=mock_output)
         mock_crew_cls.return_value = mock_crew_instance
         result = await CrewOrchestrator.execute_crew_task(
             typing.cast("list[typing.Any]", room_agents),
@@ -193,4 +225,4 @@ async def test_execute_crew_task_multi(
             MagicMock(),
             accept_language="hi-IN",
         )
-        assert result == "ResultMulti"
+        assert result == expected

--- a/backend/tests/chat/test_chat_ws.py
+++ b/backend/tests/chat/test_chat_ws.py
@@ -147,8 +147,15 @@ async def test_persist_and_broadcast_agent_response(chat_service: ChatService) -
         typing.cast(
             "AsyncMock", chat_service.agent_repo.increment_message_count
         ).return_value = None
+
+        from app.domain.chat.dtos import AgentMessage, RoomChatResponse
+
+        mock_result = RoomChatResponse(
+            messages=[AgentMessage(agent_name="Agent1", content="Done!")]
+        )
+
         responded = await chat_service.ws_broadcaster.persist_and_broadcast_agent_response(
-            room_id, typing.cast("list[typing.Any]", room_agents), "Done!", agent_names
+            room_id, typing.cast("list[typing.Any]", room_agents), mock_result, agent_names
         )
         assert len(responded) == 1
 
@@ -161,9 +168,14 @@ async def test_persist_and_broadcast_agent_response_error(chat_service: ChatServ
     typing.cast("typing.Any", chat_service.chat_repo).save_message = AsyncMock(
         side_effect=BaseORMException("DB error")
     )
+
+    from app.domain.chat.dtos import AgentMessage, RoomChatResponse
+
+    mock_result = RoomChatResponse(messages=[AgentMessage(agent_name="Agent1", content="Done!")])
+
     with pytest.raises(BaseORMException, match="DB error"):
         await chat_service.ws_broadcaster.persist_and_broadcast_agent_response(
-            room_id, typing.cast("list[typing.Any]", room_agents), "Done!", agent_names
+            room_id, typing.cast("list[typing.Any]", room_agents), mock_result, agent_names
         )
 
 
@@ -216,7 +228,14 @@ async def test_run_room_chat_ws_success(chat_service: ChatService) -> None:
     ):
         mock_hub.broadcast_to_room = AsyncMock()
         m_persist.return_value = MagicMock(id=uuid4())
-        m_exec.return_value = "Result"
+
+        from app.domain.chat.dtos import AgentMessage, RoomChatResponse
+
+        mock_result = RoomChatResponse(
+            messages=[AgentMessage(agent_name="Agent1", content="Result")]
+        )
+        m_exec.return_value = mock_result
+
         m_agent_resp.return_value = []
         m_create_task.return_value = MagicMock()
         typing.cast("typing.Any", chat_service.bg_service).store_memories_background = MagicMock()

--- a/backend/tests/test_chat_background_service.py
+++ b/backend/tests/test_chat_background_service.py
@@ -70,7 +70,12 @@ async def test_store_memories_background_success(background_service: ChatBackgro
     user_id = uuid.uuid4()
     room_id = uuid.uuid4()
     user_message = "Hello world"
-    result_text = "Agent1: How can I help?"
+
+    from app.domain.chat.dtos import AgentMessage, RoomChatResponse
+
+    mock_result = RoomChatResponse(
+        messages=[AgentMessage(agent_name="Agent1", content="How can I help?")]
+    )
 
     agent1 = MagicMock()
     agent1.name = "Agent1"
@@ -80,12 +85,8 @@ async def test_store_memories_background_success(background_service: ChatBackgro
     agent_names = ["Agent1"]
 
     with (
-        patch(
-            "app.domain.chat.websocket_broadcaster.ChatWebSocketBroadcaster.parse_transcript"
-        ) as mock_parse,
         patch("app.infrastructure.external.openrouter.embed", new_callable=AsyncMock) as mock_embed,
     ):
-        mock_parse.return_value = [("Agent1", "How can I help?")]
         mock_embed.return_value = [0.1, 0.2, 0.3]
 
         await background_service.store_memories_background(
@@ -93,7 +94,7 @@ async def test_store_memories_background_success(background_service: ChatBackgro
             room_id,
             user_message,
             responded_agents,  # type: ignore
-            result_text,
+            mock_result,
             agent_names,
         )
 


### PR DESCRIPTION
Updates the AI orchestration boundary to strictly use Pydantic/JSON schemas for LLM responses, eliminating brittle regex/string parsing for multi-agent transcripts in favor of `output_pydantic` in CrewAI tasks.

---
*PR created automatically by Jules for task [10436495653153426482](https://jules.google.com/task/10436495653153426482) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat responses are now handled as structured agent messages, improving consistency in multi-agent conversations.
  * Room chat and memory handling now support per-agent message entries directly.

* **Bug Fixes**
  * Improved reliability when saving chat history and memories by avoiding transcript parsing.
  * Better validation ensures chat results are available in the expected structured format before continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->