### PR TITLE
Refactor: Extract JWT validation logic to infrastructure layer

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -7,10 +7,12 @@ from typing import Annotated
 from fastapi import Depends
 
 from app.domain.agents.service import AgentService
+from app.domain.auth.interfaces import JWTVerifierProtocol
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
 from app.domain.memory.service import MemoryService
 from app.infrastructure.database.supabase import SupabaseClient
+from app.infrastructure.external.jwt_verifier import SupabaseJWTVerifier
 from app.infrastructure.repositories.agent_repo import AgentRepository
 from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
@@ -64,3 +66,11 @@ def get_memory_service(
 
 def get_auth_service(repo: Annotated[AuthRepository, Depends(get_auth_repo)]) -> AuthService:
     return AuthService(repo)
+
+
+_jwt_verifier_instance = SupabaseJWTVerifier()
+
+
+def get_jwt_verifier() -> JWTVerifierProtocol:
+    """Provide a singleton instance of the JWT verifier."""
+    return _jwt_verifier_instance

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -72,5 +72,9 @@ _jwt_verifier_instance = SupabaseJWTVerifier()
 
 
 def get_jwt_verifier() -> JWTVerifierProtocol:
-    """Provide a singleton instance of the JWT verifier."""
+    """Provide a singleton instance of the JWT verifier.
+
+    Returns:
+        JWTVerifierProtocol: The global singleton used for verifying Supabase JWTs.
+    """
     return _jwt_verifier_instance

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -25,12 +25,14 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, Query, WebSocket, WebSocketDisconnect
 
 from app.api.dependencies import get_jwt_verifier
 from app.domain.agents.service import AgentService
+from app.domain.auth.interfaces import JWTVerifierProtocol
 from app.domain.chat.service import ChatService
 from app.infrastructure.repositories.agent_repo import AgentRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
@@ -47,10 +49,9 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-async def _verify_token(token: str) -> UUID | None:
-    """Decode a Supabase JWT by delegating to get_jwt_verifier()."""
+async def _verify_token(token: str, jwt_verifier: JWTVerifierProtocol) -> UUID | None:
+    """Decode a Supabase JWT by delegating to the injected JWT verifier."""
     try:
-        jwt_verifier = get_jwt_verifier()
         payload = await jwt_verifier.verify_token(token)
         return payload.sub
     except Exception:
@@ -100,6 +101,7 @@ async def _handle_send_message(
 @router.websocket("/ws/chat")
 async def websocket_chat_hub(
     websocket: WebSocket,
+    jwt_verifier: Annotated[JWTVerifierProtocol, Depends(get_jwt_verifier)],
     token: str = Query(..., description="Supabase JWT access token"),
     lang: str | None = Query(
         None, description="Preferred language", pattern=r"^[a-zA-Z]{2}(?:-[a-zA-Z]{2})?$"
@@ -112,7 +114,7 @@ async def websocket_chat_hub(
     This endpoint allows clients to join/leave rooms and send messages within those rooms.
     Authentication is required via a Supabase JWT passed as a query parameter.
     """
-    user_id = await _verify_token(token)
+    user_id = await _verify_token(token, jwt_verifier)
     try:
         if user_id is None:
             await websocket.close(code=4001, reason="Unauthorized")

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -29,12 +29,10 @@ from uuid import UUID
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
+from app.api.dependencies import get_jwt_verifier
 from app.domain.agents.service import AgentService
-from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
-from app.infrastructure.database.supabase import get_supabase
 from app.infrastructure.repositories.agent_repo import AgentRepository
-from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
 from app.infrastructure.repositories.memory_repo import MemoryRepository
 from app.infrastructure.websocket.manager import chat_hub
@@ -43,17 +41,17 @@ router = APIRouter(tags=["WebSocket"])
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# JWT authentication — delegates to AuthService so algorithm/claims handling
+# JWT authentication — delegates to SupabaseJWTVerifier so algorithm/claims handling
 # stays centralised; uses a query-param token because WS upgrades cannot carry
 # a custom Authorization header from most clients.
 # ---------------------------------------------------------------------------
 
 
 async def _verify_token(token: str) -> UUID | None:
-    """Decode a Supabase JWT by delegating to AuthService.decode_jwt."""
+    """Decode a Supabase JWT by delegating to get_jwt_verifier()."""
     try:
-        auth_service = AuthService(AuthRepository(get_supabase()))
-        payload = await auth_service.decode_jwt(token)
+        jwt_verifier = get_jwt_verifier()
+        payload = await jwt_verifier.verify_token(token)
         return payload.sub
     except Exception:
         logger.warning("WS auth rejected: invalid token")

--- a/backend/app/core/security/auth.py
+++ b/backend/app/core/security/auth.py
@@ -8,9 +8,9 @@ from uuid import UUID
 from fastapi import Depends, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
-from app.api.dependencies import get_auth_service
+from app.api.dependencies import get_jwt_verifier
 from app.api.errors import raise_api_error
-from app.domain.auth.service import AuthService  # noqa: TCH001
+from app.domain.auth.interfaces import JWTVerifierProtocol
 
 # HTTPBearer extracts the Bearer token from the Authorization header.
 _bearer = HTTPBearer(auto_error=True)
@@ -18,11 +18,11 @@ _bearer = HTTPBearer(auto_error=True)
 
 async def get_current_user(
     credentials: Annotated[HTTPAuthorizationCredentials, Depends(_bearer)],
-    auth_service: Annotated[AuthService, Depends(get_auth_service)],
+    jwt_verifier: Annotated[JWTVerifierProtocol, Depends(get_jwt_verifier)],
 ) -> UUID:
     """FastAPI dependency that validates the Bearer token and returns the user UUID."""
     try:
-        payload = await auth_service.decode_jwt(credentials.credentials)
+        payload = await jwt_verifier.verify_token(credentials.credentials)
     except Exception:
         raise_api_error(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/app/domain/auth/interfaces.py
+++ b/backend/app/domain/auth/interfaces.py
@@ -6,6 +6,15 @@ from typing import Protocol
 from uuid import UUID
 
 from app.domain.auth.entities import Passkey, PasskeyCreate
+from app.domain.auth.schemas import JWTPayload
+
+
+class JWTVerifierProtocol(Protocol):
+    """Protocol for JWT Verification."""
+
+    async def verify_token(self, token: str) -> JWTPayload:
+        """Decode and verify a JWT."""
+        ...
 
 
 class AuthRepositoryProtocol(Protocol):

--- a/backend/app/domain/auth/interfaces.py
+++ b/backend/app/domain/auth/interfaces.py
@@ -10,10 +10,20 @@ from app.domain.auth.schemas import JWTPayload
 
 
 class JWTVerifierProtocol(Protocol):
-    """Protocol for JWT Verification."""
+    """Protocol for JWT Verification.
+
+    Defines the contract for decoding and validating JSON Web Tokens.
+    """
 
     async def verify_token(self, token: str) -> JWTPayload:
-        """Decode and verify a JWT."""
+        """Decode and verify a JWT.
+
+        Args:
+            token: The raw JSON Web Token string to verify.
+
+        Returns:
+            JWTPayload: The validated and decoded token payload.
+        """
         ...
 
 

--- a/backend/app/domain/auth/service.py
+++ b/backend/app/domain/auth/service.py
@@ -6,11 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-import jwt
-
-from app.core.config import get_settings
 from app.domain.auth.entities import Passkey
-from app.domain.auth.schemas import JWTPayload
 
 if TYPE_CHECKING:
     from app.domain.auth.interfaces import AuthRepositoryProtocol
@@ -21,52 +17,12 @@ logger = logging.getLogger(__name__)
 class AuthService:
     def __init__(self, repo: AuthRepositoryProtocol) -> None:
         self.repo = repo
-        self._jwks_client: jwt.PyJWKClient | None = None
 
     async def list_passkeys(
         self, user_id: str | UUID, limit: int = 50, cursor: str | None = None
     ) -> tuple[list[Passkey], str | None]:
         """Fetch a paginated list of passkeys for a user."""
         return await self.repo.get_passkeys_by_user(user_id, limit=limit, cursor=cursor)
-
-    def _get_jwks_client(self) -> jwt.PyJWKClient:
-        if self._jwks_client is None:
-            settings = get_settings()
-            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
-            self._jwks_client = jwt.PyJWKClient(jwks_url)
-        return self._jwks_client
-
-    async def decode_jwt(self, token: str) -> JWTPayload:
-        """Decode and verify a Supabase JWT."""
-        settings = get_settings()
-        try:
-            try:
-                header = jwt.get_unverified_header(token)
-            except Exception as header_exc:
-                raise jwt.DecodeError("Invalid token format") from header_exc
-
-            alg = header.get("alg")
-
-            if alg == "HS256":
-                payload = jwt.decode(
-                    token,
-                    settings.supabase_jwt_secret,
-                    algorithms=["HS256"],
-                    audience="authenticated",
-                )
-            else:
-                jwks_client = self._get_jwks_client()
-                signing_key = jwks_client.get_signing_key_from_jwt(token)
-                payload = jwt.decode(
-                    token,
-                    signing_key.key,
-                    algorithms=["ES256", "RS256"],
-                    audience="authenticated",
-                )
-            return JWTPayload(**payload)
-        except Exception as exc:
-            logger.warning("JWT validation failed: %s", exc)
-            raise
 
     # --- WebAuthn / Passkey Logic (Authlib Integration) ---
 

--- a/backend/app/infrastructure/external/jwt_verifier.py
+++ b/backend/app/infrastructure/external/jwt_verifier.py
@@ -1,0 +1,56 @@
+"""JWT verifier external integration."""
+
+from __future__ import annotations
+
+import logging
+
+import jwt
+
+from app.core.config import get_settings
+from app.domain.auth.schemas import JWTPayload
+
+logger = logging.getLogger(__name__)
+
+
+class SupabaseJWTVerifier:
+    def __init__(self) -> None:
+        self._jwks_client: jwt.PyJWKClient | None = None
+
+    def _get_jwks_client(self) -> jwt.PyJWKClient:
+        if self._jwks_client is None:
+            settings = get_settings()
+            jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
+            self._jwks_client = jwt.PyJWKClient(jwks_url)
+        return self._jwks_client
+
+    async def verify_token(self, token: str) -> JWTPayload:
+        """Decode and verify a Supabase JWT."""
+        settings = get_settings()
+        try:
+            try:
+                header = jwt.get_unverified_header(token)
+            except Exception as header_exc:
+                raise jwt.DecodeError("Invalid token format") from header_exc
+
+            alg = header.get("alg")
+
+            if alg == "HS256":
+                payload = jwt.decode(
+                    token,
+                    settings.supabase_jwt_secret,
+                    algorithms=["HS256"],
+                    audience="authenticated",
+                )
+            else:
+                jwks_client = self._get_jwks_client()
+                signing_key = jwks_client.get_signing_key_from_jwt(token)
+                payload = jwt.decode(
+                    token,
+                    signing_key.key,
+                    algorithms=["ES256", "RS256"],
+                    audience="authenticated",
+                )
+            return JWTPayload(**payload)
+        except Exception as exc:
+            logger.warning("JWT validation failed: %s", exc)
+            raise

--- a/backend/app/infrastructure/external/jwt_verifier.py
+++ b/backend/app/infrastructure/external/jwt_verifier.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import jwt
@@ -13,10 +14,17 @@ logger = logging.getLogger(__name__)
 
 
 class SupabaseJWTVerifier:
+    """External JWT verifier for Supabase tokens.
+
+    Handles token validation using either HS256 (symmetric) or RS256/ES256 (asymmetric)
+    algorithms, managing the retrieval of JSON Web Key Sets (JWKS) automatically.
+    """
+
     def __init__(self) -> None:
         self._jwks_client: jwt.PyJWKClient | None = None
 
     def _get_jwks_client(self) -> jwt.PyJWKClient:
+        """Initialize or return the cached PyJWKClient."""
         if self._jwks_client is None:
             settings = get_settings()
             jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
@@ -24,7 +32,14 @@ class SupabaseJWTVerifier:
         return self._jwks_client
 
     async def verify_token(self, token: str) -> JWTPayload:
-        """Decode and verify a Supabase JWT."""
+        """Decode and verify a Supabase JWT.
+
+        Args:
+            token: The raw JSON Web Token string to verify.
+
+        Returns:
+            JWTPayload: The validated and decoded token payload.
+        """
         settings = get_settings()
         try:
             try:
@@ -43,7 +58,8 @@ class SupabaseJWTVerifier:
                 )
             else:
                 jwks_client = self._get_jwks_client()
-                signing_key = jwks_client.get_signing_key_from_jwt(token)
+                # Run the blocking JWKS fetch off the main event loop
+                signing_key = await asyncio.to_thread(jwks_client.get_signing_key_from_jwt, token)
                 payload = jwt.decode(
                     token,
                     signing_key.key,
@@ -51,6 +67,9 @@ class SupabaseJWTVerifier:
                     audience="authenticated",
                 )
             return JWTPayload(**payload)
-        except Exception as exc:
+        except jwt.PyJWTError as exc:
             logger.warning("JWT validation failed: %s", exc)
+            raise
+        except Exception:
+            logger.exception("Unexpected error during JWT validation")
             raise

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -32,6 +32,64 @@ async def test_decode_valid_jwt() -> None:
 
 
 @pytest.mark.asyncio
+async def test_decode_jwks_rs256_jwt() -> None:
+    """A valid RS256 JWT fetches JWKS and decodes successfully."""
+    from unittest.mock import patch
+
+    from app.core.config import get_settings
+    from app.infrastructure.external.jwt_verifier import SupabaseJWTVerifier
+
+    # Mock signing key setup
+    mock_key = MagicMock()
+    mock_key.key = get_settings().supabase_jwt_secret
+
+    # Create token with RS256 alg in header but using HS256 for signing so the string is valid
+    token = jwt.encode(
+        {
+            "sub": "12345678-1234-5678-1234-567812345678",
+            "role": "authenticated",
+            "aud": "authenticated",
+        },
+        mock_key.key,
+        algorithm="HS256",
+        headers={"kid": "test_kid"},
+    )
+    # forcefully overwrite the header in the token string for testing
+    import base64
+    import json
+
+    header = {"alg": "RS256", "kid": "test_kid", "typ": "JWT"}
+    header_b64 = base64.urlsafe_b64encode(json.dumps(header).encode()).decode().rstrip("=")
+    parts = token.split(".")
+    token = f"{header_b64}.{parts[1]}.{parts[2]}"
+    # The jwt.decode logic requires the encoded string to match the decoded alg if we pass algorithms=["RS256"].
+    # For testing, we mock PyJWKClient to return a key, and we use a workaround by mocking jwt.decode
+    # to avoid needing a real RSA key pair in the test.
+
+    verifier = SupabaseJWTVerifier()
+
+    from time import time
+
+    current_time = int(time())
+    with (
+        patch("jwt.PyJWKClient.get_signing_key_from_jwt", return_value=mock_key),
+        patch(
+            "jwt.decode",
+            return_value={
+                "sub": "12345678-1234-5678-1234-567812345678",
+                "role": "authenticated",
+                "iat": current_time,
+                "exp": current_time + 3600,
+            },
+        ),
+    ):
+        payload = await verifier.verify_token(token)
+
+    assert isinstance(payload, JWTPayload)
+    assert payload.role == "authenticated"
+
+
+@pytest.mark.asyncio
 async def test_decode_expired_jwt_raises_401() -> None:
     """An expired JWT raises an error."""
     from app.infrastructure.external.jwt_verifier import SupabaseJWTVerifier

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -21,12 +21,11 @@ from tests.conftest import make_jwt
 @pytest.mark.asyncio
 async def test_decode_valid_jwt() -> None:
     """A valid JWT with a known secret decodes successfully."""
-    from app.domain.auth.service import AuthService
-    from app.infrastructure.repositories.auth_repo import AuthRepository
+    from app.infrastructure.external.jwt_verifier import SupabaseJWTVerifier
 
     token = make_jwt()
-    service = AuthService(AuthRepository(MagicMock()))
-    payload = await service.decode_jwt(token)
+    verifier = SupabaseJWTVerifier()
+    payload = await verifier.verify_token(token)
 
     assert isinstance(payload, JWTPayload)
     assert payload.role == "authenticated"
@@ -35,14 +34,13 @@ async def test_decode_valid_jwt() -> None:
 @pytest.mark.asyncio
 async def test_decode_expired_jwt_raises_401() -> None:
     """An expired JWT raises an error."""
-    from app.domain.auth.service import AuthService
-    from app.infrastructure.repositories.auth_repo import AuthRepository
+    from app.infrastructure.external.jwt_verifier import SupabaseJWTVerifier
 
     token = make_jwt(expired=True)
-    service = AuthService(AuthRepository(MagicMock()))
+    verifier = SupabaseJWTVerifier()
 
     with pytest.raises(jwt.ExpiredSignatureError):
-        await service.decode_jwt(token)
+        await verifier.verify_token(token)
 
 
 @pytest.mark.asyncio
@@ -50,17 +48,16 @@ async def test_decode_invalid_jwt_format_logs_warning(caplog: pytest.LogCaptureF
     """An invalid JWT format raises a DecodeError and logs a warning instead of an error."""
     import logging
 
-    from app.domain.auth.service import AuthService
-    from app.infrastructure.repositories.auth_repo import AuthRepository
+    from app.infrastructure.external.jwt_verifier import SupabaseJWTVerifier
 
     token = "invalid.token.format"
-    service = AuthService(AuthRepository(MagicMock()))
+    verifier = SupabaseJWTVerifier()
 
     with (
         caplog.at_level(logging.WARNING),
         pytest.raises(jwt.DecodeError, match="Invalid token format"),
     ):
-        await service.decode_jwt(token)
+        await verifier.verify_token(token)
 
     assert any(
         record.levelname == "WARNING" and "JWT validation failed" in record.message

--- a/backend/tests/test_websocket_chat.py
+++ b/backend/tests/test_websocket_chat.py
@@ -118,8 +118,10 @@ def test_websocket_endpoint_runtime_error_during_connect() -> None:
             )
             with patch("app.api.v1.websocket.chat_hub.disconnect") as mock_disconnect:
                 import asyncio
+                from unittest.mock import MagicMock
 
-                asyncio.run(websocket_chat_hub(mock_ws, token="valid", lang="en-US"))
+                mock_verifier = MagicMock()
+                asyncio.run(websocket_chat_hub(mock_ws, jwt_verifier=mock_verifier, token="valid", lang="en-US"))
 
                 mock_disconnect.assert_called_once_with(user_id)
 
@@ -140,7 +142,9 @@ def test_websocket_endpoint_runtime_error_during_close() -> None:
         mock_verify.return_value = None
         with patch("app.api.v1.websocket.chat_hub.disconnect") as mock_disconnect:
             import asyncio
+            from unittest.mock import MagicMock
 
-            asyncio.run(websocket_chat_hub(mock_ws, token="invalid", lang="en-US"))
+            mock_verifier = MagicMock()
+            asyncio.run(websocket_chat_hub(mock_ws, jwt_verifier=mock_verifier, token="invalid", lang="en-US"))
 
             mock_disconnect.assert_not_called()


### PR DESCRIPTION
Extracted `SupabaseJWTVerifier` implementation out of the `AuthService` to cleanly encapsulate infrastructure concerns and resolve architectural layering violations.

---
*PR created automatically by Jules for task [4476076807082277045](https://jules.google.com/task/4476076807082277045) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified JWT verification flow for sign-in and WebSocket access, improving token handling across the app.
  * Expanded support for multiple token validation methods, including Supabase-backed verification.

* **Bug Fixes**
  * Kept authentication failures returning clear unauthorized responses when tokens are invalid or expired.
  * Improved WebSocket authentication reliability by using the same verification path as standard API requests.

* **Tests**
  * Updated authentication tests to cover valid, expired, and malformed token behavior with the new verification flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->