### PR TITLE
fix: implement whitelist approach in productivity repository to prevent Mass Assignment

### DIFF
--- a/backend/app/infrastructure/repositories/productivity_repo.py
+++ b/backend/app/infrastructure/repositories/productivity_repo.py
@@ -139,9 +139,18 @@ class ProductivityRepository(IProductivityRepository):
             task = await Task.get_or_none(id=task_id, user_id=user_id)
             if not task:
                 return None
+
+            allowed_fields = {"title", "description", "is_completed", "due_date"}
+            update_fields = []
+
             for field, value in valid_keys.items():
-                setattr(task, field, value)
-            await task.save(update_fields=list(valid_keys.keys()))
+                if field in allowed_fields:
+                    setattr(task, field, value)
+                    update_fields.append(field)
+
+            if update_fields:
+                await task.save(update_fields=update_fields)
+
             return _map_task(task)
 
     async def delete_task(self, user_id: UUID, task_id: UUID) -> int:
@@ -190,9 +199,18 @@ class ProductivityRepository(IProductivityRepository):
             )
             if not note:
                 return None
+
+            allowed_fields = {"title", "content", "is_pinned"}
+            update_fields = []
+
             for field, value in valid_keys.items():
-                setattr(note, field, value)
-            await note.save(update_fields=list(valid_keys.keys()))
+                if field in allowed_fields:
+                    setattr(note, field, value)
+                    update_fields.append(field)
+
+            if update_fields:
+                await note.save(update_fields=update_fields)
+
             return _map_note(note)
 
     async def delete_note(self, user_id: UUID, note_id: UUID) -> int:
@@ -241,14 +259,32 @@ class ProductivityRepository(IProductivityRepository):
 
     async def update_event(
         self, user_id: UUID, event_id: UUID, valid_keys: dict
-    ) -> CalendarEventEntity:
+    ) -> CalendarEventEntity | None:
         async with handle_db_errors("update calendar event"):
-            event = await CalendarEvent.get(id=event_id, user_id=user_id).prefetch_related(
+            event = await CalendarEvent.get_or_none(id=event_id, user_id=user_id).prefetch_related(
                 "agent", "origin_message"
             )
+            if not event:
+                return None
+
+            allowed_fields = {
+                "title",
+                "description",
+                "start_time",
+                "end_time",
+                "is_all_day",
+                "location",
+            }
+            update_fields = []
+
             for field, value in valid_keys.items():
-                setattr(event, field, value)
-            await event.save(update_fields=list(valid_keys.keys()))
+                if field in allowed_fields:
+                    setattr(event, field, value)
+                    update_fields.append(field)
+
+            if update_fields:
+                await event.save(update_fields=update_fields)
+
             return _map_event(event)
 
     async def delete_event(self, user_id: UUID, event_id: UUID) -> int:


### PR DESCRIPTION
Implemented a whitelist approach in `update_task`, `update_note`, and `update_event` methods within `ProductivityRepository` to restrict the fields that can be updated. This prevents Mass Assignment vulnerabilities where an attacker could potentially inject restricted fields (like altering the `id` or `user_id` of the entity) by filtering the `valid_keys` dictionary against an explicitly defined `allowed_fields` set.

---
*PR created automatically by Jules for task [5228063997431891681](https://jules.google.com/task/5228063997431891681) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated task, note, and calendar event edits to save only valid changes, preventing unintended field updates.
  * Improved event updates to handle missing calendar events gracefully instead of failing when an item can’t be found.
  * Reduced unnecessary saves when no permitted changes are provided, making updates more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->