### PR TITLE
Refactor stream_responses into StreamingOrchestrator

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import Depends
-
 from app.domain.agents.service import AgentService
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
@@ -15,6 +13,7 @@ from app.infrastructure.repositories.agent_repo import AgentRepository
 from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
 from app.infrastructure.repositories.memory_repo import MemoryRepository
+from fastapi import Depends
 
 # ---------------------------------------------------------------------------
 # Repository factories

--- a/backend/app/api/v1/agents.py
+++ b/backend/app/api/v1/agents.py
@@ -5,23 +5,16 @@ from __future__ import annotations
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
-
 from app.api.dependencies import get_agent_service
 from app.api.errors import raise_api_error
 from app.core.security.auth import CurrentUser  # noqa: TCH001
 from app.domain.agents.models import Capability, Integration
-from app.domain.agents.schemas import (
-    AgentCreate,
-    AgentGenerate,
-    AgentGenerationResponse,
-    AgentResponse,
-    AgentTemplateResponse,
-    AgentUpdate,
-    CapabilityResponse,
-    IntegrationResponse,
-)
+from app.domain.agents.schemas import (AgentCreate, AgentGenerate,
+                                       AgentGenerationResponse, AgentResponse,
+                                       AgentTemplateResponse, AgentUpdate,
+                                       CapabilityResponse, IntegrationResponse)
 from app.domain.agents.service import AgentService  # noqa: TCH001
+from fastapi import APIRouter, Depends, Query
 
 router = APIRouter(tags=["Agents"])
 

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -4,19 +4,15 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException
-
 from app.api.dependencies import get_auth_service
 from app.core.security.auth import CurrentUser  # noqa: TCH001
-from app.domain.auth.schemas import (
-    PasskeyLoginOptionsRequest,
-    PasskeyLoginVerifyRequest,
-    PasskeyPaginatedResponse,
-    PasskeyRecord,
-    PasskeyRegisterOptionsRequest,
-    PasskeyRegisterVerifyRequest,
-)
+from app.domain.auth.schemas import (PasskeyLoginOptionsRequest,
+                                     PasskeyLoginVerifyRequest,
+                                     PasskeyPaginatedResponse, PasskeyRecord,
+                                     PasskeyRegisterOptionsRequest,
+                                     PasskeyRegisterVerifyRequest)
 from app.domain.auth.service import AuthService  # noqa: TCH001
+from fastapi import APIRouter, Depends, HTTPException
 
 router = APIRouter(tags=["Auth"])
 

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -5,24 +5,17 @@ from __future__ import annotations
 from typing import Annotated
 from uuid import UUID  # noqa: TCH003
 
-from fastapi import APIRouter, Depends, Header, Query
-from fastapi.responses import StreamingResponse
-
 from app.api.dependencies import get_chat_service
 from app.api.errors import raise_api_error
 from app.core.security.auth import CurrentUser  # noqa: TCH001
 from app.domain.agents.schemas import AgentResponse
-from app.domain.chat.dtos import (
-    AddAgentToRoom,
-    ChatMessageResponse,
-    ChatRequest,
-    MessageUpdate,
-    RoomCreate,
-    RoomResponse,
-    RoomSummaryResponse,
-    RoomUpdate,
-)
+from app.domain.chat.dtos import (AddAgentToRoom, ChatMessageResponse,
+                                  ChatRequest, MessageUpdate, RoomCreate,
+                                  RoomResponse, RoomSummaryResponse,
+                                  RoomUpdate)
 from app.domain.chat.service import ChatService  # noqa: TCH001
+from fastapi import APIRouter, Depends, Header, Query
+from fastapi.responses import StreamingResponse
 
 router = APIRouter(tags=["Chat"])
 

--- a/backend/app/api/v1/integrations.py
+++ b/backend/app/api/v1/integrations.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
-
 from app.core.security.auth import CurrentUser  # noqa: TCH001
-from app.infrastructure.external.steam import get_player_summaries, resolve_vanity_url
+from app.infrastructure.external.steam import (get_player_summaries,
+                                               resolve_vanity_url)
+from fastapi import APIRouter, HTTPException
 
 router = APIRouter(tags=["Integrations"])
 

--- a/backend/app/api/v1/memory.py
+++ b/backend/app/api/v1/memory.py
@@ -7,14 +7,14 @@ import logging
 from typing import Annotated, Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
-from openai import APIConnectionError, APITimeoutError
-
 from app.api.dependencies import get_memory_service
 from app.core.security.auth import CurrentUser  # noqa: TCH001
 from app.domain.memory.models import Memory
-from app.domain.memory.schemas import MemoryRequest, MemoryResponse  # noqa: TCH001
+from app.domain.memory.schemas import (MemoryRequest,  # noqa: TCH001
+                                       MemoryResponse)
 from app.domain.memory.service import MemoryService  # noqa: TCH001
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from openai import APIConnectionError, APITimeoutError
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["Memory"])

--- a/backend/app/api/v1/notifications.py
+++ b/backend/app/api/v1/notifications.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, status
-
 from app.core.security.auth import CurrentUser
-from app.domain.notifications.interfaces.notification_client import INotificationClient
+from app.domain.notifications.interfaces.notification_client import \
+    INotificationClient
 from app.domain.notifications.schemas import NotificationRequest
-from app.domain.notifications.use_cases.send_notification import SendNotificationUseCase
-from app.infrastructure.notifications.azure_hubs import AzureNotificationHubClient
+from app.domain.notifications.use_cases.send_notification import \
+    SendNotificationUseCase
+from app.infrastructure.notifications.azure_hubs import \
+    AzureNotificationHubClient
+from fastapi import APIRouter, Depends, HTTPException, status
 
 router = APIRouter(tags=["notifications"])
 

--- a/backend/app/api/v1/productivity/__init__.py
+++ b/backend/app/api/v1/productivity/__init__.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
-
-from app.api.v1.productivity.calendar_events import router as calendar_events_router
+from app.api.v1.productivity.calendar_events import \
+    router as calendar_events_router
 from app.api.v1.productivity.notes import router as notes_router
 from app.api.v1.productivity.tasks import router as tasks_router
+from fastapi import APIRouter
 
 router = APIRouter()
 

--- a/backend/app/api/v1/productivity/calendar_events.py
+++ b/backend/app/api/v1/productivity/calendar_events.py
@@ -6,21 +6,16 @@ import logging
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
-
 from app.api.errors import raise_api_error
 from app.core.security.auth import CurrentUser
 from app.domain.productivity.dependencies import get_productivity_use_case
-from app.domain.productivity.schemas import (
-    CalendarEventCreate,
-    CalendarEventResponse,
-    CalendarEventUpdate,
-)
+from app.domain.productivity.schemas import (CalendarEventCreate,
+                                             CalendarEventResponse,
+                                             CalendarEventUpdate)
 from app.domain.productivity.use_cases.manage_productivity import (
-    CalendarEventNotFoundError,
-    InvalidTimeRangeError,
-    ManageProductivityUseCase,
-)
+    CalendarEventNotFoundError, InvalidTimeRangeError,
+    ManageProductivityUseCase)
+from fastapi import APIRouter, Depends, Query
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/api/v1/productivity/notes.py
+++ b/backend/app/api/v1/productivity/notes.py
@@ -6,16 +6,14 @@ import logging
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
-
 from app.api.errors import raise_api_error
 from app.core.security.auth import CurrentUser
 from app.domain.productivity.dependencies import get_productivity_use_case
-from app.domain.productivity.schemas import NoteCreate, NoteResponse, NoteUpdate
+from app.domain.productivity.schemas import (NoteCreate, NoteResponse,
+                                             NoteUpdate)
 from app.domain.productivity.use_cases.manage_productivity import (
-    ManageProductivityUseCase,
-    NoteNotFoundError,
-)
+    ManageProductivityUseCase, NoteNotFoundError)
+from fastapi import APIRouter, Depends, Query
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/api/v1/productivity/tasks.py
+++ b/backend/app/api/v1/productivity/tasks.py
@@ -6,16 +6,14 @@ import logging
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
-
 from app.api.errors import raise_api_error
 from app.core.security.auth import CurrentUser
 from app.domain.productivity.dependencies import get_productivity_use_case
-from app.domain.productivity.schemas import TaskCreate, TaskResponse, TaskUpdate
+from app.domain.productivity.schemas import (TaskCreate, TaskResponse,
+                                             TaskUpdate)
 from app.domain.productivity.use_cases.manage_productivity import (
-    ManageProductivityUseCase,
-    TaskNotFoundError,
-)
+    ManageProductivityUseCase, TaskNotFoundError)
+from fastapi import APIRouter, Depends, Query
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/api/v1/websocket.py
+++ b/backend/app/api/v1/websocket.py
@@ -27,8 +27,6 @@ import json
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
-
 from app.domain.agents.service import AgentService
 from app.domain.auth.service import AuthService
 from app.domain.chat.service import ChatService
@@ -38,6 +36,7 @@ from app.infrastructure.repositories.auth_repo import AuthRepository
 from app.infrastructure.repositories.chat_repo import ChatRepository
 from app.infrastructure.repositories.memory_repo import MemoryRepository
 from app.infrastructure.websocket.manager import chat_hub
+from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
 router = APIRouter(tags=["WebSocket"])
 logger = logging.getLogger(__name__)

--- a/backend/app/core/security/auth.py
+++ b/backend/app/core/security/auth.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import Depends, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-
 from app.api.dependencies import get_auth_service
 from app.api.errors import raise_api_error
 from app.domain.auth.service import AuthService  # noqa: TCH001
+from fastapi import Depends, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 # HTTPBearer extracts the Bearer token from the Authorization header.
 _bearer = HTTPBearer(auto_error=True)

--- a/backend/app/domain/agent_tools/models.py
+++ b/backend/app/domain/agent_tools/models.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from tortoise import fields
-
 from app.infrastructure.database.base import SupabaseModel
+from tortoise import fields
 
 if TYPE_CHECKING:
     from app.domain.agents.models import Agent

--- a/backend/app/domain/agent_tools/productivity/__init__.py
+++ b/backend/app/domain/agent_tools/productivity/__init__.py
@@ -1,24 +1,12 @@
 from __future__ import annotations
 
-from .events_tools import (
-    CreateEventInput,
-    CreateEventTool,
-    DeleteEventInput,
-    DeleteEventTool,
-    ListEventsInput,
-    ListEventsTool,
-    UpdateEventInput,
-    UpdateEventTool,
-)
-from .notes_tools import CreateNoteInput, CreateNoteTool, ListNotesInput, ListNotesTool
-from .tasks_tools import (
-    CreateTaskInput,
-    CreateTaskTool,
-    ListTasksInput,
-    ListTasksTool,
-    UpdateTaskInput,
-    UpdateTaskTool,
-)
+from .events_tools import (CreateEventInput, CreateEventTool, DeleteEventInput,
+                           DeleteEventTool, ListEventsInput, ListEventsTool,
+                           UpdateEventInput, UpdateEventTool)
+from .notes_tools import (CreateNoteInput, CreateNoteTool, ListNotesInput,
+                          ListNotesTool)
+from .tasks_tools import (CreateTaskInput, CreateTaskTool, ListTasksInput,
+                          ListTasksTool, UpdateTaskInput, UpdateTaskTool)
 
 __all__ = [
     "CreateEventInput",

--- a/backend/app/domain/agent_tools/productivity/events_tools.py
+++ b/backend/app/domain/agent_tools/productivity/events_tools.py
@@ -5,14 +5,11 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from crewai.tools import BaseTool
-from pydantic import BaseModel, Field
-
 from app.domain.productivity.dependencies import get_productivity_use_case
 from app.domain.productivity.use_cases.manage_productivity import (
-    CalendarEventNotFoundError,
-    InvalidTimeRangeError,
-)
+    CalendarEventNotFoundError, InvalidTimeRangeError)
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/domain/agent_tools/productivity/notes_tools.py
+++ b/backend/app/domain/agent_tools/productivity/notes_tools.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import logging
 from uuid import UUID
 
-from crewai.tools import BaseTool
-from pydantic import BaseModel, Field
-
 from app.domain.productivity.dependencies import get_productivity_use_case
 from app.domain.productivity.schemas import NoteCreate
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/domain/agent_tools/productivity/tasks_tools.py
+++ b/backend/app/domain/agent_tools/productivity/tasks_tools.py
@@ -4,12 +4,12 @@ import logging
 from datetime import datetime
 from uuid import UUID
 
-from crewai.tools import BaseTool
-from pydantic import BaseModel, Field
-
 from app.domain.productivity.dependencies import get_productivity_use_case
 from app.domain.productivity.schemas import TaskCreate, TaskUpdate
-from app.domain.productivity.use_cases.manage_productivity import TaskNotFoundError
+from app.domain.productivity.use_cases.manage_productivity import \
+    TaskNotFoundError
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/domain/agent_tools/productivity_tools.py
+++ b/backend/app/domain/agent_tools/productivity_tools.py
@@ -1,25 +1,21 @@
 from __future__ import annotations
 
-from app.domain.agent_tools.productivity import (
-    CreateEventInput,
-    CreateEventTool,
-    CreateNoteInput,
-    CreateNoteTool,
-    CreateTaskInput,
-    CreateTaskTool,
-    DeleteEventInput,
-    DeleteEventTool,
-    ListEventsInput,
-    ListEventsTool,
-    ListNotesInput,
-    ListNotesTool,
-    ListTasksInput,
-    ListTasksTool,
-    UpdateEventInput,
-    UpdateEventTool,
-    UpdateTaskInput,
-    UpdateTaskTool,
-)
+from app.domain.agent_tools.productivity import (CreateEventInput,
+                                                 CreateEventTool,
+                                                 CreateNoteInput,
+                                                 CreateNoteTool,
+                                                 CreateTaskInput,
+                                                 CreateTaskTool,
+                                                 DeleteEventInput,
+                                                 DeleteEventTool,
+                                                 ListEventsInput,
+                                                 ListEventsTool,
+                                                 ListNotesInput, ListNotesTool,
+                                                 ListTasksInput, ListTasksTool,
+                                                 UpdateEventInput,
+                                                 UpdateEventTool,
+                                                 UpdateTaskInput,
+                                                 UpdateTaskTool)
 
 __all__ = [
     "CreateEventInput",

--- a/backend/app/domain/agents/models.py
+++ b/backend/app/domain/agents/models.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from tortoise import fields
-
 from app.infrastructure.database.base import SupabaseModel
+from tortoise import fields
 
 
 class Agent(SupabaseModel):

--- a/backend/app/domain/agents/schemas.py
+++ b/backend/app/domain/agents/schemas.py
@@ -6,7 +6,8 @@ from datetime import datetime
 from typing import Annotated, Any
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator
+from pydantic import (BaseModel, ConfigDict, Field, StringConstraints,
+                      field_validator)
 
 
 class CapabilityResponse(BaseModel):

--- a/backend/app/domain/agents/service.py
+++ b/backend/app/domain/agents/service.py
@@ -5,23 +5,18 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from app.domain.agents.models import Agent, AgentIntegration, Capability, Integration
-from app.domain.agents.schemas import (
-    AgentCreate,
-    AgentGenerationResponse,
-    AgentResponse,
-    AgentTemplateResponse,
-    AgentUpdate,
-    MoodResponse,
-)
+from app.domain.agents.models import (Agent, AgentIntegration, Capability,
+                                      Integration)
+from app.domain.agents.schemas import (AgentCreate, AgentGenerationResponse,
+                                       AgentResponse, AgentTemplateResponse,
+                                       AgentUpdate, MoodResponse)
 from app.infrastructure.external.openrouter import structured_completion
 
 if TYPE_CHECKING:
     from uuid import UUID
 
-    from openai.types.chat import ChatCompletionMessageParam
-
     from app.infrastructure.repositories.agent_repo import AgentRepository
+    from openai.types.chat import ChatCompletionMessageParam
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/domain/auth/service.py
+++ b/backend/app/domain/auth/service.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 import jwt
-
 from app.core.config import get_settings
 from app.domain.auth.entities import Passkey
 from app.domain.auth.schemas import JWTPayload

--- a/backend/app/domain/chat/background_service.py
+++ b/backend/app/domain/chat/background_service.py
@@ -11,12 +11,11 @@ from pydantic import BaseModel
 if TYPE_CHECKING:
     from uuid import UUID
 
-    from openai.types.chat import ChatCompletionMessageParam
-
     from app.domain.agents.models import Agent
     from app.domain.agents.service import AgentService
     from app.infrastructure.repositories.agent_repo import AgentRepository
     from app.infrastructure.repositories.memory_repo import MemoryRepository
+    from openai.types.chat import ChatCompletionMessageParam
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +70,8 @@ class ChatBackgroundService:
         agent_names: list[str],
     ) -> None:
         """Embed and store the conversation turn as memories for future retrieval."""
-        from app.domain.chat.websocket_broadcaster import ChatWebSocketBroadcaster
+        from app.domain.chat.websocket_broadcaster import \
+            ChatWebSocketBroadcaster
         from app.domain.memory.models import Memory
         from app.infrastructure.external.openrouter import embed
 
@@ -120,7 +120,8 @@ class ChatBackgroundService:
         if not self.chat_repo:
             return
 
-        from app.infrastructure.external.openrouter import structured_completion
+        from app.infrastructure.external.openrouter import \
+            structured_completion
 
         try:
             # Check if history is getting long enough to warrant a summary

--- a/backend/app/domain/chat/crew_orchestrator.py
+++ b/backend/app/domain/chat/crew_orchestrator.py
@@ -7,40 +7,29 @@ import logging
 from typing import TYPE_CHECKING, Any, cast
 
 import crewai
-from crewai import LLM, Crew, Process, Task
-
 from app.core.config import get_settings
-from app.domain.agent_tools.productivity_tools import (
-    CreateEventTool,
-    CreateNoteTool,
-    CreateTaskTool,
-    DeleteEventTool,
-    ListEventsTool,
-    ListNotesTool,
-    ListTasksTool,
-    UpdateEventTool,
-    UpdateTaskTool,
-)
+from app.domain.agent_tools.productivity_tools import (CreateEventTool,
+                                                       CreateNoteTool,
+                                                       CreateTaskTool,
+                                                       DeleteEventTool,
+                                                       ListEventsTool,
+                                                       ListNotesTool,
+                                                       ListTasksTool,
+                                                       UpdateEventTool,
+                                                       UpdateTaskTool)
 from app.domain.chat.language import resolve_language
-from app.domain.chat.prompts import (
-    HISTORY_PREFIX,
-    MEMORY_PREFIX,
-    MULTI_AGENT_EXPECTED_OUTPUT,
-    MULTI_AGENT_PROMPT,
-    SINGLE_AGENT_EXPECTED_OUTPUT,
-    SINGLE_AGENT_PROMPT,
-    SUMMARY_PREFIX,
-)
-from app.infrastructure.external.discord_tool import (
-    DiscordGetServerInfoTool,
-    DiscordSendMessageTool,
-)
+from app.domain.chat.prompts import (HISTORY_PREFIX, MEMORY_PREFIX,
+                                     MULTI_AGENT_EXPECTED_OUTPUT,
+                                     MULTI_AGENT_PROMPT,
+                                     SINGLE_AGENT_EXPECTED_OUTPUT,
+                                     SINGLE_AGENT_PROMPT, SUMMARY_PREFIX)
+from app.infrastructure.external.discord_tool import (DiscordGetServerInfoTool,
+                                                      DiscordSendMessageTool)
 from app.infrastructure.external.spotify_tool import (
-    SpotifyCurrentlyPlayingTool,
-    SpotifyRecentlyPlayedTool,
-    SpotifySearchTool,
-)
-from app.infrastructure.external.steam_tool import SteamOwnedGamesTool, SteamPlayerSummaryTool
+    SpotifyCurrentlyPlayingTool, SpotifyRecentlyPlayedTool, SpotifySearchTool)
+from app.infrastructure.external.steam_tool import (SteamOwnedGamesTool,
+                                                    SteamPlayerSummaryTool)
+from crewai import LLM, Crew, Process, Task
 
 if TYPE_CHECKING:
     from uuid import UUID

--- a/backend/app/domain/chat/service.py
+++ b/backend/app/domain/chat/service.py
@@ -17,8 +17,8 @@ from app.domain.chat.dtos import (
     RoomResponse,
     RoomSummaryResponse,
 )
+from app.domain.chat.streaming_orchestrator import StreamingOrchestrator
 from app.domain.chat.websocket_broadcaster import ChatWebSocketBroadcaster
-from app.infrastructure.external.openrouter import stream_chat
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -207,49 +207,10 @@ class ChatService:
         self, user_message: str, user_id: UUID, accept_language: str | None = None
     ) -> AsyncIterator[str]:
         """A simple non-room chat stream for general queries using the first available agent."""
-        db_agents = await self.agent_repo.list_by_user(user_id)
-        if not db_agents:
-            yield "No agents available. Please create one first."
-            return
-
-        agent = db_agents[0]
-        model_name = get_settings().default_chat_model
-
-        messages: list[ChatCompletionMessageParam] = [
-            {"role": "system", "content": agent.personality}
-        ]
-        if accept_language:
-            messages.append(
-                {
-                    "role": "system",
-                    "content": f"IMPORTANT: Please respond in the following language locale: {accept_language}",
-                }
-            )
-        messages.append({"role": "user", "content": user_message})
-
-        try:
-            response = await stream_chat(
-                model=model_name,
-                messages=messages,
-            )
-
-            async for chunk in response:
-                if not chunk.choices:
-                    continue
-                delta_content = chunk.choices[0].delta.content
-                if delta_content:
-                    yield delta_content
-            yield "[[STATUS:done]]\n"
-        except TimeoutError:
-            logger.warning("Timeout connecting to AI service for user=%s", user_id)
-            yield "\n[[STATUS:error]]\nConnection timed out. Please try again later.\n"
-        except Exception as e:
-            if isinstance(e, (openai.APIConnectionError, openai.APITimeoutError, OSError)):
-                logger.warning("Connection error to AI service for user=%s", user_id)
-                yield "\n[[STATUS:error]]\nConnection error. Please try again later.\n"
-            else:
-                logger.exception("Unexpected error in chat stream for user=%s", user_id)
-                yield "\n[[STATUS:error]]\nAn unexpected error occurred.\n"
+        async for chunk in StreamingOrchestrator.stream_responses(
+            self.agent_repo, user_message, user_id, accept_language
+        ):
+            yield chunk
 
     async def run_crew(
         self, user_message: str, user_id: UUID, accept_language: str | None = None

--- a/backend/app/domain/chat/service.py
+++ b/backend/app/domain/chat/service.py
@@ -6,17 +6,11 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
-import openai
-
-from app.core.config import get_settings
 from app.domain.chat.background_service import ChatBackgroundService
 from app.domain.chat.crew_orchestrator import CrewOrchestrator
-from app.domain.chat.dtos import (
-    ChatMessageResponse,
-    RoomAgentSummaryResponse,
-    RoomResponse,
-    RoomSummaryResponse,
-)
+from app.domain.chat.dtos import (ChatMessageResponse,
+                                  RoomAgentSummaryResponse, RoomResponse,
+                                  RoomSummaryResponse)
 from app.domain.chat.streaming_orchestrator import StreamingOrchestrator
 from app.domain.chat.websocket_broadcaster import ChatWebSocketBroadcaster
 
@@ -24,11 +18,10 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
     from uuid import UUID
 
-    from openai.types.chat import ChatCompletionMessageParam
-
     from app.domain.agents.models import Agent
     from app.domain.agents.service import AgentService
-    from app.domain.chat.entities import ChatMessageEntity, ChatRoomAgentEntity, ChatRoomEntity
+    from app.domain.chat.entities import (ChatMessageEntity,
+                                          ChatRoomAgentEntity, ChatRoomEntity)
     from app.infrastructure.repositories.agent_repo import AgentRepository
     from app.infrastructure.repositories.chat_repo import ChatRepository
     from app.infrastructure.repositories.memory_repo import MemoryRepository
@@ -260,7 +253,8 @@ class ChatService:
         accept_language: str | None = None,
     ) -> None:
         """Process a room message and push all updates via the WebSocket hub."""
-        from app.infrastructure.websocket.manager import chat_hub  # noqa: PLC0415
+        from app.infrastructure.websocket.manager import \
+            chat_hub  # noqa: PLC0415
 
         if not await self.user_in_room(user_id, room_id):
             await chat_hub.broadcast_to_room(
@@ -294,7 +288,8 @@ class ChatService:
         # 4. Retrieve relevant memories via vector similarity for extra context.
         memory_context: str | None = None
         try:
-            from app.infrastructure.external.openrouter import embed  # noqa: PLC0415
+            from app.infrastructure.external.openrouter import \
+                embed  # noqa: PLC0415
 
             query_vector = await embed(user_message)
             memories = await self.memory_repo.match_memories(

--- a/backend/app/domain/chat/streaming_orchestrator.py
+++ b/backend/app/domain/chat/streaming_orchestrator.py
@@ -1,0 +1,77 @@
+"""Chat streaming orchestrator."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import openai
+
+from app.core.config import get_settings
+from app.infrastructure.external.openrouter import stream_chat
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from uuid import UUID
+
+    from openai.types.chat import ChatCompletionMessageParam
+
+    from app.infrastructure.repositories.agent_repo import AgentRepository
+
+logger = logging.getLogger(__name__)
+
+
+class StreamingOrchestrator:
+    """Orchestrates direct streaming interactions for non-room chat."""
+
+    @staticmethod
+    async def stream_responses(
+        agent_repo: AgentRepository,
+        user_message: str,
+        user_id: UUID,
+        accept_language: str | None = None,
+    ) -> AsyncIterator[str]:
+        """A simple non-room chat stream for general queries using the first available agent."""
+        db_agents = await agent_repo.list_by_user(user_id)
+        if not db_agents:
+            yield "No agents available. Please create one first."
+            return
+
+        agent = db_agents[0]
+        model_name = get_settings().default_chat_model
+
+        messages: list[ChatCompletionMessageParam] = [
+            {"role": "system", "content": agent.personality}
+        ]
+        if accept_language:
+            messages.append(
+                {
+                    "role": "system",
+                    "content": f"IMPORTANT: Please respond in the following language locale: {accept_language}",
+                }
+            )
+        messages.append({"role": "user", "content": user_message})
+
+        try:
+            response = await stream_chat(
+                model=model_name,
+                messages=messages,
+            )
+
+            async for chunk in response:
+                if not chunk.choices:
+                    continue
+                delta_content = chunk.choices[0].delta.content
+                if delta_content:
+                    yield delta_content
+            yield "[[STATUS:done]]\n"
+        except TimeoutError:
+            logger.warning("Timeout connecting to AI service for user=%s", user_id)
+            yield "\n[[STATUS:error]]\nConnection timed out. Please try again later.\n"
+        except Exception as e:
+            if isinstance(e, (openai.APIConnectionError, openai.APITimeoutError, OSError)):
+                logger.warning("Connection error to AI service for user=%s", user_id)
+                yield "\n[[STATUS:error]]\nConnection error. Please try again later.\n"
+            else:
+                logger.exception("Unexpected error in chat stream for user=%s", user_id)
+                yield "\n[[STATUS:error]]\nAn unexpected error occurred.\n"

--- a/backend/app/domain/chat/streaming_orchestrator.py
+++ b/backend/app/domain/chat/streaming_orchestrator.py
@@ -6,7 +6,6 @@ import logging
 from typing import TYPE_CHECKING
 
 import openai
-
 from app.core.config import get_settings
 from app.infrastructure.external.openrouter import stream_chat
 
@@ -14,9 +13,8 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
     from uuid import UUID
 
-    from openai.types.chat import ChatCompletionMessageParam
-
     from app.infrastructure.repositories.agent_repo import AgentRepository
+    from openai.types.chat import ChatCompletionMessageParam
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/domain/chat/websocket_broadcaster.py
+++ b/backend/app/domain/chat/websocket_broadcaster.py
@@ -34,7 +34,8 @@ class ChatWebSocketBroadcaster:
         client_temp_id: str | None = None,
     ) -> ChatMessageEntity:
         """Persist the user message and broadcast to room members."""
-        from app.infrastructure.websocket.manager import chat_hub  # noqa: PLC0415
+        from app.infrastructure.websocket.manager import \
+            chat_hub  # noqa: PLC0415
 
         user_msg = ChatMessageEntity(
             id=uuid.uuid4(), room_id=room_id, user_id=user_id, content=user_message
@@ -65,7 +66,8 @@ class ChatWebSocketBroadcaster:
 
     async def broadcast_thinking_status(self, room_id: UUID, agent_names: list[str]) -> None:
         """Broadcast thinking status to all room members."""
-        from app.infrastructure.websocket.manager import chat_hub  # noqa: PLC0415
+        from app.infrastructure.websocket.manager import \
+            chat_hub  # noqa: PLC0415
 
         await chat_hub.broadcast_to_room(
             room_id,
@@ -82,7 +84,8 @@ class ChatWebSocketBroadcaster:
 
     def create_step_callback(self, room_id: UUID, agent_names: list[str]) -> Callable[[Any], None]:
         """Create a callback for CrewAI to broadcast live activity."""
-        from app.infrastructure.websocket.manager import chat_hub  # noqa: PLC0415
+        from app.infrastructure.websocket.manager import \
+            chat_hub  # noqa: PLC0415
 
         loop = asyncio.get_running_loop()
 
@@ -190,9 +193,9 @@ class ChatWebSocketBroadcaster:
         Returns the list of agents who actually produced a response segment so
         that the caller can run per-agent post-processing (mood, affinity, etc.).
         """
+        from app.infrastructure.websocket.manager import \
+            chat_hub  # noqa: PLC0415
         from tortoise.exceptions import BaseORMException
-
-        from app.infrastructure.websocket.manager import chat_hub  # noqa: PLC0415
 
         agent_by_name = {a.name.lower(): a for a in room_agents}
         segments = self.parse_transcript(result_text, agent_names)

--- a/backend/app/domain/memory/graph_service.py
+++ b/backend/app/domain/memory/graph_service.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import logging
 from uuid import UUID
 
-from pydantic import BaseModel, Field
-
 from app.domain.memory.models import MemoryGraphEdge, MemoryGraphNode
+from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +40,8 @@ class GraphExtractionService:
     async def extract_graph_from_text(text: str) -> GraphExtractionSchema | None:
         """Use LLM structured output to extract graph nodes and edges from text."""
         try:
-            from app.infrastructure.external.openrouter import structured_completion
+            from app.infrastructure.external.openrouter import \
+                structured_completion
 
             # Using gpt-4o-mini for fast/cheap structured extraction
             return await structured_completion(

--- a/backend/app/domain/memory/models.py
+++ b/backend/app/domain/memory/models.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from tortoise import fields
-
 from app.infrastructure.database.base import SupabaseModel
+from tortoise import fields
 
 
 class MemoryCollection(SupabaseModel):

--- a/backend/app/domain/memory/service.py
+++ b/backend/app/domain/memory/service.py
@@ -72,7 +72,8 @@ class MemoryService:
             try:
                 import asyncio
 
-                from app.domain.memory.graph_service import GraphExtractionService
+                from app.domain.memory.graph_service import \
+                    GraphExtractionService
 
                 asyncio.create_task(  # noqa: RUF006
                     GraphExtractionService.process_and_store_graph(content, u_id)

--- a/backend/app/domain/notifications/use_cases/send_notification.py
+++ b/backend/app/domain/notifications/use_cases/send_notification.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import logging
 
-from app.domain.notifications.interfaces.notification_client import INotificationClient
+from app.domain.notifications.interfaces.notification_client import \
+    INotificationClient
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/domain/productivity/dependencies.py
+++ b/backend/app/domain/productivity/dependencies.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from app.domain.productivity.use_cases.manage_productivity import ManageProductivityUseCase
-from app.infrastructure.repositories.productivity_repo import ProductivityRepository
+from app.domain.productivity.use_cases.manage_productivity import \
+    ManageProductivityUseCase
+from app.infrastructure.repositories.productivity_repo import \
+    ProductivityRepository
 
 
 def get_productivity_use_case() -> ManageProductivityUseCase:

--- a/backend/app/domain/productivity/interfaces/repository.py
+++ b/backend/app/domain/productivity/interfaces/repository.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from typing import Protocol
 from uuid import UUID
 
-from app.domain.productivity.entities import CalendarEventEntity, NoteEntity, TaskEntity
-from app.domain.productivity.schemas import CalendarEventCreate, NoteCreate, TaskCreate
+from app.domain.productivity.entities import (CalendarEventEntity, NoteEntity,
+                                              TaskEntity)
+from app.domain.productivity.schemas import (CalendarEventCreate, NoteCreate,
+                                             TaskCreate)
 
 
 class IProductivityRepository(Protocol):

--- a/backend/app/domain/productivity/models.py
+++ b/backend/app/domain/productivity/models.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from tortoise import fields
-
 from app.infrastructure.database.base import SupabaseModel
+from tortoise import fields
 
 if TYPE_CHECKING:
     from app.domain.agents.models import Agent

--- a/backend/app/domain/productivity/schemas.py
+++ b/backend/app/domain/productivity/schemas.py
@@ -6,7 +6,8 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (AliasChoices, BaseModel, ConfigDict, Field,
+                      field_validator, model_validator)
 
 
 def extract_uuid_from_relation(v: Any) -> UUID | None:

--- a/backend/app/domain/productivity/use_cases/manage_productivity.py
+++ b/backend/app/domain/productivity/use_cases/manage_productivity.py
@@ -5,16 +5,14 @@ from __future__ import annotations
 import logging
 from uuid import UUID
 
-from app.domain.productivity.entities import CalendarEventEntity, NoteEntity, TaskEntity
-from app.domain.productivity.interfaces.repository import IProductivityRepository
-from app.domain.productivity.schemas import (
-    CalendarEventCreate,
-    CalendarEventUpdate,
-    NoteCreate,
-    NoteUpdate,
-    TaskCreate,
-    TaskUpdate,
-)
+from app.domain.productivity.entities import (CalendarEventEntity, NoteEntity,
+                                              TaskEntity)
+from app.domain.productivity.interfaces.repository import \
+    IProductivityRepository
+from app.domain.productivity.schemas import (CalendarEventCreate,
+                                             CalendarEventUpdate, NoteCreate,
+                                             NoteUpdate, TaskCreate,
+                                             TaskUpdate)
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/infrastructure/database/migrations/generator.py
+++ b/backend/app/infrastructure/database/migrations/generator.py
@@ -9,12 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from app.infrastructure.database.migrations.constants import (
-    ALL_MODEL_MODULES,
-    CHECKSUM_FILE,
-    MIGRATIONS_DIR,
-    SEED_SQL,
-    SNAPSHOT_FILE,
-)
+    ALL_MODEL_MODULES, CHECKSUM_FILE, MIGRATIONS_DIR, SEED_SQL, SNAPSHOT_FILE)
 
 if TYPE_CHECKING:
     from tortoise.backends.asyncpg.client import AsyncpgDBClient
@@ -26,7 +21,8 @@ if TYPE_CHECKING:
 
 async def _generate_schema_sql() -> str:
     from tortoise import Tortoise
-    from tortoise.backends.asyncpg.schema_generator import AsyncpgSchemaGenerator
+    from tortoise.backends.asyncpg.schema_generator import \
+        AsyncpgSchemaGenerator
 
     await Tortoise.init(
         db_url="sqlite://:memory:",

--- a/backend/app/infrastructure/database/migrations/runner.py
+++ b/backend/app/infrastructure/database/migrations/runner.py
@@ -7,18 +7,12 @@ import subprocess
 import sys
 from pathlib import Path
 
-from app.infrastructure.database.migrations.constants import (
-    CHECKSUM_FILE,
-    ENV_STUBS,
-    MIGRATIONS_DIR,
-)
+from app.infrastructure.database.migrations.constants import (CHECKSUM_FILE,
+                                                              ENV_STUBS,
+                                                              MIGRATIONS_DIR)
 from app.infrastructure.database.migrations.generator import (
-    _collect_extras,
-    _content_checksum,
-    _file_checksum,
-    _generate_schema_sql,
-    _read_checksum,
-)
+    _collect_extras, _content_checksum, _file_checksum, _generate_schema_sql,
+    _read_checksum)
 
 # ---------------------------------------------------------------------------
 # Tracking table DDL — created once by ``migrate`` if it doesn't exist

--- a/backend/app/infrastructure/database/models/auth_models.py
+++ b/backend/app/infrastructure/database/models/auth_models.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from tortoise import fields
-
 from app.infrastructure.database.base import SupabaseModel
+from tortoise import fields
 
 
 class Profile(SupabaseModel):

--- a/backend/app/infrastructure/database/models/chat_models.py
+++ b/backend/app/infrastructure/database/models/chat_models.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
-from tortoise import fields
-
 from app.infrastructure.database.base import SupabaseModel
+from tortoise import fields
 
 
 class ChatRoom(SupabaseModel):

--- a/backend/app/infrastructure/database/supabase.py
+++ b/backend/app/infrastructure/database/supabase.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Annotated, Any
 
-from fastapi import Depends
-
 from app.core.config import get_settings
+from fastapi import Depends
 
 if TYPE_CHECKING:
     from supabase import Client

--- a/backend/app/infrastructure/database/tortoise.py
+++ b/backend/app/infrastructure/database/tortoise.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import urllib.parse
 
-from tortoise import Tortoise
-
 from app.core.config import get_settings
+from tortoise import Tortoise
 
 raw_url = get_settings().database_url or ""
 if raw_url.startswith("postgresql://"):

--- a/backend/app/infrastructure/database/utils.py
+++ b/backend/app/infrastructure/database/utils.py
@@ -7,10 +7,10 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import asyncpg.exceptions
-from fastapi import HTTPException
-from tortoise.exceptions import DBConnectionError, IntegrityError, OperationalError
-
 from app.api.errors import raise_api_error
+from fastapi import HTTPException
+from tortoise.exceptions import (DBConnectionError, IntegrityError,
+                                 OperationalError)
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/infrastructure/external/discord_tool.py
+++ b/backend/app/infrastructure/external/discord_tool.py
@@ -7,10 +7,9 @@ import json
 import logging
 
 import nest_asyncio
+from app.infrastructure.external.discord import get_server_info, send_message
 from crewai.tools import BaseTool
 from pydantic import Field
-
-from app.infrastructure.external.discord import get_server_info, send_message
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/infrastructure/external/openrouter.py
+++ b/backend/app/infrastructure/external/openrouter.py
@@ -8,10 +8,10 @@ import typing
 from typing import TYPE_CHECKING, TypeVar
 
 import openai
-from pydantic import BaseModel
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
-
 from app.core.config import get_settings
+from pydantic import BaseModel
+from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
+                      wait_exponential)
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/infrastructure/external/spotify_tool.py
+++ b/backend/app/infrastructure/external/spotify_tool.py
@@ -8,17 +8,14 @@ import logging
 import typing
 
 import nest_asyncio
+from app.infrastructure.external.spotify import (add_tracks_to_playlist,
+                                                 create_playlist,
+                                                 get_currently_playing,
+                                                 get_recently_played,
+                                                 get_recommendations,
+                                                 search_spotify)
 from crewai.tools import BaseTool
 from pydantic import Field
-
-from app.infrastructure.external.spotify import (
-    add_tracks_to_playlist,
-    create_playlist,
-    get_currently_playing,
-    get_recently_played,
-    get_recommendations,
-    search_spotify,
-)
 
 
 def _run_async_in_sync(coro: typing.Coroutine[typing.Any, typing.Any, typing.Any]) -> typing.Any:

--- a/backend/app/infrastructure/external/steam.py
+++ b/backend/app/infrastructure/external/steam.py
@@ -6,7 +6,6 @@ import logging
 from typing import Any
 
 import httpx
-
 from app.core.config import get_settings
 
 logger = logging.getLogger(__name__)

--- a/backend/app/infrastructure/external/steam_tool.py
+++ b/backend/app/infrastructure/external/steam_tool.py
@@ -6,10 +6,10 @@ import asyncio
 import json
 
 import nest_asyncio
+from app.infrastructure.external.steam import (get_owned_games,
+                                               get_player_summaries)
 from crewai.tools import BaseTool
 from pydantic import Field
-
-from app.infrastructure.external.steam import get_owned_games, get_player_summaries
 
 
 class SteamPlayerSummaryTool(BaseTool):

--- a/backend/app/infrastructure/notifications/azure_hubs.py
+++ b/backend/app/infrastructure/notifications/azure_hubs.py
@@ -5,10 +5,11 @@ import json
 import logging
 from typing import Any, cast
 
-from notificationhubs_rest_python.NotificationHub import AzureNotification, AzureNotificationHub
-
 from app.core.config import get_settings
-from app.domain.notifications.interfaces.notification_client import INotificationClient
+from app.domain.notifications.interfaces.notification_client import \
+    INotificationClient
+from notificationhubs_rest_python.NotificationHub import (AzureNotification,
+                                                          AzureNotificationHub)
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/infrastructure/repositories/agent_repo.py
+++ b/backend/app/infrastructure/repositories/agent_repo.py
@@ -6,15 +6,9 @@ import math
 from datetime import UTC, datetime
 from uuid import UUID
 
+from app.domain.agents.models import (Agent, AgentTemplate, Capability,
+                                      Integration, UserAgentAffinity)
 from tortoise.transactions import in_transaction
-
-from app.domain.agents.models import (
-    Agent,
-    AgentTemplate,
-    Capability,
-    Integration,
-    UserAgentAffinity,
-)
 
 
 class AgentRepository:

--- a/backend/app/infrastructure/repositories/chat_repo.py
+++ b/backend/app/infrastructure/repositories/chat_repo.py
@@ -6,12 +6,14 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
+from app.domain.agents.models import Agent
+from app.domain.chat.entities import (ChatMessageEntity, ChatRoomAgentEntity,
+                                      ChatRoomEntity)
+from app.infrastructure.database.models.chat_models import (ChatMessage,
+                                                            ChatRoom,
+                                                            ChatRoomAgent)
 from tortoise import Tortoise
 from tortoise.expressions import Q
-
-from app.domain.agents.models import Agent
-from app.domain.chat.entities import ChatMessageEntity, ChatRoomAgentEntity, ChatRoomEntity
-from app.infrastructure.database.models.chat_models import ChatMessage, ChatRoom, ChatRoomAgent
 
 
 def _map_room_to_entity(room: ChatRoom) -> ChatRoomEntity:

--- a/backend/app/infrastructure/repositories/memory_repo.py
+++ b/backend/app/infrastructure/repositories/memory_repo.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from uuid import UUID
 
+from app.domain.memory.models import Memory, MemoryRelationship
 from tortoise import Tortoise
 from tortoise.expressions import Q
-
-from app.domain.memory.models import Memory, MemoryRelationship
 
 
 class MemoryRepository:

--- a/backend/app/infrastructure/repositories/productivity_repo.py
+++ b/backend/app/infrastructure/repositories/productivity_repo.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
-from app.domain.productivity.entities import CalendarEventEntity, NoteEntity, TaskEntity
-from app.domain.productivity.interfaces.repository import IProductivityRepository
+from app.domain.productivity.entities import (CalendarEventEntity, NoteEntity,
+                                              TaskEntity)
+from app.domain.productivity.interfaces.repository import \
+    IProductivityRepository
 from app.domain.productivity.models import CalendarEvent, Note, Task
-from app.domain.productivity.schemas import CalendarEventCreate, NoteCreate, TaskCreate
+from app.domain.productivity.schemas import (CalendarEventCreate, NoteCreate,
+                                             TaskCreate)
 from app.infrastructure.database.utils import handle_db_errors
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,9 +6,6 @@ import logging
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, cast
 
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-
 from app.api.v1.agents import router as agents_router
 from app.api.v1.auth import router as auth_router
 from app.api.v1.chat import router as chat_router
@@ -19,6 +16,8 @@ from app.api.v1.productivity import router as productivity_router
 from app.api.v1.websocket import router as websocket_router
 from app.core.config import get_settings
 from app.infrastructure.database.tortoise import close_db, init_db
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -21,12 +21,10 @@ from app.infrastructure.database.migrations.constants import apply_env_stubs
 apply_env_stubs()
 
 # fmt: off
-from app.infrastructure.database.migrations.generator import cmd_makemigrations  # noqa: E402
+from app.infrastructure.database.migrations.generator import \
+    cmd_makemigrations  # noqa: E402
 from app.infrastructure.database.migrations.runner import (  # noqa: E402
-    cmd_check,
-    cmd_migrate,
-    cmd_status,
-)
+    cmd_check, cmd_migrate, cmd_status)
 
 # fmt: on
 

--- a/backend/tests/agents/test_agent_generation.py
+++ b/backend/tests/agents/test_agent_generation.py
@@ -4,7 +4,6 @@ import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
 from app.domain.agents.schemas import AgentGenerationResponse, MoodResponse
 from app.domain.agents.service import AgentService
 

--- a/backend/tests/agents/test_agent_lifecycle.py
+++ b/backend/tests/agents/test_agent_lifecycle.py
@@ -4,7 +4,6 @@ import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
 from app.domain.agents.models import AgentTemplate, Capability, Integration
 from app.domain.agents.schemas import AgentCreate, AgentUpdate
 from app.domain.agents.service import AgentService

--- a/backend/tests/app/domain/notifications/test_api.py
+++ b/backend/tests/app/domain/notifications/test_api.py
@@ -4,11 +4,11 @@ from collections.abc import Sequence
 from typing import Any
 
 import pytest
-from fastapi.testclient import TestClient
-
 from app.api.v1.notifications import get_notification_client
-from app.domain.notifications.interfaces.notification_client import INotificationClient
+from app.domain.notifications.interfaces.notification_client import \
+    INotificationClient
 from app.main import app
+from fastapi.testclient import TestClient
 
 
 class MockNotificationClient(INotificationClient):

--- a/backend/tests/app/domain/notifications/test_use_cases.py
+++ b/backend/tests/app/domain/notifications/test_use_cases.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-
-from app.domain.notifications.interfaces.notification_client import INotificationClient
-from app.domain.notifications.use_cases.send_notification import SendNotificationUseCase
+from app.domain.notifications.interfaces.notification_client import \
+    INotificationClient
+from app.domain.notifications.use_cases.send_notification import \
+    SendNotificationUseCase
 
 
 class MockNotificationClient(INotificationClient):

--- a/backend/tests/app/infrastructure/notifications/test_azure_hubs.py
+++ b/backend/tests/app/infrastructure/notifications/test_azure_hubs.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from app.core.config import Settings, get_settings
-from app.infrastructure.notifications.azure_hubs import AzureNotificationHubClient
+from app.infrastructure.notifications.azure_hubs import \
+    AzureNotificationHubClient
 
 
 @pytest.fixture

--- a/backend/tests/chat/conftest.py
+++ b/backend/tests/chat/conftest.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
-
 from app.domain.chat.service import ChatService
 
 

--- a/backend/tests/chat/test_chat_crew.py
+++ b/backend/tests/chat/test_chat_crew.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-
 from app.domain.chat.crew_orchestrator import CrewOrchestrator
 from app.domain.chat.service import ChatService
 

--- a/backend/tests/chat/test_chat_rooms.py
+++ b/backend/tests/chat/test_chat_rooms.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
-
 from app.domain.chat.entities import ChatMessageEntity, ChatRoomEntity
 from app.domain.chat.service import ChatService
 

--- a/backend/tests/chat/test_chat_ws.py
+++ b/backend/tests/chat/test_chat_ws.py
@@ -5,9 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from tortoise.exceptions import BaseORMException
-
 from app.domain.chat.service import ChatService
+from tortoise.exceptions import BaseORMException
 
 
 @pytest.mark.asyncio
@@ -16,7 +15,9 @@ async def test_stream_responses_timeout_error(chat_service: typing.Any) -> None:
     agent = MagicMock()
     agent.personality = "Helpful"
     chat_service.agent_repo.list_by_user.return_value = [agent]
-    with patch("app.domain.chat.streaming_orchestrator.stream_chat", new_callable=AsyncMock) as mock_stream_chat:
+    with patch(
+        "app.domain.chat.streaming_orchestrator.stream_chat", new_callable=AsyncMock
+    ) as mock_stream_chat:
         mock_stream_chat.side_effect = TimeoutError("Connection timed out")
         responses = []
         async for r in chat_service.stream_responses("Hi", user_id):
@@ -33,7 +34,9 @@ async def test_stream_responses_api_connection_error(chat_service: typing.Any) -
     agent = MagicMock()
     agent.personality = "Helpful"
     chat_service.agent_repo.list_by_user.return_value = [agent]
-    with patch("app.domain.chat.streaming_orchestrator.stream_chat", new_callable=AsyncMock) as mock_stream_chat:
+    with patch(
+        "app.domain.chat.streaming_orchestrator.stream_chat", new_callable=AsyncMock
+    ) as mock_stream_chat:
         request = httpx.Request("POST", "http://test")
         mock_stream_chat.side_effect = openai.APIConnectionError(request=request)
         responses = []
@@ -62,7 +65,9 @@ async def test_stream_responses(chat_service: typing.Any, monkeypatch: pytest.Mo
         yield chunk3
         yield chunk2
 
-    with patch("app.domain.chat.streaming_orchestrator.stream_chat", new_callable=AsyncMock) as mock_stream_chat:
+    with patch(
+        "app.domain.chat.streaming_orchestrator.stream_chat", new_callable=AsyncMock
+    ) as mock_stream_chat:
         mock_stream_chat.return_value = mock_async_generator()
         responses = []
         async for r in chat_service.stream_responses("Hi", user_id, accept_language="fr-FR"):

--- a/backend/tests/chat/test_chat_ws.py
+++ b/backend/tests/chat/test_chat_ws.py
@@ -16,7 +16,7 @@ async def test_stream_responses_timeout_error(chat_service: typing.Any) -> None:
     agent = MagicMock()
     agent.personality = "Helpful"
     chat_service.agent_repo.list_by_user.return_value = [agent]
-    with patch("app.domain.chat.service.stream_chat", new_callable=AsyncMock) as mock_stream_chat:
+    with patch("app.domain.chat.streaming_orchestrator.stream_chat", new_callable=AsyncMock) as mock_stream_chat:
         mock_stream_chat.side_effect = TimeoutError("Connection timed out")
         responses = []
         async for r in chat_service.stream_responses("Hi", user_id):
@@ -33,7 +33,7 @@ async def test_stream_responses_api_connection_error(chat_service: typing.Any) -
     agent = MagicMock()
     agent.personality = "Helpful"
     chat_service.agent_repo.list_by_user.return_value = [agent]
-    with patch("app.domain.chat.service.stream_chat", new_callable=AsyncMock) as mock_stream_chat:
+    with patch("app.domain.chat.streaming_orchestrator.stream_chat", new_callable=AsyncMock) as mock_stream_chat:
         request = httpx.Request("POST", "http://test")
         mock_stream_chat.side_effect = openai.APIConnectionError(request=request)
         responses = []
@@ -62,7 +62,7 @@ async def test_stream_responses(chat_service: typing.Any, monkeypatch: pytest.Mo
         yield chunk3
         yield chunk2
 
-    with patch("app.domain.chat.service.stream_chat", new_callable=AsyncMock) as mock_stream_chat:
+    with patch("app.domain.chat.streaming_orchestrator.stream_chat", new_callable=AsyncMock) as mock_stream_chat:
         mock_stream_chat.return_value = mock_async_generator()
         responses = []
         async for r in chat_service.stream_responses("Hi", user_id, accept_language="fr-FR"):

--- a/backend/tests/productivity/conftest.py
+++ b/backend/tests/productivity/conftest.py
@@ -5,11 +5,10 @@ from collections.abc import AsyncGenerator, Generator
 
 import pytest
 import pytest_asyncio
-from httpx import ASGITransport, AsyncClient
-
 from app.core.security.auth import get_current_user
 from app.domain.productivity.models import CalendarEvent, Note, Task
 from app.main import app
+from httpx import ASGITransport, AsyncClient
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -18,7 +17,8 @@ async def clear_productivity_db() -> AsyncGenerator[None]:
     await Note.all().delete()
     await CalendarEvent.all().delete()
     from app.domain.agents.models import Agent
-    from app.infrastructure.database.models.chat_models import ChatMessage, ChatRoom
+    from app.infrastructure.database.models.chat_models import (ChatMessage,
+                                                                ChatRoom)
 
     await Agent.all().delete()
     await ChatRoom.all().delete()
@@ -28,7 +28,8 @@ async def clear_productivity_db() -> AsyncGenerator[None]:
     await Note.all().delete()
     await CalendarEvent.all().delete()
     from app.domain.agents.models import Agent
-    from app.infrastructure.database.models.chat_models import ChatMessage, ChatRoom
+    from app.infrastructure.database.models.chat_models import (ChatMessage,
+                                                                ChatRoom)
 
     await Agent.all().delete()
     await ChatRoom.all().delete()

--- a/backend/tests/productivity/test_db_errors.py
+++ b/backend/tests/productivity/test_db_errors.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import pytest
-from tortoise.exceptions import IntegrityError
-
 from app.infrastructure.database.utils import handle_db_errors
+from tortoise.exceptions import IntegrityError
 
 
 @pytest.mark.asyncio

--- a/backend/tests/productivity/test_events.py
+++ b/backend/tests/productivity/test_events.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import uuid
 
 import pytest
-
 from app.domain.productivity.models import CalendarEvent
 
 
@@ -12,7 +11,8 @@ async def test_create_event(async_client, mock_user_id, override_get_current_use
     from datetime import UTC, datetime, timedelta
 
     from app.domain.agents.models import Agent
-    from app.infrastructure.database.models.chat_models import ChatMessage, ChatRoom
+    from app.infrastructure.database.models.chat_models import (ChatMessage,
+                                                                ChatRoom)
 
     now = datetime.now(UTC)
     agent = await Agent.create(
@@ -125,7 +125,8 @@ async def test_list_events_with_relations(async_client, mock_user_id, override_g
     from datetime import UTC, datetime, timedelta
 
     from app.domain.agents.models import Agent
-    from app.infrastructure.database.models.chat_models import ChatMessage, ChatRoom
+    from app.infrastructure.database.models.chat_models import (ChatMessage,
+                                                                ChatRoom)
 
     now = datetime.now(UTC)
     agent = await Agent.create(

--- a/backend/tests/productivity/test_notes.py
+++ b/backend/tests/productivity/test_notes.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import uuid
 
 import pytest
-
 from app.domain.productivity.models import Note
 
 

--- a/backend/tests/productivity/test_tasks.py
+++ b/backend/tests/productivity/test_tasks.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import uuid
 
 import pytest
-
 from app.domain.productivity.models import Task
 
 

--- a/backend/tests/test_agents_routes.py
+++ b/backend/tests/test_agents_routes.py
@@ -4,13 +4,12 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID
 
 import pytest
-from fastapi.testclient import TestClient
-
 from app.api.dependencies import get_agent_service
 from app.core.security.auth import get_current_user
 from app.domain.agents.models import Agent
 from app.domain.agents.service import _build_agent_response
 from app.main import app
+from fastapi.testclient import TestClient
 
 
 @pytest.fixture

--- a/backend/tests/test_api_coverage.py
+++ b/backend/tests/test_api_coverage.py
@@ -6,13 +6,10 @@ from unittest.mock import patch
 
 import httpx
 import pytest
-
 from app.infrastructure.external.discord import get_server_info, send_message
-from app.infrastructure.external.spotify import (
-    get_currently_playing,
-    get_recently_played,
-    search_spotify,
-)
+from app.infrastructure.external.spotify import (get_currently_playing,
+                                                 get_recently_played,
+                                                 search_spotify)
 
 
 @pytest.fixture

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock
 
 import jwt
 import pytest
-
 from app.domain.auth.schemas import JWTPayload
 from app.infrastructure.database.supabase import get_supabase
 from app.main import app

--- a/backend/tests/test_chat_background_service.py
+++ b/backend/tests/test_chat_background_service.py
@@ -4,7 +4,6 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from app.domain.chat.background_service import ChatBackgroundService
 
 

--- a/backend/tests/test_chat_routes.py
+++ b/backend/tests/test_chat_routes.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
-
 from app.api.dependencies import get_chat_service
 from app.core.security.auth import get_current_user
 from app.domain.chat.dtos import MessageUpdate

--- a/backend/tests/test_discord_api.py
+++ b/backend/tests/test_discord_api.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-
 from app.infrastructure.external.discord import get_server_info, send_message
 
 

--- a/backend/tests/test_discord_tool.py
+++ b/backend/tests/test_discord_tool.py
@@ -7,11 +7,8 @@ import typing
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
-from app.infrastructure.external.discord_tool import (
-    DiscordGetServerInfoTool,
-    DiscordSendMessageTool,
-)
+from app.infrastructure.external.discord_tool import (DiscordGetServerInfoTool,
+                                                      DiscordSendMessageTool)
 
 
 @pytest.fixture

--- a/backend/tests/test_discord_tool_more.py
+++ b/backend/tests/test_discord_tool_more.py
@@ -6,11 +6,8 @@ import typing
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
-from app.infrastructure.external.discord_tool import (
-    DiscordGetServerInfoTool,
-    DiscordSendMessageTool,
-)
+from app.infrastructure.external.discord_tool import (DiscordGetServerInfoTool,
+                                                      DiscordSendMessageTool)
 
 
 @pytest.fixture

--- a/backend/tests/test_document_service.py
+++ b/backend/tests/test_document_service.py
@@ -58,7 +58,6 @@ def test_extract_text_txt_latin1() -> None:
 
 def test_chunk_text_zero_chunk_size() -> None:
     import pytest
-
     from app.domain.memory.document_service import DocumentService
 
     with pytest.raises(ValueError, match="chunk_size must be greater than 0"):
@@ -67,7 +66,6 @@ def test_chunk_text_zero_chunk_size() -> None:
 
 def test_chunk_text_negative_overlap() -> None:
     import pytest
-
     from app.domain.memory.document_service import DocumentService
 
     with pytest.raises(ValueError, match="overlap must be non-negative"):

--- a/backend/tests/test_events_tools.py
+++ b/backend/tests/test_events_tools.py
@@ -6,13 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-
-from app.domain.agent_tools.productivity.events_tools import (
-    CreateEventTool,
-    DeleteEventTool,
-    ListEventsTool,
-    UpdateEventTool,
-)
+from app.domain.agent_tools.productivity.events_tools import (CreateEventTool,
+                                                              DeleteEventTool,
+                                                              ListEventsTool,
+                                                              UpdateEventTool)
 from app.domain.productivity.models import CalendarEvent
 
 

--- a/backend/tests/test_get_memory_graph.py
+++ b/backend/tests/test_get_memory_graph.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
-
 from app.domain.memory.service import MemoryService
 
 

--- a/backend/tests/test_graph_service.py
+++ b/backend/tests/test_graph_service.py
@@ -4,13 +4,10 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-from app.domain.memory.graph_service import (
-    GraphEntity,
-    GraphExtractionSchema,
-    GraphExtractionService,
-    GraphRelationship,
-)
+from app.domain.memory.graph_service import (GraphEntity,
+                                             GraphExtractionSchema,
+                                             GraphExtractionService,
+                                             GraphRelationship)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_infrastructure.py
+++ b/backend/tests/test_infrastructure.py
@@ -78,7 +78,8 @@ async def test_structured_completion_delegates_to_client() -> None:
             return_value=MagicMock(default_chat_model="test-model", openrouter_api_key="k"),
         ),
     ):
-        from app.infrastructure.external.openrouter import structured_completion
+        from app.infrastructure.external.openrouter import \
+            structured_completion
 
         result = await structured_completion([{"role": "user", "content": "Hi"}], MyModel)
     assert result.value == "ok"
@@ -91,7 +92,8 @@ async def test_structured_completion_delegates_to_client() -> None:
 
 @pytest.mark.asyncio
 async def test_client_chat_completion_delegates_to_structured() -> None:
-    from app.infrastructure.external.openrouter import ChatResponse, OpenRouterClient
+    from app.infrastructure.external.openrouter import (ChatResponse,
+                                                        OpenRouterClient)
 
     client = OpenRouterClient.__new__(OpenRouterClient)
     client.structured_completion = AsyncMock(  # type: ignore[method-assign]

--- a/backend/tests/test_memory_graph.py
+++ b/backend/tests/test_memory_graph.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
 from app.infrastructure.repositories.memory_repo import MemoryRepository
 
 

--- a/backend/tests/test_memory_routes.py
+++ b/backend/tests/test_memory_routes.py
@@ -6,12 +6,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
-from fastapi.testclient import TestClient
-
 from app.api.dependencies import get_memory_service
 from app.core.security.auth import get_current_user
 from app.domain.memory.models import Memory
 from app.main import app
+from fastapi.testclient import TestClient
 
 
 @pytest.fixture
@@ -197,10 +196,9 @@ def test_list_memories_route_oserror(client: TestClient) -> None:
 
 
 def test_upload_document_service_timeout(client: TestClient) -> None:
+    from app.core.security.auth import get_current_user
     from httpx import Request
     from openai import APITimeoutError
-
-    from app.core.security.auth import get_current_user
 
     user_id = uuid4()
     mock_service = AsyncMock()
@@ -305,10 +303,9 @@ def test_upload_document_unexpected_error(client: TestClient) -> None:
 
 
 def test_upload_document_service_unavailable(client: TestClient) -> None:
+    from app.core.security.auth import get_current_user
     from httpx import Request
     from openai import APIConnectionError
-
-    from app.core.security.auth import get_current_user
 
     user_id = uuid4()
     mock_service = AsyncMock()

--- a/backend/tests/test_memory_service.py
+++ b/backend/tests/test_memory_service.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-
 from app.domain.memory.service import MemoryService
 
 

--- a/backend/tests/test_notes_tools.py
+++ b/backend/tests/test_notes_tools.py
@@ -6,8 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-
-from app.domain.agent_tools.productivity.notes_tools import CreateNoteTool, ListNotesTool
+from app.domain.agent_tools.productivity.notes_tools import (CreateNoteTool,
+                                                             ListNotesTool)
 from app.domain.productivity.entities import NoteEntity
 
 

--- a/backend/tests/test_openrouter.py
+++ b/backend/tests/test_openrouter.py
@@ -5,15 +5,11 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from app.infrastructure.external.openrouter import (OpenRouterClient,
+                                                    chat_completion, embed,
+                                                    get_openrouter_client,
+                                                    structured_completion)
 from pydantic import BaseModel
-
-from app.infrastructure.external.openrouter import (
-    OpenRouterClient,
-    chat_completion,
-    embed,
-    get_openrouter_client,
-    structured_completion,
-)
 
 
 def test_get_openrouter_client() -> None:

--- a/backend/tests/test_repositories.py
+++ b/backend/tests/test_repositories.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-
 from app.domain.agents.models import Agent
 from app.domain.chat.entities import ChatMessageEntity
 from app.domain.memory.models import Memory

--- a/backend/tests/test_spotify_api.py
+++ b/backend/tests/test_spotify_api.py
@@ -5,12 +5,9 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-
-from app.infrastructure.external.spotify import (
-    get_currently_playing,
-    get_recently_played,
-    search_spotify,
-)
+from app.infrastructure.external.spotify import (get_currently_playing,
+                                                 get_recently_played,
+                                                 search_spotify)
 
 
 @pytest.fixture

--- a/backend/tests/test_spotify_tool.py
+++ b/backend/tests/test_spotify_tool.py
@@ -7,12 +7,8 @@ import typing
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
 from app.infrastructure.external.spotify_tool import (
-    SpotifyCurrentlyPlayingTool,
-    SpotifyRecentlyPlayedTool,
-    SpotifySearchTool,
-)
+    SpotifyCurrentlyPlayingTool, SpotifyRecentlyPlayedTool, SpotifySearchTool)
 
 
 @pytest.fixture

--- a/backend/tests/test_spotify_tool_more.py
+++ b/backend/tests/test_spotify_tool_more.py
@@ -6,12 +6,8 @@ import typing
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
 from app.infrastructure.external.spotify_tool import (
-    SpotifyCurrentlyPlayingTool,
-    SpotifyRecentlyPlayedTool,
-    SpotifySearchTool,
-)
+    SpotifyCurrentlyPlayingTool, SpotifyRecentlyPlayedTool, SpotifySearchTool)
 
 
 @pytest.fixture

--- a/backend/tests/test_steam_api.py
+++ b/backend/tests/test_steam_api.py
@@ -4,12 +4,9 @@ import typing
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-from app.infrastructure.external.steam import (
-    get_owned_games,
-    get_player_summaries,
-    resolve_vanity_url,
-)
+from app.infrastructure.external.steam import (get_owned_games,
+                                               get_player_summaries,
+                                               resolve_vanity_url)
 
 
 @pytest.fixture

--- a/backend/tests/test_steam_tool.py
+++ b/backend/tests/test_steam_tool.py
@@ -4,8 +4,8 @@ import typing
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
-from app.infrastructure.external.steam_tool import SteamOwnedGamesTool, SteamPlayerSummaryTool
+from app.infrastructure.external.steam_tool import (SteamOwnedGamesTool,
+                                                    SteamPlayerSummaryTool)
 
 
 @pytest.fixture

--- a/backend/tests/test_tasks_tools.py
+++ b/backend/tests/test_tasks_tools.py
@@ -6,12 +6,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-
-from app.domain.agent_tools.productivity.tasks_tools import (
-    CreateTaskTool,
-    ListTasksTool,
-    UpdateTaskTool,
-)
+from app.domain.agent_tools.productivity.tasks_tools import (CreateTaskTool,
+                                                             ListTasksTool,
+                                                             UpdateTaskTool)
 from app.domain.productivity.models import Task
 
 

--- a/backend/tests/test_websocket_chat.py
+++ b/backend/tests/test_websocket_chat.py
@@ -5,9 +5,8 @@ import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from starlette.websockets import WebSocketDisconnect
-
 from app.domain.chat.service import ChatService
+from starlette.websockets import WebSocketDisconnect
 
 if typing.TYPE_CHECKING:
     from fastapi.testclient import TestClient
@@ -103,9 +102,8 @@ def test_websocket_endpoint_runtime_error_during_connect() -> None:
     import uuid
     from unittest.mock import AsyncMock, patch
 
-    from fastapi import WebSocket
-
     from app.api.v1.websocket import websocket_chat_hub
+    from fastapi import WebSocket
 
     user_id = uuid.uuid4()
     mock_ws = AsyncMock(spec=WebSocket)
@@ -127,9 +125,8 @@ def test_websocket_endpoint_runtime_error_during_connect() -> None:
 def test_websocket_endpoint_runtime_error_during_close() -> None:
     from unittest.mock import AsyncMock, patch
 
-    from fastapi import WebSocket
-
     from app.api.v1.websocket import websocket_chat_hub
+    from fastapi import WebSocket
 
     mock_ws = AsyncMock(spec=WebSocket)
     mock_ws.close.side_effect = RuntimeError(

--- a/backend/tests/test_websocket_manager.py
+++ b/backend/tests/test_websocket_manager.py
@@ -4,7 +4,6 @@ import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
 from app.infrastructure.websocket.manager import ChatHub
 
 


### PR DESCRIPTION
Debt Identified:
- `ChatService` in `app/domain/chat/service.py` is acting as a "God Class", directly implementing raw LLM streaming (OpenAI connection errors, token yielding) alongside DB CRUD, WebSockets, and Background tasks.
- This violates the Single Responsibility Principle (SRP) and the Layer Contract.

Refactored Code:
- Created `StreamingOrchestrator` in `app/domain/chat/streaming_orchestrator.py` to isolate the `stream_chat` integration and error handling.
- `ChatService` now delegates to this orchestrator via `async for`.
- Mock targets in `test_chat_ws.py` updated accordingly.

Structural Note:
- Isolating raw API streaming into its own orchestration class clarifies the boundaries of the `ChatService`. The ChatService no longer needs to be intimately aware of `openai` exception types, simplifying maintenance and adhering to clean architecture.

---
*PR created automatically by Jules for task [1136345240532796446](https://jules.google.com/task/1136345240532796446) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat streaming now runs through a dedicated streaming flow for more consistent chunk delivery.
  * Added a clear streamed message for cases when no agents are available.
  * Improved localized responses when a language preference is provided.

* **Bug Fixes**
  * Enhanced WebSocket chat streaming error handling with better timeout and upstream connection failure messaging.
  * Streaming is more reliable for both successful and failing requests.

* **Tests**
  * Updated streaming-related mocks to match the new streaming flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->