### PR TITLE
Fix unhandled DoesNotExist error on missing calendar event updates

### DIFF
--- a/backend/app/domain/productivity/interfaces/repository.py
+++ b/backend/app/domain/productivity/interfaces/repository.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from typing import Protocol
 from uuid import UUID
 
-from app.domain.productivity.entities import CalendarEventEntity, NoteEntity, TaskEntity
-from app.domain.productivity.schemas import CalendarEventCreate, NoteCreate, TaskCreate
+from app.domain.productivity.entities import (CalendarEventEntity, NoteEntity,
+                                              TaskEntity)
+from app.domain.productivity.schemas import (CalendarEventCreate, NoteCreate,
+                                             TaskCreate)
 
 
 class IProductivityRepository(Protocol):
@@ -24,7 +26,9 @@ class IProductivityRepository(Protocol):
         """
         ...
 
-    async def list_tasks(self, user_id: UUID, limit: int = 50, offset: int = 0) -> list[TaskEntity]:
+    async def list_tasks(
+        self, user_id: UUID, limit: int = 50, offset: int = 0
+    ) -> list[TaskEntity]:
         """List tasks for a user.
 
         Args:
@@ -88,7 +92,9 @@ class IProductivityRepository(Protocol):
         """
         ...
 
-    async def list_notes(self, user_id: UUID, limit: int = 50, offset: int = 0) -> list[NoteEntity]:
+    async def list_notes(
+        self, user_id: UUID, limit: int = 50, offset: int = 0
+    ) -> list[NoteEntity]:
         """List notes for a user.
 
         Args:
@@ -169,7 +175,9 @@ class IProductivityRepository(Protocol):
         """
         ...
 
-    async def get_event(self, user_id: UUID, event_id: UUID) -> CalendarEventEntity | None:
+    async def get_event(
+        self, user_id: UUID, event_id: UUID
+    ) -> CalendarEventEntity | None:
         """Get a specific calendar event.
 
         Args:

--- a/backend/app/domain/productivity/interfaces/repository.py
+++ b/backend/app/domain/productivity/interfaces/repository.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 from typing import Protocol
 from uuid import UUID
 
-from app.domain.productivity.entities import (CalendarEventEntity, NoteEntity,
-                                              TaskEntity)
-from app.domain.productivity.schemas import (CalendarEventCreate, NoteCreate,
-                                             TaskCreate)
+from app.domain.productivity.entities import CalendarEventEntity, NoteEntity, TaskEntity
+from app.domain.productivity.schemas import CalendarEventCreate, NoteCreate, TaskCreate
 
 
 class IProductivityRepository(Protocol):
@@ -26,9 +24,7 @@ class IProductivityRepository(Protocol):
         """
         ...
 
-    async def list_tasks(
-        self, user_id: UUID, limit: int = 50, offset: int = 0
-    ) -> list[TaskEntity]:
+    async def list_tasks(self, user_id: UUID, limit: int = 50, offset: int = 0) -> list[TaskEntity]:
         """List tasks for a user.
 
         Args:
@@ -92,9 +88,7 @@ class IProductivityRepository(Protocol):
         """
         ...
 
-    async def list_notes(
-        self, user_id: UUID, limit: int = 50, offset: int = 0
-    ) -> list[NoteEntity]:
+    async def list_notes(self, user_id: UUID, limit: int = 50, offset: int = 0) -> list[NoteEntity]:
         """List notes for a user.
 
         Args:
@@ -175,9 +169,7 @@ class IProductivityRepository(Protocol):
         """
         ...
 
-    async def get_event(
-        self, user_id: UUID, event_id: UUID
-    ) -> CalendarEventEntity | None:
+    async def get_event(self, user_id: UUID, event_id: UUID) -> CalendarEventEntity | None:
         """Get a specific calendar event.
 
         Args:

--- a/backend/app/infrastructure/repositories/productivity_repo.py
+++ b/backend/app/infrastructure/repositories/productivity_repo.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
-from app.domain.productivity.entities import CalendarEventEntity, NoteEntity, TaskEntity
-from app.domain.productivity.interfaces.repository import IProductivityRepository
+from app.domain.productivity.entities import (CalendarEventEntity, NoteEntity,
+                                              TaskEntity)
+from app.domain.productivity.interfaces.repository import \
+    IProductivityRepository
 from app.domain.productivity.models import CalendarEvent, Note, Task
-from app.domain.productivity.schemas import CalendarEventCreate, NoteCreate, TaskCreate
+from app.domain.productivity.schemas import (CalendarEventCreate, NoteCreate,
+                                             TaskCreate)
 from app.infrastructure.database.utils import handle_db_errors
 
 
@@ -115,7 +118,9 @@ class ProductivityRepository(IProductivityRepository):
             )
             return _map_task(task)
 
-    async def list_tasks(self, user_id: UUID, limit: int = 50, offset: int = 0) -> list[TaskEntity]:
+    async def list_tasks(
+        self, user_id: UUID, limit: int = 50, offset: int = 0
+    ) -> list[TaskEntity]:
         async with handle_db_errors("list tasks"):
             tasks = (
                 await Task.filter(user_id=user_id)
@@ -161,7 +166,9 @@ class ProductivityRepository(IProductivityRepository):
             )
             return _map_note(note)
 
-    async def list_notes(self, user_id: UUID, limit: int = 50, offset: int = 0) -> list[NoteEntity]:
+    async def list_notes(
+        self, user_id: UUID, limit: int = 50, offset: int = 0
+    ) -> list[NoteEntity]:
         async with handle_db_errors("list notes"):
             notes = (
                 await Note.filter(user_id=user_id)
@@ -230,22 +237,26 @@ class ProductivityRepository(IProductivityRepository):
             )
             return [_map_event(e) for e in events]
 
-    async def get_event(self, user_id: UUID, event_id: UUID) -> CalendarEventEntity | None:
+    async def get_event(
+        self, user_id: UUID, event_id: UUID
+    ) -> CalendarEventEntity | None:
         async with handle_db_errors("get calendar event"):
-            event = await CalendarEvent.get_or_none(id=event_id, user_id=user_id).prefetch_related(
-                "agent", "origin_message"
-            )
+            event = await CalendarEvent.get_or_none(
+                id=event_id, user_id=user_id
+            ).prefetch_related("agent", "origin_message")
             if event:
                 return _map_event(event)
             return None
 
     async def update_event(
         self, user_id: UUID, event_id: UUID, valid_keys: dict
-    ) -> CalendarEventEntity:
+    ) -> CalendarEventEntity | None:
         async with handle_db_errors("update calendar event"):
-            event = await CalendarEvent.get(id=event_id, user_id=user_id).prefetch_related(
-                "agent", "origin_message"
-            )
+            event = await CalendarEvent.get_or_none(
+                id=event_id, user_id=user_id
+            ).prefetch_related("agent", "origin_message")
+            if not event:
+                return None
             for field, value in valid_keys.items():
                 setattr(event, field, value)
             await event.save(update_fields=list(valid_keys.keys()))

--- a/backend/app/infrastructure/repositories/productivity_repo.py
+++ b/backend/app/infrastructure/repositories/productivity_repo.py
@@ -5,13 +5,10 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
-from app.domain.productivity.entities import (CalendarEventEntity, NoteEntity,
-                                              TaskEntity)
-from app.domain.productivity.interfaces.repository import \
-    IProductivityRepository
+from app.domain.productivity.entities import CalendarEventEntity, NoteEntity, TaskEntity
+from app.domain.productivity.interfaces.repository import IProductivityRepository
 from app.domain.productivity.models import CalendarEvent, Note, Task
-from app.domain.productivity.schemas import (CalendarEventCreate, NoteCreate,
-                                             TaskCreate)
+from app.domain.productivity.schemas import CalendarEventCreate, NoteCreate, TaskCreate
 from app.infrastructure.database.utils import handle_db_errors
 
 
@@ -118,9 +115,7 @@ class ProductivityRepository(IProductivityRepository):
             )
             return _map_task(task)
 
-    async def list_tasks(
-        self, user_id: UUID, limit: int = 50, offset: int = 0
-    ) -> list[TaskEntity]:
+    async def list_tasks(self, user_id: UUID, limit: int = 50, offset: int = 0) -> list[TaskEntity]:
         async with handle_db_errors("list tasks"):
             tasks = (
                 await Task.filter(user_id=user_id)
@@ -166,9 +161,7 @@ class ProductivityRepository(IProductivityRepository):
             )
             return _map_note(note)
 
-    async def list_notes(
-        self, user_id: UUID, limit: int = 50, offset: int = 0
-    ) -> list[NoteEntity]:
+    async def list_notes(self, user_id: UUID, limit: int = 50, offset: int = 0) -> list[NoteEntity]:
         async with handle_db_errors("list notes"):
             notes = (
                 await Note.filter(user_id=user_id)
@@ -237,13 +230,11 @@ class ProductivityRepository(IProductivityRepository):
             )
             return [_map_event(e) for e in events]
 
-    async def get_event(
-        self, user_id: UUID, event_id: UUID
-    ) -> CalendarEventEntity | None:
+    async def get_event(self, user_id: UUID, event_id: UUID) -> CalendarEventEntity | None:
         async with handle_db_errors("get calendar event"):
-            event = await CalendarEvent.get_or_none(
-                id=event_id, user_id=user_id
-            ).prefetch_related("agent", "origin_message")
+            event = await CalendarEvent.get_or_none(id=event_id, user_id=user_id).prefetch_related(
+                "agent", "origin_message"
+            )
             if event:
                 return _map_event(event)
             return None
@@ -252,9 +243,9 @@ class ProductivityRepository(IProductivityRepository):
         self, user_id: UUID, event_id: UUID, valid_keys: dict
     ) -> CalendarEventEntity | None:
         async with handle_db_errors("update calendar event"):
-            event = await CalendarEvent.get_or_none(
-                id=event_id, user_id=user_id
-            ).prefetch_related("agent", "origin_message")
+            event = await CalendarEvent.get_or_none(id=event_id, user_id=user_id).prefetch_related(
+                "agent", "origin_message"
+            )
             if not event:
                 return None
             for field, value in valid_keys.items():


### PR DESCRIPTION
- Modified `ProductivityRepository.update_event` to use `get_or_none()` rather than `get()`.
- Added a check to return `None` if the queried event model is `None`, instead of trying to proceed with missing values.
- Updated return type annotation to properly state it could be `None`.

---
*PR created automatically by Jules for task [9495792120126417322](https://jules.google.com/task/9495792120126417322) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event update handling so missing calendar events are treated as “not found,” returning no result instead of failing unexpectedly.
* **Refactor**
  * Reworked repository method and import formatting to improve readability while preserving existing query behavior for listing tasks/notes and retrieving events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->