### PR TITLE
docs(frontend): add missing JSDoc blocks to components and hooks

### DIFF
--- a/frontend/src/components/layout/GlobalQuickActions.tsx
+++ b/frontend/src/components/layout/GlobalQuickActions.tsx
@@ -15,6 +15,14 @@ type QuickAction = {
   route: string;
 };
 
+/**
+ * A floating action button (FAB) component that provides quick access to core features
+ * from anywhere in the app (e.g. creating new chats, agents, or tasks).
+ *
+ * Behavior:
+ * - Hidden automatically on chat routes (`/chat/`) to prevent UI overlap.
+ * - Spawns an animated bottom modal with available action items when pressed.
+ */
 export function GlobalQuickActions() {
   const { t } = useTranslation();
   const router = useRouter();

--- a/frontend/src/components/layout/PageShell.tsx
+++ b/frontend/src/components/layout/PageShell.tsx
@@ -6,14 +6,24 @@ import { DESIGN_TOKENS } from '@/core/design/tokens';
 import { useTheme } from '@/hooks/useTheme';
 
 interface PageShellProps {
+  /** The primary title shown at the top of the page. */
   title: string;
+  /** An optional secondary subtitle shown below the title. */
   subtitle?: string;
+  /** An optional React node rendered on the right side of the header. */
   right?: React.ReactNode;
+  /** The content of the page. */
   children: React.ReactNode;
+  /** Whether the page content should be scrollable. Defaults to `true`. */
   scroll?: boolean;
+  /** Additional styles to apply to the content container. */
   contentStyle?: ViewStyle;
 }
 
+/**
+ * A reusable container component that renders a distinct visual block (card)
+ * within a page. Typically used with `PageSectionHeader`.
+ */
 export const PageSectionCard = ({
   children,
   style,
@@ -38,11 +48,17 @@ export const PageSectionCard = ({
   );
 };
 
+/**
+ * A reusable header component intended for use above `PageSectionCard` components
+ * to visually label a block of content.
+ */
 export const PageSectionHeader = ({
   title,
   action,
 }: {
+  /** The title of the section. */
   title: string;
+  /** An optional React node rendered on the right side of the section header. */
   action?: React.ReactNode;
 }) => {
   return (
@@ -55,6 +71,9 @@ export const PageSectionHeader = ({
   );
 };
 
+/**
+ * Internal header component for the `PageShell`.
+ */
 const PageHeader = ({
   title,
   subtitle,
@@ -79,6 +98,12 @@ const PageHeader = ({
   );
 };
 
+/**
+ * The standard layout container for top-level screens in the application.
+ *
+ * Provides consistent Safe Area handling, optional scrolling, and standard page-level
+ * typography headers. Automatically accounts for the bottom tab bar inset.
+ */
 export const PageShell = ({
   title,
   subtitle,

--- a/frontend/src/hooks/useChatRoomSetup.ts
+++ b/frontend/src/hooks/useChatRoomSetup.ts
@@ -6,6 +6,16 @@ import { ApiService } from '@/core/api/ApiService';
 import { getApiErrorMessage } from '@/core/api/errors';
 import { Agent } from '@/core/models';
 
+/**
+ * Custom hook to manage the lifecycle, state, and connections of a chat room.
+ *
+ * This hook handles connecting and disconnecting from the SignalR chat hub,
+ * fetching initial room messages and agent data, and explicitly joining/leaving
+ * the room channel based on component mount/unmount events.
+ *
+ * @param roomId - The UUID of the chat room to set up. If undefined, no action is taken.
+ * @returns An object containing the list of agents in the room, state setters, and a refetch function.
+ */
 export function useChatRoomSetup(roomId: string | undefined) {
   const { t } = useTranslation();
   const fetchMessages = useChatStore((s) => s.fetchMessages);

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,5 +1,15 @@
 import { useEffect, useState } from 'react';
 
+/**
+ * Custom hook to debounce a rapidly changing value (e.g. search inputs).
+ *
+ * It delays the state update of the given `value` until after `delayMs` milliseconds
+ * have elapsed since the last time the `value` was changed.
+ *
+ * @param value - The value to debounce.
+ * @param delayMs - The delay in milliseconds.
+ * @returns The debounced value.
+ */
 export function useDebounce<T>(value: T, delayMs: number): T {
   const [debounced, setDebounced] = useState(value);
 


### PR DESCRIPTION
Added comprehensive JSDoc blocks to the following files:
- frontend/src/components/layout/GlobalQuickActions.tsx
- frontend/src/components/layout/PageShell.tsx
- frontend/src/hooks/useChatRoomSetup.ts
- frontend/src/hooks/useDebounce.ts

---
*PR created automatically by Jules for task [2480844451335560819](https://jules.google.com/task/2480844451335560819) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added inline documentation for several shared UI components and hooks, making their behavior and usage clearer.
  * Clarified how key layout elements and quick actions behave in the app.
  * Improved developer-facing guidance for chat room setup and debounced input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->