### PR TITLE
test: add integration test suite for ChatService

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -118,3 +118,46 @@ def test_user_id() -> Any:
 def authed_headers(test_user_id: Any) -> dict[str, str]:
     """Authorization headers for the test user."""
     return auth_headers(user_id=test_user_id)
+
+@pytest_asyncio.fixture
+async def chat_service(
+    chat_repo: "ChatRepository",
+    agent_repo: "AgentRepository",
+    memory_repo: "MemoryRepository",
+    agent_service: "AgentService"
+) -> "ChatService":
+    from app.domain.chat.service import ChatService
+    return ChatService(
+        chat_repo=chat_repo,
+        agent_repo=agent_repo,
+        memory_repo=memory_repo,
+        agent_service=agent_service
+    )
+
+@pytest_asyncio.fixture
+async def chat_repo() -> "ChatRepository":
+    from app.infrastructure.repositories.chat_repo import ChatRepository
+    return ChatRepository()
+
+@pytest_asyncio.fixture
+async def agent_repo() -> "AgentRepository":
+    from app.infrastructure.repositories.agent_repo import AgentRepository
+    return AgentRepository()
+
+@pytest_asyncio.fixture
+async def memory_repo() -> "MemoryRepository":
+    from app.infrastructure.repositories.memory_repo import MemoryRepository
+    return MemoryRepository()
+
+@pytest_asyncio.fixture
+async def agent_service(agent_repo: "AgentRepository") -> "AgentService":
+    from app.domain.agents.service import AgentService
+    return AgentService(repo=agent_repo)
+
+@pytest_asyncio.fixture
+async def test_user(test_user_id: str) -> "Profile":
+    from app.infrastructure.database.models.auth_models import Profile
+    return await Profile.create(
+        id=test_user_id,
+        display_name="test user",
+    )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -17,6 +17,13 @@ from tortoise import Tortoise
 if TYPE_CHECKING:
     from collections.abc import Generator
 
+    from app.domain.agents.service import AgentService
+    from app.domain.chat.service import ChatService
+    from app.infrastructure.database.models.auth_models import Profile
+    from app.infrastructure.repositories.agent_repo import AgentRepository
+    from app.infrastructure.repositories.chat_repo import ChatRepository
+    from app.infrastructure.repositories.memory_repo import MemoryRepository
+
 # ---------------------------------------------------------------------------
 # Required env vars — set before importing the app so Settings initialises.
 # ---------------------------------------------------------------------------
@@ -121,11 +128,11 @@ def authed_headers(test_user_id: Any) -> dict[str, str]:
 
 @pytest_asyncio.fixture
 async def chat_service(
-    chat_repo: "ChatRepository",
-    agent_repo: "AgentRepository",
-    memory_repo: "MemoryRepository",
-    agent_service: "AgentService"
-) -> "ChatService":
+    chat_repo: ChatRepository,
+    agent_repo: AgentRepository,
+    memory_repo: MemoryRepository,
+    agent_service: AgentService
+) -> ChatService:
     from app.domain.chat.service import ChatService
     return ChatService(
         chat_repo=chat_repo,
@@ -135,27 +142,27 @@ async def chat_service(
     )
 
 @pytest_asyncio.fixture
-async def chat_repo() -> "ChatRepository":
+async def chat_repo() -> ChatRepository:
     from app.infrastructure.repositories.chat_repo import ChatRepository
     return ChatRepository()
 
 @pytest_asyncio.fixture
-async def agent_repo() -> "AgentRepository":
+async def agent_repo() -> AgentRepository:
     from app.infrastructure.repositories.agent_repo import AgentRepository
     return AgentRepository()
 
 @pytest_asyncio.fixture
-async def memory_repo() -> "MemoryRepository":
+async def memory_repo() -> MemoryRepository:
     from app.infrastructure.repositories.memory_repo import MemoryRepository
     return MemoryRepository()
 
 @pytest_asyncio.fixture
-async def agent_service(agent_repo: "AgentRepository") -> "AgentService":
+async def agent_service(agent_repo: AgentRepository) -> AgentService:
     from app.domain.agents.service import AgentService
     return AgentService(repo=agent_repo)
 
 @pytest_asyncio.fixture
-async def test_user(test_user_id: str) -> "Profile":
+async def test_user(test_user_id: str) -> Profile:
     from app.infrastructure.database.models.auth_models import Profile
     return await Profile.create(
         id=test_user_id,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -126,44 +126,56 @@ def authed_headers(test_user_id: Any) -> dict[str, str]:
     """Authorization headers for the test user."""
     return auth_headers(user_id=test_user_id)
 
+
 @pytest_asyncio.fixture
 async def chat_service(
     chat_repo: ChatRepository,
     agent_repo: AgentRepository,
     memory_repo: MemoryRepository,
-    agent_service: AgentService
+    agent_service: AgentService,
 ) -> ChatService:
     from app.domain.chat.service import ChatService
+
     return ChatService(
         chat_repo=chat_repo,
         agent_repo=agent_repo,
         memory_repo=memory_repo,
-        agent_service=agent_service
+        agent_service=agent_service,
     )
+
 
 @pytest_asyncio.fixture
 async def chat_repo() -> ChatRepository:
     from app.infrastructure.repositories.chat_repo import ChatRepository
+
     return ChatRepository()
+
 
 @pytest_asyncio.fixture
 async def agent_repo() -> AgentRepository:
     from app.infrastructure.repositories.agent_repo import AgentRepository
+
     return AgentRepository()
+
 
 @pytest_asyncio.fixture
 async def memory_repo() -> MemoryRepository:
     from app.infrastructure.repositories.memory_repo import MemoryRepository
+
     return MemoryRepository()
+
 
 @pytest_asyncio.fixture
 async def agent_service(agent_repo: AgentRepository) -> AgentService:
     from app.domain.agents.service import AgentService
+
     return AgentService(repo=agent_repo)
+
 
 @pytest_asyncio.fixture
 async def test_user(test_user_id: str) -> Profile:
     from app.infrastructure.database.models.auth_models import Profile
+
     return await Profile.create(
         id=test_user_id,
         display_name="test user",

--- a/backend/tests/domain/chat/test_service.py
+++ b/backend/tests/domain/chat/test_service.py
@@ -9,9 +9,9 @@ from app.infrastructure.database.models.chat_models import ChatRoom, ChatRoomAge
 
 pytestmark = pytest.mark.asyncio
 
+
 async def test_chat_service_create_and_list_rooms(
-    chat_service: ChatService,
-    test_user: Profile
+    chat_service: ChatService, test_user: Profile
 ) -> None:
     # Arrange
     room_name = "Test Room"
@@ -30,16 +30,18 @@ async def test_chat_service_create_and_list_rooms(
     assert db_room.name == room_name
     assert db_room.user_id == test_user.id
 
+
 async def test_chat_service_update_and_delete_room(
-    chat_service: ChatService,
-    test_user: Profile
+    chat_service: ChatService, test_user: Profile
 ) -> None:
     # Arrange
     room = await chat_service.create_room(name="Initial Room", user_id=test_user.id)
 
     # Act - Update
     updated_name = "Updated Room"
-    updated_room = await chat_service.update_room(room_id=room.id, name=updated_name, user_id=test_user.id)
+    updated_room = await chat_service.update_room(
+        room_id=room.id, name=updated_name, user_id=test_user.id
+    )
 
     # Assert - Update
     assert updated_room is not None
@@ -57,9 +59,9 @@ async def test_chat_service_update_and_delete_room(
     db_room = await ChatRoom.get_or_none(id=room.id)
     assert db_room is None
 
+
 async def test_chat_service_add_and_remove_agent(
-    chat_service: ChatService,
-    test_user: Profile
+    chat_service: ChatService, test_user: Profile
 ) -> None:
     # Arrange
     room = await chat_service.create_room(name="Agent Room", user_id=test_user.id)
@@ -67,11 +69,13 @@ async def test_chat_service_add_and_remove_agent(
         user_id=test_user.id,
         name="Test Agent",
         system_prompt="You are a test agent.",
-        personality="Test personality"
+        personality="Test personality",
     )
 
     # Act - Add Agent
-    added_agent_entity = await chat_service.add_agent_to_room(room_id=room.id, agent_id=agent.id, user_id=test_user.id)
+    added_agent_entity = await chat_service.add_agent_to_room(
+        room_id=room.id, agent_id=agent.id, user_id=test_user.id
+    )
 
     # Assert - Add Agent
     assert added_agent_entity is not None
@@ -87,7 +91,9 @@ async def test_chat_service_add_and_remove_agent(
     assert listed_agents[0].id == agent.id
 
     # Act - Remove Agent
-    remove_result = await chat_service.remove_agent_from_room(room_id=room.id, agent_id=agent.id, user_id=test_user.id)
+    remove_result = await chat_service.remove_agent_from_room(
+        room_id=room.id, agent_id=agent.id, user_id=test_user.id
+    )
 
     # Assert - Remove Agent
     assert remove_result is True
@@ -95,18 +101,17 @@ async def test_chat_service_add_and_remove_agent(
     db_room_agent_deleted = await ChatRoomAgent.get_or_none(room_id=room.id, agent_id=agent.id)
     assert db_room_agent_deleted is None
 
+
 @patch("app.domain.chat.service.stream_chat")
 async def test_chat_service_stream_responses_timeout(
-    mock_stream_chat: AsyncMock,
-    chat_service: ChatService,
-    test_user: Profile
+    mock_stream_chat: AsyncMock, chat_service: ChatService, test_user: Profile
 ) -> None:
     # Arrange
     await AgentModel.create(
         user_id=test_user.id,
         name="Timeout Agent",
         system_prompt="You are a timeout agent.",
-        personality="Timeout personality"
+        personality="Timeout personality",
     )
     mock_stream_chat.side_effect = TimeoutError()
 
@@ -120,9 +125,9 @@ async def test_chat_service_stream_responses_timeout(
     assert "Connection timed out" in full_response
     assert "[[STATUS:error]]" in full_response
 
+
 async def test_chat_service_run_crew_no_agents(
-    chat_service: ChatService,
-    test_user: Profile
+    chat_service: ChatService, test_user: Profile
 ) -> None:
     # Arrange - Ensure no agents exist for the user
     await AgentModel.filter(user_id=test_user.id).delete()
@@ -134,27 +139,20 @@ async def test_chat_service_run_crew_no_agents(
     assert result["task_type"] == "error"
     assert result["result"] == "No agents available."
 
+
 @patch("app.infrastructure.websocket.manager.chat_hub.broadcast_to_room")
 async def test_chat_service_run_room_chat_ws_unauthorized(
-    mock_broadcast: AsyncMock,
-    chat_service: ChatService,
-    test_user: Profile
+    mock_broadcast: AsyncMock, chat_service: ChatService, test_user: Profile
 ) -> None:
     # Arrange
     # Create room with a DIFFERENT user ID
     from uuid import uuid4
-    other_user = await Profile.create(
-        id=uuid4(),
-        display_name="other"
-    )
+
+    other_user = await Profile.create(id=uuid4(), display_name="other")
     room = await chat_service.create_room(name="Unauthorized Room", user_id=other_user.id)
 
     # Act
-    await chat_service.run_room_chat_ws(
-        room_id=room.id,
-        user_message="Hello",
-        user_id=test_user.id
-    )
+    await chat_service.run_room_chat_ws(room_id=room.id, user_message="Hello", user_id=test_user.id)
 
     # Assert
     mock_broadcast.assert_called_once()

--- a/backend/tests/domain/chat/test_service.py
+++ b/backend/tests/domain/chat/test_service.py
@@ -1,0 +1,164 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.domain.agents.models import Agent as AgentModel
+from app.domain.chat.service import ChatService
+from app.infrastructure.database.models.auth_models import Profile
+from app.infrastructure.database.models.chat_models import ChatRoom, ChatRoomAgent
+
+pytestmark = pytest.mark.asyncio
+
+async def test_chat_service_create_and_list_rooms(
+    chat_service: ChatService,
+    test_user: Profile
+) -> None:
+    # Arrange
+    room_name = "Test Room"
+
+    # Act
+    created_room = await chat_service.create_room(name=room_name, user_id=test_user.id)
+    listed_rooms = await chat_service.list_rooms(user_id=test_user.id)
+
+    # Assert
+    assert created_room.name == room_name
+    assert len(listed_rooms) == 1
+    assert listed_rooms[0].id == created_room.id
+
+    # Verify via DB
+    db_room = await ChatRoom.get(id=created_room.id)
+    assert db_room.name == room_name
+    assert db_room.user_id == test_user.id
+
+async def test_chat_service_update_and_delete_room(
+    chat_service: ChatService,
+    test_user: Profile
+) -> None:
+    # Arrange
+    room = await chat_service.create_room(name="Initial Room", user_id=test_user.id)
+
+    # Act - Update
+    updated_name = "Updated Room"
+    updated_room = await chat_service.update_room(room_id=room.id, name=updated_name, user_id=test_user.id)
+
+    # Assert - Update
+    assert updated_room is not None
+    assert updated_room.name == updated_name
+
+    db_room = await ChatRoom.get(id=room.id)
+    assert db_room.name == updated_name
+
+    # Act - Delete
+    delete_result = await chat_service.delete_room(room_id=room.id, user_id=test_user.id)
+
+    # Assert - Delete
+    assert delete_result is True
+
+    db_room = await ChatRoom.get_or_none(id=room.id)
+    assert db_room is None
+
+async def test_chat_service_add_and_remove_agent(
+    chat_service: ChatService,
+    test_user: Profile
+) -> None:
+    # Arrange
+    room = await chat_service.create_room(name="Agent Room", user_id=test_user.id)
+    agent = await AgentModel.create(
+        user_id=test_user.id,
+        name="Test Agent",
+        system_prompt="You are a test agent.",
+        personality="Test personality"
+    )
+
+    # Act - Add Agent
+    added_agent_entity = await chat_service.add_agent_to_room(room_id=room.id, agent_id=agent.id, user_id=test_user.id)
+
+    # Assert - Add Agent
+    assert added_agent_entity is not None
+    assert added_agent_entity.agent_id == agent.id
+
+    db_room_agent = await ChatRoomAgent.get_or_none(room_id=room.id, agent_id=agent.id)
+    assert db_room_agent is not None
+
+    # Act - List Agents
+    listed_agents = await chat_service.list_room_agents(room_id=room.id, user_id=test_user.id)
+    assert listed_agents is not None
+    assert len(listed_agents) == 1
+    assert listed_agents[0].id == agent.id
+
+    # Act - Remove Agent
+    remove_result = await chat_service.remove_agent_from_room(room_id=room.id, agent_id=agent.id, user_id=test_user.id)
+
+    # Assert - Remove Agent
+    assert remove_result is True
+
+    db_room_agent_deleted = await ChatRoomAgent.get_or_none(room_id=room.id, agent_id=agent.id)
+    assert db_room_agent_deleted is None
+
+@patch("app.domain.chat.service.stream_chat")
+async def test_chat_service_stream_responses_timeout(
+    mock_stream_chat: AsyncMock,
+    chat_service: ChatService,
+    test_user: Profile
+) -> None:
+    # Arrange
+    await AgentModel.create(
+        user_id=test_user.id,
+        name="Timeout Agent",
+        system_prompt="You are a timeout agent.",
+        personality="Timeout personality"
+    )
+    mock_stream_chat.side_effect = TimeoutError()
+
+    # Act
+    chunks = []
+    async for chunk in chat_service.stream_responses(user_message="Hello", user_id=test_user.id):
+        chunks.append(chunk)
+
+    # Assert
+    full_response = "".join(chunks)
+    assert "Connection timed out" in full_response
+    assert "[[STATUS:error]]" in full_response
+
+async def test_chat_service_run_crew_no_agents(
+    chat_service: ChatService,
+    test_user: Profile
+) -> None:
+    # Arrange - Ensure no agents exist for the user
+    await AgentModel.filter(user_id=test_user.id).delete()
+
+    # Act
+    result = await chat_service.run_crew(user_message="Hello", user_id=test_user.id)
+
+    # Assert
+    assert result["task_type"] == "error"
+    assert result["result"] == "No agents available."
+
+@patch("app.infrastructure.websocket.manager.chat_hub.broadcast_to_room")
+async def test_chat_service_run_room_chat_ws_unauthorized(
+    mock_broadcast: AsyncMock,
+    chat_service: ChatService,
+    test_user: Profile
+) -> None:
+    # Arrange
+    # Create room with a DIFFERENT user ID
+    from uuid import uuid4
+    other_user = await Profile.create(
+        id=uuid4(),
+        display_name="other"
+    )
+    room = await chat_service.create_room(name="Unauthorized Room", user_id=other_user.id)
+
+    # Act
+    await chat_service.run_room_chat_ws(
+        room_id=room.id,
+        user_message="Hello",
+        user_id=test_user.id
+    )
+
+    # Assert
+    mock_broadcast.assert_called_once()
+    call_args = mock_broadcast.call_args[0]
+    assert call_args[0] == room.id
+    assert call_args[1]["type"] == "error"
+    assert "Unauthorized or room not found" in call_args[1]["data"]["message"]


### PR DESCRIPTION
This implements the required test coverage for the `ChatService` module bridging the `backend/app/domain/chat/service.py` logic.

### Changes
1. Added full Room lifecycle tests.
2. Added testing for Agent associations.
3. Implemented 'Chaos' test scenarios involving mock-induced API timeouts to handle API disconnects correctly.
4. Used `Profile` models correctly mimicking the underlying integration requirements.

---
*PR created automatically by Jules for task [9044660859062746501](https://jules.google.com/task/9044660859062746501) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broader automated coverage for chat room workflows, including creating, listing, updating, and deleting rooms.
  * Added checks for adding and removing agents from rooms.
  * Added coverage for chat streaming timeout handling and error messaging.
  * Added a room chat access test to verify unauthorized or missing-room cases return the expected error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->